### PR TITLE
Prevent capture filename collisions

### DIFF
--- a/docs/prd-406-collision-safe-capture-file-identity.md
+++ b/docs/prd-406-collision-safe-capture-file-identity.md
@@ -62,19 +62,27 @@ This affects temporary capture identity and persistent auto-save destinations fo
 
 1. Capture post-processors must copy to auto-save destinations with overwrite disabled.
 2. A destination collision must never modify the existing destination.
-3. If an auto-save copy fails, the current behavior remains: log/telemetry records the output failure, the temporary capture remains available, and recent-capture path replacement does not occur.
-4. Explicit Save As operations are outside this rule because the file picker and user intent own their overwrite semantics.
+3. A destination collision must generate a new candidate and retry, up to a bounded maximum of 10 attempts.
+4. If an auto-save copy fails for a reason other than collision, the current behavior remains: log/telemetry records the output failure, the temporary capture remains available, and recent-capture path replacement does not occur.
+5. Explicit Save As operations are outside this rule because the file picker and user intent own their overwrite semantics.
+
+### Temporary capture safety
+
+1. A temporary destination must be reserved atomically with create-new semantics before an image or recorder adapter receives its path.
+2. A temporary-path collision must generate a new candidate and retry, up to a bounded maximum of 10 attempts.
+3. A failed image save or recorder start must remove the reservation without masking the original failure.
+4. A successfully started capture owns the reserved file and continues through the existing lifecycle.
 
 ## Design Decision
 
-Use a full timestamp for readability, a GUID suffix for collision resistance across threads and processes, and `overwrite: false` as the hard data-safety boundary.
+Use a full timestamp for readability, a GUID suffix for collision resistance across threads and processes, and a shared allocator as the hard data-safety boundary. The allocator atomically reserves temporary paths with `FileMode.CreateNew`, copies auto-save output with `overwrite: false`, and retries confirmed collisions up to 10 times.
 
 The alternatives are weaker:
 
 - A fuller timestamp alone still admits collisions at the clock's resolution and under injected/frozen clocks.
 - An in-process sequence does not protect across restarts or processes and introduces singleton lifecycle state.
 - Checking `FileExists` before an overwrite-enabled copy has a time-of-check/time-of-use race.
-- Retrying a generated GUID collision adds complexity without improving the no-data-loss invariant: a create-new copy already preserves the existing file, while the temporary capture remains recoverable if the astronomically unlikely collision occurs.
+- Relying on GUID probability alone does not enforce the no-overwrite invariant and leaves behavior to individual capture adapters.
 
 ## Acceptance Criteria
 
@@ -83,7 +91,10 @@ The alternatives are weaker:
 - Each filename contains the complete expected timestamp and a 32-character GUID suffix.
 - Image filenames end in `.png`, video filenames in `.mp4`, and audio filenames in `.wav`.
 - Image, video, and audio auto-save calls use `overwrite: false`.
+- Temporary image, video, and audio destinations are reserved with create-new semantics.
+- Confirmed collisions retry with a new candidate and stop after 10 attempts.
 - A pre-existing auto-save destination is never overwritten.
+- A pre-existing temporary destination is never overwritten by allocation.
 - Recent-capture path replacement occurs only after a successful copy.
 - Existing capture and application tests remain green.
 
@@ -93,7 +104,9 @@ The alternatives are weaker:
 
 - Add focused unit tests for the canonical filename format and same-clock uniqueness across all media generators.
 - Add a parallel-generation test over the shared filename implementation.
-- Verify each post-processor passes `overwrite: false` to `IFileSystem.CopyFile`.
+- Add deterministic allocator tests for temporary reservation, auto-save copy, collision retry, non-collision failure, and bounded exhaustion.
+- Verify failed image/recorder startup cleans its reserved temporary file.
+- Verify the Windows image adapter replaces an app-owned reservation with encoded image data.
 - Run the full `CaptureTool.Application.Tests` project.
 - Run the infrastructure filesystem tests to retain coverage of create-new copy semantics.
 
@@ -105,8 +118,9 @@ No UI validation is required for this isolated naming change. If a packaged smok
 
 - **Longer filenames:** The additional timestamp fields and GUID remain far below Windows path-component limits.
 - **External filename parsing:** No supported contract documents the old pattern. The `Capture_` prefix and media extensions remain stable.
-- **Random collision:** A GUID collision is operationally negligible; `overwrite: false` remains the definitive guard against data loss.
-- **Auto-save failure after collision:** The existing temporary capture is retained and output failure is logged, preserving user data.
+- **Random collision:** A GUID collision is operationally negligible, but create-new/copy-no-overwrite semantics and bounded retry enforce the invariant independently of probability.
+- **Adapter writes to a reserved file:** The reservation is an app-owned empty file. Existing image and CaptureKit adapters already accept a destination path they create or replace; startup failure cleanup removes a rejected reservation.
+- **Collision retry exhaustion:** The operation fails without modifying the pre-existing files, and normal capture failure handling remains in control.
 
 ## Rollout
 

--- a/docs/prd-406-collision-safe-capture-file-identity.md
+++ b/docs/prd-406-collision-safe-capture-file-identity.md
@@ -1,0 +1,113 @@
+# PRD: Collision-Safe Capture File Identity
+
+## Summary
+
+GitHub issue: https://github.com/shanebweaver/CaptureTool/issues/406
+
+Status: approved for implementation in this change.
+
+CaptureTool must assign every newly captured image, video, and audio asset a collision-resistant filename and must never overwrite an existing auto-saved capture as a collision policy. The filename remains human-readable, but uniqueness no longer depends on a partial timestamp.
+
+## Problem
+
+The image, video, and audio filename generators currently use this pattern:
+
+```text
+Capture_{yyyy-MM-dd}_{FFFFF}.extension
+```
+
+`FFFFF` represents only the fractional portion of a second. It omits hour, minute, and whole second, so captures taken on the same day can generate the same filename. Auto-save then calls `CopyFile` with overwrite enabled, allowing a later capture to replace an earlier file silently.
+
+This affects temporary capture identity and persistent auto-save destinations for images, videos, and audio recordings.
+
+## Goals
+
+- Generate collision-resistant filenames for all three captured media types.
+- Retain a readable local timestamp in each filename for sorting and diagnosis.
+- Prevent auto-save from overwriting an existing destination under every circumstance.
+- Keep the existing per-media filename generator and post-processor boundaries stable.
+- Add regression coverage for equal clock values, parallel generation, extensions, and no-overwrite copy behavior.
+
+## Non-Goals
+
+- Renaming or migrating captures that already exist.
+- Changing user-selected Save As overwrite behavior.
+- Changing recent-capture retention or temporary-file cleanup policy.
+- Changing capture contents, codecs, or metadata.
+- Guaranteeing that auto-save succeeds when the destination is unavailable, full, or rejects writes.
+
+## User Stories
+
+- As a user taking several captures quickly, I do not lose an earlier capture because a later capture reused its name.
+- As a user running captures at the same clock value, every asset still receives a distinct path.
+- As a user browsing an auto-save folder, filenames remain chronologically understandable.
+- As a user with an existing file at a generated destination, CaptureTool preserves that file rather than overwriting it.
+
+## Product Requirements
+
+### Filename contract
+
+1. Image, video, and audio capture filenames must use the canonical pattern:
+
+   ```text
+   Capture_yyyy-MM-dd_HHmmss_fffffff_<32 lowercase hexadecimal characters>.extension
+   ```
+
+2. The timestamp must come from the existing `IClock` dependency and use local-time semantics consistent with the current implementation.
+3. The suffix must be a newly generated GUID formatted with `N`, making identity independent of clock precision, process scheduling, and capture concurrency.
+4. Extensions must remain `.png`, `.mp4`, and `.wav` for image, video, and audio captures respectively.
+5. All media generators must use one shared formatting implementation so the contract cannot drift between capture types.
+
+### Auto-save safety
+
+1. Capture post-processors must copy to auto-save destinations with overwrite disabled.
+2. A destination collision must never modify the existing destination.
+3. If an auto-save copy fails, the current behavior remains: log/telemetry records the output failure, the temporary capture remains available, and recent-capture path replacement does not occur.
+4. Explicit Save As operations are outside this rule because the file picker and user intent own their overwrite semantics.
+
+## Design Decision
+
+Use a full timestamp for readability, a GUID suffix for collision resistance across threads and processes, and `overwrite: false` as the hard data-safety boundary.
+
+The alternatives are weaker:
+
+- A fuller timestamp alone still admits collisions at the clock's resolution and under injected/frozen clocks.
+- An in-process sequence does not protect across restarts or processes and introduces singleton lifecycle state.
+- Checking `FileExists` before an overwrite-enabled copy has a time-of-check/time-of-use race.
+- Retrying a generated GUID collision adds complexity without improving the no-data-loss invariant: a create-new copy already preserves the existing file, while the temporary capture remains recoverable if the astronomically unlikely collision occurs.
+
+## Acceptance Criteria
+
+- Two calls made with the same `IClock.Now` value produce different filenames for each media type.
+- Parallel filename generation produces no duplicates.
+- Each filename contains the complete expected timestamp and a 32-character GUID suffix.
+- Image filenames end in `.png`, video filenames in `.mp4`, and audio filenames in `.wav`.
+- Image, video, and audio auto-save calls use `overwrite: false`.
+- A pre-existing auto-save destination is never overwritten.
+- Recent-capture path replacement occurs only after a successful copy.
+- Existing capture and application tests remain green.
+
+## Validation Plan
+
+### Automated
+
+- Add focused unit tests for the canonical filename format and same-clock uniqueness across all media generators.
+- Add a parallel-generation test over the shared filename implementation.
+- Verify each post-processor passes `overwrite: false` to `IFileSystem.CopyFile`.
+- Run the full `CaptureTool.Application.Tests` project.
+- Run the infrastructure filesystem tests to retain coverage of create-new copy semantics.
+
+### Manual
+
+No UI validation is required for this isolated naming change. If a packaged smoke test is performed, take several rapid captures of each enabled type and confirm that the resulting temporary/auto-save files are distinct and chronologically readable.
+
+## Risks and Mitigations
+
+- **Longer filenames:** The additional timestamp fields and GUID remain far below Windows path-component limits.
+- **External filename parsing:** No supported contract documents the old pattern. The `Capture_` prefix and media extensions remain stable.
+- **Random collision:** A GUID collision is operationally negligible; `overwrite: false` remains the definitive guard against data loss.
+- **Auto-save failure after collision:** The existing temporary capture is retained and output failure is logged, preserving user data.
+
+## Rollout
+
+The change requires no migration or feature flag. New captures use the new identity format immediately; existing files and recent-capture entries remain valid.

--- a/src/CaptureTool.Application.Abstractions/Files/IFileSystem.cs
+++ b/src/CaptureTool.Application.Abstractions/Files/IFileSystem.cs
@@ -9,6 +9,7 @@ public interface IFileSystem
     DateTime GetLastWriteTimeUtc(string filePath);
     void SetLastWriteTimeUtc(string filePath, DateTime lastWriteTimeUtc);
     void CreateDirectory(string folderPath);
+    void CreateEmptyFile(string filePath);
     void CopyFile(string sourcePath, string destinationPath, bool overwrite);
     void DeleteFile(string filePath);
     void DeleteDirectory(string folderPath, bool recursive);

--- a/src/CaptureTool.Application/Capture/Audio/AudioCaptureFileNameGenerator.cs
+++ b/src/CaptureTool.Application/Capture/Audio/AudioCaptureFileNameGenerator.cs
@@ -14,6 +14,6 @@ internal sealed class AudioCaptureFileNameGenerator
     public string GetNewCaptureFileName()
     {
         DateTime timestamp = _clock.Now;
-        return $"Capture_{timestamp:yyyy-MM-dd}_{timestamp:FFFFF}.wav";
+        return CaptureFileNameFormatter.Create(timestamp, "wav");
     }
 }

--- a/src/CaptureTool.Application/Capture/Audio/AudioCapturePostProcessor.cs
+++ b/src/CaptureTool.Application/Capture/Audio/AudioCapturePostProcessor.cs
@@ -94,7 +94,7 @@ internal sealed class AudioCapturePostProcessor
 
             string newFilePath = Path.Combine(audioFolder, _fileNameGenerator.GetNewCaptureFileName());
 
-            _fileSystem.CopyFile(audioFile.FilePath, newFilePath, true);
+            _fileSystem.CopyFile(audioFile.FilePath, newFilePath, overwrite: false);
             _recentCaptureCatalog.ReplacePath(audioFile.FilePath, newFilePath);
             TrackOutput("auto_save", TelemetryOutcomes.Succeeded);
         }

--- a/src/CaptureTool.Application/Capture/Audio/AudioCapturePostProcessor.cs
+++ b/src/CaptureTool.Application/Capture/Audio/AudioCapturePostProcessor.cs
@@ -1,5 +1,4 @@
 using CaptureTool.Application.Abstractions.Clipboard;
-using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Library.RecentCaptures;
 using CaptureTool.Application.Abstractions.Settings;
@@ -14,7 +13,7 @@ namespace CaptureTool.Application.Capture.Audio;
 internal sealed class AudioCapturePostProcessor
 {
     private readonly IClipboardService _clipboardService;
-    private readonly IFileSystem _fileSystem;
+    private readonly CaptureFileAllocator _fileAllocator;
     private readonly ISettingsService _settingsService;
     private readonly IStorageService _storageService;
     private readonly ITaskEnvironment _taskEnvironment;
@@ -25,7 +24,7 @@ internal sealed class AudioCapturePostProcessor
 
     public AudioCapturePostProcessor(
         IClipboardService clipboardService,
-        IFileSystem fileSystem,
+        CaptureFileAllocator fileAllocator,
         ISettingsService settingsService,
         IStorageService storageService,
         ITaskEnvironment taskEnvironment,
@@ -35,7 +34,7 @@ internal sealed class AudioCapturePostProcessor
         ITelemetryService? telemetryService = null)
     {
         _clipboardService = clipboardService;
-        _fileSystem = fileSystem;
+        _fileAllocator = fileAllocator;
         _settingsService = settingsService;
         _storageService = storageService;
         _taskEnvironment = taskEnvironment;
@@ -92,9 +91,10 @@ internal sealed class AudioCapturePostProcessor
                 audioFolder = _storageService.GetSystemDefaultMusicFolderPath();
             }
 
-            string newFilePath = Path.Combine(audioFolder, _fileNameGenerator.GetNewCaptureFileName());
-
-            _fileSystem.CopyFile(audioFile.FilePath, newFilePath, overwrite: false);
+            string newFilePath = _fileAllocator.CopyToUniqueFile(
+                audioFile.FilePath,
+                audioFolder,
+                _fileNameGenerator.GetNewCaptureFileName);
             _recentCaptureCatalog.ReplacePath(audioFile.FilePath, newFilePath);
             TrackOutput("auto_save", TelemetryOutcomes.Succeeded);
         }

--- a/src/CaptureTool.Application/Capture/Audio/AudioCaptureWorkflow.cs
+++ b/src/CaptureTool.Application/Capture/Audio/AudioCaptureWorkflow.cs
@@ -14,6 +14,7 @@ internal sealed class AudioCaptureWorkflow : IAudioCaptureWorkflow
     private readonly IFileSystem _fileSystem;
     private readonly ISettingsService _settingsService;
     private readonly IStorageService _storageService;
+    private readonly CaptureFileAllocator _fileAllocator;
     private readonly AudioCaptureStateStore _stateStore;
     private readonly AudioCapturePostProcessor _postProcessor;
     private readonly AudioCaptureFileNameGenerator _fileNameGenerator;
@@ -39,6 +40,7 @@ internal sealed class AudioCaptureWorkflow : IAudioCaptureWorkflow
         IFileSystem fileSystem,
         ISettingsService settingsService,
         IStorageService storageService,
+        CaptureFileAllocator fileAllocator,
         AudioCaptureStateStore stateStore,
         AudioCapturePostProcessor postProcessor,
         AudioCaptureFileNameGenerator fileNameGenerator,
@@ -48,6 +50,7 @@ internal sealed class AudioCaptureWorkflow : IAudioCaptureWorkflow
         _fileSystem = fileSystem;
         _settingsService = settingsService;
         _storageService = storageService;
+        _fileAllocator = fileAllocator;
         _stateStore = stateStore;
         _postProcessor = postProcessor;
         _fileNameGenerator = fileNameGenerator;
@@ -62,19 +65,25 @@ internal sealed class AudioCaptureWorkflow : IAudioCaptureWorkflow
         _stateStore.PrepareForAudioCapture(defaultDesktopAudioEnabled);
         TrackCapture(TelemetryEvents.CaptureRequested);
 
-        string tempAudioPath = Path.Combine(
+        string tempAudioPath = _fileAllocator.ReserveUniqueFile(
             _storageService.GetApplicationTemporaryFolderPath(),
-            _fileNameGenerator.GetNewCaptureFileName());
+            _fileNameGenerator.GetNewCaptureFileName);
 
-        AudioCaptureSession session = _stateStore.StartSession(tempAudioPath);
+        AudioCaptureSession? session = null;
 
         try
         {
+            session = _stateStore.StartSession(tempAudioPath);
             _audioRecorder.StartCapture(session.TempAudioPath);
         }
         catch
         {
-            _stateStore.StopSession(session.Id);
+            if (session is not null)
+            {
+                _stateStore.StopSession(session.Id);
+            }
+
+            _fileAllocator.TryDeleteFile(tempAudioPath);
             TrackCapture(TelemetryEvents.CaptureFailed, TelemetryOutcomes.Failed);
             throw;
         }

--- a/src/CaptureTool.Application/Capture/CaptureFileAllocator.cs
+++ b/src/CaptureTool.Application/Capture/CaptureFileAllocator.cs
@@ -1,0 +1,85 @@
+using CaptureTool.Application.Abstractions.Files;
+
+namespace CaptureTool.Application.Capture;
+
+internal sealed class CaptureFileAllocator
+{
+    internal const int MaxAttempts = 10;
+
+    private readonly IFileSystem _fileSystem;
+
+    public CaptureFileAllocator(IFileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+    }
+
+    public string ReserveUniqueFile(string folderPath, Func<string> createFileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+        ArgumentNullException.ThrowIfNull(createFileName);
+
+        return ExecuteWithUniquePath(
+            folderPath,
+            createFileName,
+            path => _fileSystem.CreateEmptyFile(path));
+    }
+
+    public string CopyToUniqueFile(
+        string sourcePath,
+        string folderPath,
+        Func<string> createFileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+        ArgumentNullException.ThrowIfNull(createFileName);
+
+        return ExecuteWithUniquePath(
+            folderPath,
+            createFileName,
+            path => _fileSystem.CopyFile(sourcePath, path, overwrite: false));
+    }
+
+    public void TryDeleteFile(string filePath)
+    {
+        try
+        {
+            _fileSystem.DeleteFile(filePath);
+        }
+        catch
+        {
+            // Cleanup must not replace the original capture failure.
+        }
+    }
+
+    private string ExecuteWithUniquePath(
+        string folderPath,
+        Func<string> createFileName,
+        Action<string> createFile)
+    {
+        IOException? lastCollision = null;
+
+        for (int attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            string filePath = Path.Combine(folderPath, createFileName());
+
+            try
+            {
+                createFile(filePath);
+                return filePath;
+            }
+            catch (IOException exception)
+            {
+                if (!_fileSystem.FileExists(filePath))
+                {
+                    throw;
+                }
+
+                lastCollision = exception;
+            }
+        }
+
+        throw new IOException(
+            $"Could not allocate a unique capture file after {MaxAttempts} attempts.",
+            lastCollision);
+    }
+}

--- a/src/CaptureTool.Application/Capture/CaptureFileNameFormatter.cs
+++ b/src/CaptureTool.Application/Capture/CaptureFileNameFormatter.cs
@@ -1,0 +1,15 @@
+using System.Globalization;
+
+namespace CaptureTool.Application.Capture;
+
+internal static class CaptureFileNameFormatter
+{
+    public static string Create(DateTime timestamp, string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Capture_{timestamp:yyyy-MM-dd_HHmmss_fffffff}_{Guid.NewGuid():N}.{extension}");
+    }
+}

--- a/src/CaptureTool.Application/Capture/Image/ImageCaptureFileNameGenerator.cs
+++ b/src/CaptureTool.Application/Capture/Image/ImageCaptureFileNameGenerator.cs
@@ -14,6 +14,6 @@ internal sealed class ImageCaptureFileNameGenerator
     public string GetNewCaptureFileName()
     {
         DateTime timestamp = _clock.Now;
-        return $"Capture_{timestamp:yyyy-MM-dd}_{timestamp:FFFFF}.png";
+        return CaptureFileNameFormatter.Create(timestamp, "png");
     }
 }

--- a/src/CaptureTool.Application/Capture/Image/ImageCapturePostProcessor.cs
+++ b/src/CaptureTool.Application/Capture/Image/ImageCapturePostProcessor.cs
@@ -96,7 +96,7 @@ internal sealed class ImageCapturePostProcessor
 
                 string newFilePath = Path.Combine(screenshotsFolder, _fileNameGenerator.GetNewCaptureFileName());
 
-                _fileSystem.CopyFile(imageFile.FilePath, newFilePath, true);
+                _fileSystem.CopyFile(imageFile.FilePath, newFilePath, overwrite: false);
                 imageFile.PersistentFilePath = newFilePath;
                 _recentCaptureCatalog.ReplacePath(imageFile.FilePath, newFilePath);
                 TrackOutput("auto_save", TelemetryOutcomes.Succeeded);

--- a/src/CaptureTool.Application/Capture/Image/ImageCapturePostProcessor.cs
+++ b/src/CaptureTool.Application/Capture/Image/ImageCapturePostProcessor.cs
@@ -1,5 +1,4 @@
 using CaptureTool.Application.Abstractions.Clipboard;
-using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Library.RecentCaptures;
 using CaptureTool.Application.Abstractions.Settings;
@@ -14,7 +13,7 @@ namespace CaptureTool.Application.Capture.Image;
 internal sealed class ImageCapturePostProcessor
 {
     private readonly IClipboardService _clipboardService;
-    private readonly IFileSystem _fileSystem;
+    private readonly CaptureFileAllocator _fileAllocator;
     private readonly ISettingsService _settingsService;
     private readonly IStorageService _storageService;
     private readonly ITaskEnvironment _taskEnvironment;
@@ -25,7 +24,7 @@ internal sealed class ImageCapturePostProcessor
 
     public ImageCapturePostProcessor(
         IClipboardService clipboardService,
-        IFileSystem fileSystem,
+        CaptureFileAllocator fileAllocator,
         ISettingsService settingsService,
         IStorageService storageService,
         ITaskEnvironment taskEnvironment,
@@ -35,7 +34,7 @@ internal sealed class ImageCapturePostProcessor
         ITelemetryService? telemetryService = null)
     {
         _clipboardService = clipboardService;
-        _fileSystem = fileSystem;
+        _fileAllocator = fileAllocator;
         _settingsService = settingsService;
         _storageService = storageService;
         _taskEnvironment = taskEnvironment;
@@ -94,9 +93,10 @@ internal sealed class ImageCapturePostProcessor
                     screenshotsFolder = _storageService.GetSystemDefaultScreenshotsFolderPath();
                 }
 
-                string newFilePath = Path.Combine(screenshotsFolder, _fileNameGenerator.GetNewCaptureFileName());
-
-                _fileSystem.CopyFile(imageFile.FilePath, newFilePath, overwrite: false);
+                string newFilePath = _fileAllocator.CopyToUniqueFile(
+                    imageFile.FilePath,
+                    screenshotsFolder,
+                    _fileNameGenerator.GetNewCaptureFileName);
                 imageFile.PersistentFilePath = newFilePath;
                 _recentCaptureCatalog.ReplacePath(imageFile.FilePath, newFilePath);
                 TrackOutput("auto_save", TelemetryOutcomes.Succeeded);

--- a/src/CaptureTool.Application/Capture/Image/ImageCaptureWorkflow.cs
+++ b/src/CaptureTool.Application/Capture/Image/ImageCaptureWorkflow.cs
@@ -10,6 +10,7 @@ namespace CaptureTool.Application.Capture.Image;
 internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptureState
 {
     private readonly IStorageService _storageService;
+    private readonly CaptureFileAllocator _fileAllocator;
     private readonly IScreenCapture _screenCapture;
     private readonly ImageCapturePostProcessor _postProcessor;
     private readonly ImageCaptureFileNameGenerator _fileNameGenerator;
@@ -19,12 +20,14 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
 
     public ImageCaptureWorkflow(
         IStorageService storageService,
+        CaptureFileAllocator fileAllocator,
         IScreenCapture screenCapture,
         ImageCapturePostProcessor postProcessor,
         ImageCaptureFileNameGenerator fileNameGenerator,
         ITelemetryService? telemetryService = null)
     {
         _storageService = storageService;
+        _fileAllocator = fileAllocator;
         _screenCapture = screenCapture;
         _postProcessor = postProcessor;
         _fileNameGenerator = fileNameGenerator;
@@ -41,16 +44,18 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
     {
         TrackCapture(TelemetryEvents.CaptureRequested, "all_screens");
 
+        string? tempPath = null;
+        bool captureCreated = false;
         try
         {
             TrackCapture(TelemetryEvents.CaptureStarted, "all_screens");
-            string tempPath = Path.Combine(
+            tempPath = _fileAllocator.ReserveUniqueFile(
                 _storageService.GetApplicationTemporaryFolderPath(),
-                _fileNameGenerator.GetNewCaptureFileName()
-            );
+                _fileNameGenerator.GetNewCaptureFileName);
 
             using System.Drawing.Image combined = _screenCapture.CombineMonitors([.. monitors]);
             _screenCapture.SaveImageToFile(combined, tempPath);
+            captureCreated = true;
 
             ImageFile imageFile = CompleteCapture(new ImageFile(tempPath));
             TrackCapture(TelemetryEvents.CaptureCompleted, "all_screens", TelemetryOutcomes.Succeeded);
@@ -58,6 +63,11 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
         }
         catch
         {
+            if (!captureCreated && tempPath is not null)
+            {
+                _fileAllocator.TryDeleteFile(tempPath);
+            }
+
             TrackCapture(TelemetryEvents.CaptureFailed, "all_screens", TelemetryOutcomes.Failed);
             throw;
         }
@@ -68,19 +78,21 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
         string captureType = args.CaptureType.ToString();
         TrackCapture(TelemetryEvents.CaptureRequested, captureType);
 
+        string? tempPath = null;
+        bool captureCreated = false;
         try
         {
             TrackCapture(TelemetryEvents.CaptureStarted, captureType);
-            string tempPath = Path.Combine(
+            tempPath = _fileAllocator.ReserveUniqueFile(
                 _storageService.GetApplicationTemporaryFolderPath(),
-                _fileNameGenerator.GetNewCaptureFileName()
-            );
+                _fileNameGenerator.GetNewCaptureFileName);
 
             MonitorCaptureResult monitor = args.Monitor;
             Rectangle area = args.Area;
             using Bitmap image = _screenCapture.CreateBitmapFromMonitorCaptureResult(monitor);
             using Bitmap cropped = _screenCapture.CreateCroppedBitmap(image, area, monitor.Scale);
             _screenCapture.SaveImageToFile(cropped, tempPath);
+            captureCreated = true;
 
             ImageFile imageFile = CompleteCapture(new ImageFile(tempPath));
             TrackCapture(TelemetryEvents.CaptureCompleted, captureType, TelemetryOutcomes.Succeeded);
@@ -88,6 +100,11 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
         }
         catch
         {
+            if (!captureCreated && tempPath is not null)
+            {
+                _fileAllocator.TryDeleteFile(tempPath);
+            }
+
             TrackCapture(TelemetryEvents.CaptureFailed, captureType, TelemetryOutcomes.Failed);
             throw;
         }

--- a/src/CaptureTool.Application/Capture/Video/VideoCaptureFileNameGenerator.cs
+++ b/src/CaptureTool.Application/Capture/Video/VideoCaptureFileNameGenerator.cs
@@ -14,6 +14,6 @@ internal sealed class VideoCaptureFileNameGenerator
     public string GetNewCaptureFileName()
     {
         DateTime timestamp = _clock.Now;
-        return $"Capture_{timestamp:yyyy-MM-dd}_{timestamp:FFFFF}.mp4";
+        return CaptureFileNameFormatter.Create(timestamp, "mp4");
     }
 }

--- a/src/CaptureTool.Application/Capture/Video/VideoCapturePostProcessor.cs
+++ b/src/CaptureTool.Application/Capture/Video/VideoCapturePostProcessor.cs
@@ -94,7 +94,7 @@ internal sealed class VideoCapturePostProcessor
 
             string newFilePath = Path.Combine(videosFolder, _fileNameGenerator.GetNewCaptureFileName());
 
-            _fileSystem.CopyFile(videoFile.FilePath, newFilePath, true);
+            _fileSystem.CopyFile(videoFile.FilePath, newFilePath, overwrite: false);
             _recentCaptureCatalog.ReplacePath(videoFile.FilePath, newFilePath);
             TrackOutput("auto_save", TelemetryOutcomes.Succeeded);
         }

--- a/src/CaptureTool.Application/Capture/Video/VideoCapturePostProcessor.cs
+++ b/src/CaptureTool.Application/Capture/Video/VideoCapturePostProcessor.cs
@@ -1,5 +1,4 @@
 using CaptureTool.Application.Abstractions.Clipboard;
-using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Library.RecentCaptures;
 using CaptureTool.Application.Abstractions.Settings;
@@ -14,7 +13,7 @@ namespace CaptureTool.Application.Capture.Video;
 internal sealed class VideoCapturePostProcessor
 {
     private readonly IClipboardService _clipboardService;
-    private readonly IFileSystem _fileSystem;
+    private readonly CaptureFileAllocator _fileAllocator;
     private readonly ISettingsService _settingsService;
     private readonly IStorageService _storageService;
     private readonly ITaskEnvironment _taskEnvironment;
@@ -25,7 +24,7 @@ internal sealed class VideoCapturePostProcessor
 
     public VideoCapturePostProcessor(
         IClipboardService clipboardService,
-        IFileSystem fileSystem,
+        CaptureFileAllocator fileAllocator,
         ISettingsService settingsService,
         IStorageService storageService,
         ITaskEnvironment taskEnvironment,
@@ -35,7 +34,7 @@ internal sealed class VideoCapturePostProcessor
         ITelemetryService? telemetryService = null)
     {
         _clipboardService = clipboardService;
-        _fileSystem = fileSystem;
+        _fileAllocator = fileAllocator;
         _settingsService = settingsService;
         _storageService = storageService;
         _taskEnvironment = taskEnvironment;
@@ -92,9 +91,10 @@ internal sealed class VideoCapturePostProcessor
                 videosFolder = _storageService.GetSystemDefaultVideosFolderPath();
             }
 
-            string newFilePath = Path.Combine(videosFolder, _fileNameGenerator.GetNewCaptureFileName());
-
-            _fileSystem.CopyFile(videoFile.FilePath, newFilePath, overwrite: false);
+            string newFilePath = _fileAllocator.CopyToUniqueFile(
+                videoFile.FilePath,
+                videosFolder,
+                _fileNameGenerator.GetNewCaptureFileName);
             _recentCaptureCatalog.ReplacePath(videoFile.FilePath, newFilePath);
             TrackOutput("auto_save", TelemetryOutcomes.Succeeded);
         }

--- a/src/CaptureTool.Application/Capture/Video/VideoCaptureWorkflow.cs
+++ b/src/CaptureTool.Application/Capture/Video/VideoCaptureWorkflow.cs
@@ -15,6 +15,7 @@ internal sealed class VideoCaptureWorkflow : IVideoCaptureWorkflow
     private readonly IScreenRecorder _screenRecorder;
     private readonly ISettingsService _settingsService;
     private readonly IStorageService _storageService;
+    private readonly CaptureFileAllocator _fileAllocator;
     private readonly IBackgroundTaskRunner _backgroundTaskRunner;
     private readonly IVideoCaptureSupportService _videoCaptureSupportService;
     private readonly VideoCaptureStateStore _stateStore;
@@ -41,6 +42,7 @@ internal sealed class VideoCaptureWorkflow : IVideoCaptureWorkflow
         IScreenRecorder screenRecorder,
         ISettingsService settingsService,
         IStorageService storageService,
+        CaptureFileAllocator fileAllocator,
         IBackgroundTaskRunner backgroundTaskRunner,
         IVideoCaptureSupportService videoCaptureSupportService,
         VideoCaptureStateStore stateStore,
@@ -51,6 +53,7 @@ internal sealed class VideoCaptureWorkflow : IVideoCaptureWorkflow
         _screenRecorder = screenRecorder;
         _settingsService = settingsService;
         _storageService = storageService;
+        _fileAllocator = fileAllocator;
         _backgroundTaskRunner = backgroundTaskRunner;
         _videoCaptureSupportService = videoCaptureSupportService;
         _stateStore = stateStore;
@@ -92,24 +95,30 @@ internal sealed class VideoCaptureWorkflow : IVideoCaptureWorkflow
             throw new VideoCaptureNotSupportedException(supportStatus.UnsupportedReason);
         }
 
-        string tempVideoPath = Path.Combine(
+        string tempVideoPath = _fileAllocator.ReserveUniqueFile(
             _storageService.GetApplicationTemporaryFolderPath(),
-            _fileNameGenerator.GetNewCaptureFileName());
+            _fileNameGenerator.GetNewCaptureFileName);
 
         CaptureRecordingTarget target = CreateRecordingTarget(args);
-        VideoCaptureSession session = _stateStore.StartSession(tempVideoPath, target, args.CaptureType);
+        VideoCaptureSession? session = null;
 
         try
         {
+            session = _stateStore.StartSession(tempVideoPath, target, args.CaptureType);
             _screenRecorder.StartRecording(session.CreateRecordingOptions());
         }
         catch (Exception ex)
         {
-            _stateStore.ClearSession(session.Id);
+            if (session is not null)
+            {
+                _stateStore.ClearSession(session.Id);
+            }
+
+            _fileAllocator.TryDeleteFile(tempVideoPath);
             TrackCapture(
                 TelemetryEvents.CaptureFailed,
                 args.CaptureType.ToString(),
-                session.AudioSettings,
+                session?.AudioSettings ?? Snapshot.AudioSettings,
                 TelemetryOutcomes.Failed,
                 TelemetryFailureStages.RecorderStart,
                 ClassifyRecorderStartFailure(ex));

--- a/src/CaptureTool.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/src/CaptureTool.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using CaptureTool.Application.Abstractions.Ai;
 using CaptureTool.Application.Abstractions.Edit.External;
 using CaptureTool.Application.Abstractions.EditSessions;
 using CaptureTool.Application.Ai;
+using CaptureTool.Application.Capture;
 using CaptureTool.Application.Edit.External;
 using CaptureTool.Application.EditSessions;
 using CaptureTool.Application.UseCases;
@@ -41,6 +42,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<IOpenExternalEditorUseCase, OpenExternalEditorUseCase>();
         services.AddSingleton<IActiveEditSessionService, ActiveEditSessionService>();
         services.AddSingleton<IEditSessionGuard, EditSessionGuard>();
+        services.AddSingleton<CaptureFileAllocator>();
 
         return services;
     }

--- a/src/CaptureTool.Infrastructure/Files/LocalFileSystem.cs
+++ b/src/CaptureTool.Infrastructure/Files/LocalFileSystem.cs
@@ -21,6 +21,11 @@ public sealed class LocalFileSystem : IFileSystem
 
     public void CreateDirectory(string folderPath) => Directory.CreateDirectory(folderPath);
 
+    public void CreateEmptyFile(string filePath)
+    {
+        using FileStream stream = new(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+    }
+
     public void CopyFile(string sourcePath, string destinationPath, bool overwrite) =>
         File.Copy(sourcePath, destinationPath, overwrite);
 

--- a/tests/CaptureTool.Application.Tests/Capture/AudioCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/AudioCaptureWorkflowTests.cs
@@ -6,6 +6,7 @@ using CaptureTool.Application.Abstractions.Library.RecentCaptures;
 using CaptureTool.Application.Abstractions.Settings;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.TaskEnvironment;
+using CaptureTool.Application.Capture;
 using CaptureTool.Application.Capture.Audio;
 using CaptureTool.Domain.Capture;
 using CaptureTool.Domain.FileSystem;
@@ -50,12 +51,16 @@ public sealed class AudioCaptureWorkflowTests
         recorder
             .Setup(service => service.StartCapture(It.IsAny<string>()))
             .Throws(new InvalidOperationException("failed"));
-        AudioCaptureWorkflow workflow = CreateWorkflow(recorder);
+        var fileSystem = new Mock<IFileSystem>();
+        AudioCaptureWorkflow workflow = CreateWorkflow(recorder, fileSystem: fileSystem);
 
         workflow.Invoking(service => service.StartCapture()).Should().Throw<InvalidOperationException>();
 
         workflow.IsRecording.Should().BeFalse();
         workflow.CaptureState.Should().Be(AudioCaptureState.Stopped);
+        fileSystem.Verify(
+            service => service.DeleteFile(It.Is<string>(path => path.EndsWith(".wav", StringComparison.Ordinal))),
+            Times.Once);
     }
 
     [TestMethod]
@@ -259,6 +264,7 @@ public sealed class AudioCaptureWorkflowTests
         Mock<IRecentCaptureCatalog>? recentCaptureCatalog = null)
     {
         settings ??= CreateSettings();
+        fileSystem ??= new Mock<IFileSystem>();
 
         storage ??= new Mock<IStorageService>();
         storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(@"C:\Temp");
@@ -271,9 +277,10 @@ public sealed class AudioCaptureWorkflowTests
             .Returns(true);
 
         AudioCaptureFileNameGenerator fileNameGenerator = new(TestClock.Instance);
+        var fileAllocator = new CaptureFileAllocator(fileSystem.Object);
         AudioCapturePostProcessor postProcessor = new(
             clipboard?.Object ?? Mock.Of<IClipboardService>(),
-            fileSystem?.Object ?? Mock.Of<IFileSystem>(),
+            fileAllocator,
             settings.Object,
             storage.Object,
             taskEnvironment.Object,
@@ -283,9 +290,10 @@ public sealed class AudioCaptureWorkflowTests
 
         return new AudioCaptureWorkflow(
             recorder.Object,
-            fileSystem?.Object ?? Mock.Of<IFileSystem>(),
+            fileSystem.Object,
             settings.Object,
             storage.Object,
+            fileAllocator,
             new AudioCaptureStateStore(),
             postProcessor,
             fileNameGenerator);

--- a/tests/CaptureTool.Application.Tests/Capture/AudioCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/AudioCaptureWorkflowTests.cs
@@ -168,7 +168,7 @@ public sealed class AudioCaptureWorkflowTests
             service => service.CopyFile(
                 audioFile.FilePath,
                 It.Is<string>(path => path.StartsWith(@"C:\Audio", StringComparison.OrdinalIgnoreCase) && path.EndsWith(".wav")),
-                true),
+                false),
             Times.Once);
         await copied.Task.WaitAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
         recentCaptureCatalog.Verify(

--- a/tests/CaptureTool.Application.Tests/Capture/CaptureFileAllocatorTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/CaptureFileAllocatorTests.cs
@@ -1,0 +1,91 @@
+using CaptureTool.Application.Abstractions.Files;
+using CaptureTool.Application.Capture;
+using Moq;
+
+namespace CaptureTool.Application.Tests.Capture;
+
+[TestClass]
+public sealed class CaptureFileAllocatorTests
+{
+    [TestMethod]
+    public void ReserveUniqueFile_WhenFirstNameExists_RetriesWithNextName()
+    {
+        const string FolderPath = @"C:\Temp";
+        string existingPath = Path.Combine(FolderPath, "existing.png");
+        string uniquePath = Path.Combine(FolderPath, "unique.png");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem
+            .Setup(service => service.CreateEmptyFile(existingPath))
+            .Throws(new IOException("File exists."));
+        fileSystem.Setup(service => service.FileExists(existingPath)).Returns(true);
+        var names = new Queue<string>(["existing.png", "unique.png"]);
+        var allocator = new CaptureFileAllocator(fileSystem.Object);
+
+        string result = allocator.ReserveUniqueFile(FolderPath, names.Dequeue);
+
+        Assert.AreEqual(uniquePath, result);
+        fileSystem.Verify(service => service.CreateEmptyFile(existingPath), Times.Once);
+        fileSystem.Verify(service => service.CreateEmptyFile(uniquePath), Times.Once);
+    }
+
+    [TestMethod]
+    public void CopyToUniqueFile_WhenFirstNameExists_RetriesWithoutOverwrite()
+    {
+        const string SourcePath = @"C:\Temp\source.png";
+        const string FolderPath = @"C:\Captures";
+        string existingPath = Path.Combine(FolderPath, "existing.png");
+        string uniquePath = Path.Combine(FolderPath, "unique.png");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem
+            .Setup(service => service.CopyFile(SourcePath, existingPath, false))
+            .Throws(new IOException("File exists."));
+        fileSystem.Setup(service => service.FileExists(existingPath)).Returns(true);
+        var names = new Queue<string>(["existing.png", "unique.png"]);
+        var allocator = new CaptureFileAllocator(fileSystem.Object);
+
+        string result = allocator.CopyToUniqueFile(SourcePath, FolderPath, names.Dequeue);
+
+        Assert.AreEqual(uniquePath, result);
+        fileSystem.Verify(service => service.CopyFile(SourcePath, existingPath, false), Times.Once);
+        fileSystem.Verify(service => service.CopyFile(SourcePath, uniquePath, false), Times.Once);
+    }
+
+    [TestMethod]
+    public void ReserveUniqueFile_WhenFailureIsNotANameCollision_DoesNotRetry()
+    {
+        const string FolderPath = @"C:\Temp";
+        string path = Path.Combine(FolderPath, "capture.png");
+        var expected = new IOException("Disk is full.");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(service => service.CreateEmptyFile(path)).Throws(expected);
+        fileSystem.Setup(service => service.FileExists(path)).Returns(false);
+        var allocator = new CaptureFileAllocator(fileSystem.Object);
+
+        IOException actual = Assert.ThrowsExactly<IOException>(() =>
+            allocator.ReserveUniqueFile(FolderPath, () => "capture.png"));
+
+        Assert.AreSame(expected, actual);
+        fileSystem.Verify(service => service.CreateEmptyFile(path), Times.Once);
+    }
+
+    [TestMethod]
+    public void ReserveUniqueFile_WhenEveryNameExists_StopsAfterBoundedAttempts()
+    {
+        const string FolderPath = @"C:\Temp";
+        string path = Path.Combine(FolderPath, "capture.png");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem
+            .Setup(service => service.CreateEmptyFile(path))
+            .Throws(new IOException("File exists."));
+        fileSystem.Setup(service => service.FileExists(path)).Returns(true);
+        var allocator = new CaptureFileAllocator(fileSystem.Object);
+
+        IOException exception = Assert.ThrowsExactly<IOException>(() =>
+            allocator.ReserveUniqueFile(FolderPath, () => "capture.png"));
+
+        StringAssert.Contains(exception.Message, CaptureFileAllocator.MaxAttempts.ToString());
+        fileSystem.Verify(
+            service => service.CreateEmptyFile(path),
+            Times.Exactly(CaptureFileAllocator.MaxAttempts));
+    }
+}

--- a/tests/CaptureTool.Application.Tests/Capture/CaptureFileNameGeneratorTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/CaptureFileNameGeneratorTests.cs
@@ -1,0 +1,54 @@
+using CaptureTool.Application.Capture.Audio;
+using CaptureTool.Application.Capture.Image;
+using CaptureTool.Application.Capture.Video;
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace CaptureTool.Application.Tests.Capture;
+
+[TestClass]
+public sealed class CaptureFileNameGeneratorTests
+{
+    [TestMethod]
+    public void ImageGenerator_WhenClockDoesNotAdvance_ProducesUniqueCanonicalNames()
+    {
+        var generator = new ImageCaptureFileNameGenerator(TestClock.Instance);
+
+        AssertUniqueCanonicalNames(generator.GetNewCaptureFileName, "png");
+    }
+
+    [TestMethod]
+    public void VideoGenerator_WhenClockDoesNotAdvance_ProducesUniqueCanonicalNames()
+    {
+        var generator = new VideoCaptureFileNameGenerator(TestClock.Instance);
+
+        AssertUniqueCanonicalNames(generator.GetNewCaptureFileName, "mp4");
+    }
+
+    [TestMethod]
+    public void AudioGenerator_WhenClockDoesNotAdvance_ProducesUniqueCanonicalNames()
+    {
+        var generator = new AudioCaptureFileNameGenerator(TestClock.Instance);
+
+        AssertUniqueCanonicalNames(generator.GetNewCaptureFileName, "wav");
+    }
+
+    private static void AssertUniqueCanonicalNames(Func<string> createFileName, string extension)
+    {
+        const int Count = 256;
+        var names = new ConcurrentBag<string>();
+
+        Parallel.For(0, Count, _ => names.Add(createFileName()));
+
+        Assert.AreEqual(Count, names.Distinct(StringComparer.Ordinal).Count());
+
+        var pattern = new Regex(
+            $"^Capture_2026-01-02_030405_0000000_[0-9a-f]{{32}}\\.{Regex.Escape(extension)}$",
+            RegexOptions.CultureInvariant);
+
+        foreach (string name in names)
+        {
+            Assert.IsTrue(pattern.IsMatch(name), $"Unexpected capture filename: {name}");
+        }
+    }
+}

--- a/tests/CaptureTool.Application.Tests/Capture/CapturePostProcessorTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/CapturePostProcessorTests.cs
@@ -5,6 +5,7 @@ using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Settings;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.TaskEnvironment;
+using CaptureTool.Application.Capture;
 using CaptureTool.Application.Capture.Audio;
 using CaptureTool.Application.Capture.Image;
 using CaptureTool.Application.Capture.Video;
@@ -29,7 +30,7 @@ public sealed class CapturePostProcessorTests
             DestinationFolder);
         ImageCapturePostProcessor processor = new(
             Mock.Of<IClipboardService>(),
-            fileSystem.Object,
+            new CaptureFileAllocator(fileSystem.Object),
             settings.Object,
             Mock.Of<IStorageService>(),
             CreateImmediateTaskEnvironment().Object,
@@ -60,7 +61,7 @@ public sealed class CapturePostProcessorTests
             DestinationFolder);
         VideoCapturePostProcessor processor = new(
             Mock.Of<IClipboardService>(),
-            fileSystem.Object,
+            new CaptureFileAllocator(fileSystem.Object),
             settings.Object,
             Mock.Of<IStorageService>(),
             CreateImmediateTaskEnvironment().Object,
@@ -91,7 +92,7 @@ public sealed class CapturePostProcessorTests
             DestinationFolder);
         AudioCapturePostProcessor processor = new(
             Mock.Of<IClipboardService>(),
-            fileSystem.Object,
+            new CaptureFileAllocator(fileSystem.Object),
             settings.Object,
             Mock.Of<IStorageService>(),
             CreateImmediateTaskEnvironment().Object,

--- a/tests/CaptureTool.Application.Tests/Capture/CapturePostProcessorTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/CapturePostProcessorTests.cs
@@ -1,0 +1,134 @@
+using CaptureTool.Application.Abstractions.Clipboard;
+using CaptureTool.Application.Abstractions.Files;
+using CaptureTool.Application.Abstractions.Library.RecentCaptures;
+using CaptureTool.Application.Abstractions.Logging;
+using CaptureTool.Application.Abstractions.Settings;
+using CaptureTool.Application.Abstractions.Storage;
+using CaptureTool.Application.Abstractions.TaskEnvironment;
+using CaptureTool.Application.Capture.Audio;
+using CaptureTool.Application.Capture.Image;
+using CaptureTool.Application.Capture.Video;
+using CaptureTool.Domain.FileSystem;
+using Moq;
+
+namespace CaptureTool.Application.Tests.Capture;
+
+[TestClass]
+public sealed class CapturePostProcessorTests
+{
+    [TestMethod]
+    public void ImageAutoSave_CopiesWithoutOverwrite()
+    {
+        const string SourcePath = @"C:\Temp\capture.png";
+        const string DestinationFolder = @"C:\Captures";
+        var fileSystem = new Mock<IFileSystem>();
+        Mock<ISettingsService> settings = CreateSettings(
+            CaptureToolSettings.Settings_ImageCapture_AutoSave,
+            CaptureToolSettings.Settings_ImageCapture_AutoCopy,
+            CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder,
+            DestinationFolder);
+        ImageCapturePostProcessor processor = new(
+            Mock.Of<IClipboardService>(),
+            fileSystem.Object,
+            settings.Object,
+            Mock.Of<IStorageService>(),
+            CreateImmediateTaskEnvironment().Object,
+            Mock.Of<ILogService>(),
+            new ImageCaptureFileNameGenerator(TestClock.Instance),
+            Mock.Of<IRecentCaptureCatalog>());
+
+        processor.Process(new ImageFile(SourcePath));
+
+        fileSystem.Verify(
+            service => service.CopyFile(
+                SourcePath,
+                It.Is<string>(path => path.StartsWith(DestinationFolder, StringComparison.Ordinal) && path.EndsWith(".png", StringComparison.Ordinal)),
+                false),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public void VideoAutoSave_CopiesWithoutOverwrite()
+    {
+        const string SourcePath = @"C:\Temp\capture.mp4";
+        const string DestinationFolder = @"C:\Captures";
+        var fileSystem = new Mock<IFileSystem>();
+        Mock<ISettingsService> settings = CreateSettings(
+            CaptureToolSettings.Settings_VideoCapture_AutoSave,
+            CaptureToolSettings.Settings_VideoCapture_AutoCopy,
+            CaptureToolSettings.Settings_VideoCapture_AutoSaveFolder,
+            DestinationFolder);
+        VideoCapturePostProcessor processor = new(
+            Mock.Of<IClipboardService>(),
+            fileSystem.Object,
+            settings.Object,
+            Mock.Of<IStorageService>(),
+            CreateImmediateTaskEnvironment().Object,
+            Mock.Of<ILogService>(),
+            new VideoCaptureFileNameGenerator(TestClock.Instance),
+            Mock.Of<IRecentCaptureCatalog>());
+
+        processor.Process(new VideoFile(SourcePath));
+
+        fileSystem.Verify(
+            service => service.CopyFile(
+                SourcePath,
+                It.Is<string>(path => path.StartsWith(DestinationFolder, StringComparison.Ordinal) && path.EndsWith(".mp4", StringComparison.Ordinal)),
+                false),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public void AudioAutoSave_CopiesWithoutOverwrite()
+    {
+        const string SourcePath = @"C:\Temp\capture.wav";
+        const string DestinationFolder = @"C:\Captures";
+        var fileSystem = new Mock<IFileSystem>();
+        Mock<ISettingsService> settings = CreateSettings(
+            CaptureToolSettings.Settings_AudioCapture_AutoSave,
+            CaptureToolSettings.Settings_AudioCapture_AutoCopy,
+            CaptureToolSettings.Settings_AudioCapture_AutoSaveFolder,
+            DestinationFolder);
+        AudioCapturePostProcessor processor = new(
+            Mock.Of<IClipboardService>(),
+            fileSystem.Object,
+            settings.Object,
+            Mock.Of<IStorageService>(),
+            CreateImmediateTaskEnvironment().Object,
+            Mock.Of<ILogService>(),
+            new AudioCaptureFileNameGenerator(TestClock.Instance),
+            Mock.Of<IRecentCaptureCatalog>());
+
+        processor.Process(new AudioFile(SourcePath));
+
+        fileSystem.Verify(
+            service => service.CopyFile(
+                SourcePath,
+                It.Is<string>(path => path.StartsWith(DestinationFolder, StringComparison.Ordinal) && path.EndsWith(".wav", StringComparison.Ordinal)),
+                false),
+            Times.Once);
+    }
+
+    private static Mock<ISettingsService> CreateSettings(
+        IBoolSettingDefinition autoSaveSetting,
+        IBoolSettingDefinition autoCopySetting,
+        IStringSettingDefinition folderSetting,
+        string destinationFolder)
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(service => service.Get(autoSaveSetting)).Returns(true);
+        settings.Setup(service => service.Get(autoCopySetting)).Returns(false);
+        settings.Setup(service => service.Get(folderSetting)).Returns(destinationFolder);
+        return settings;
+    }
+
+    private static Mock<ITaskEnvironment> CreateImmediateTaskEnvironment()
+    {
+        var taskEnvironment = new Mock<ITaskEnvironment>();
+        taskEnvironment
+            .Setup(environment => environment.TryExecute(It.IsAny<Action>()))
+            .Callback<Action>(action => action())
+            .Returns(true);
+        return taskEnvironment;
+    }
+}

--- a/tests/CaptureTool.Application.Tests/Capture/ImageCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/ImageCaptureWorkflowTests.cs
@@ -1,11 +1,13 @@
 using CaptureTool.Application.Abstractions.Capture;
 using CaptureTool.Application.Abstractions.Clipboard;
+using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Library.RecentCaptures;
 using CaptureTool.Application.Abstractions.Settings;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.TaskEnvironment;
 using CaptureTool.Application.Abstractions.Telemetry;
+using CaptureTool.Application.Capture;
 using CaptureTool.Application.Capture.Image;
 using CaptureTool.Domain.Capture;
 using CaptureTool.Domain.FileSystem;
@@ -107,6 +109,34 @@ public sealed class ImageCaptureWorkflowTests
     }
 
     [TestMethod]
+    public void CaptureMonitors_WhenImageSaveFails_DeletesReservedFile()
+    {
+        const string TempFolder = @"C:\Temp";
+        var fileSystem = new Mock<IFileSystem>();
+        var screenCapture = new Mock<IScreenCapture>();
+        screenCapture
+            .Setup(service => service.CombineMonitors(It.IsAny<IList<MonitorCaptureResult>>()))
+            .Returns(new Bitmap(2, 2));
+        screenCapture
+            .Setup(service => service.SaveImageToFile(It.IsAny<Image>(), It.IsAny<string>()))
+            .Throws(new InvalidOperationException("Save failed."));
+        ImageCaptureWorkflow workflow = CreateWorkflow(
+            TempFolder,
+            screenCapture: screenCapture.Object,
+            fileSystem: fileSystem.Object);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            workflow.CaptureMonitors([CreateMonitor()]));
+
+        fileSystem.Verify(
+            service => service.CreateEmptyFile(It.Is<string>(path => path.EndsWith(".png", StringComparison.Ordinal))),
+            Times.Once);
+        fileSystem.Verify(
+            service => service.DeleteFile(It.Is<string>(path => path.EndsWith(".png", StringComparison.Ordinal))),
+            Times.Once);
+    }
+
+    [TestMethod]
     public void CaptureMonitors_WhenAutoSaveAndCopyEnabled_CopiesToClipboardAndSavesToConfiguredFolder()
     {
         string tempFolder = CreateTestFolder();
@@ -146,7 +176,8 @@ public sealed class ImageCaptureWorkflowTests
         ISettingsService? settings = null,
         IScreenCapture? screenCapture = null,
         ITelemetryService? telemetry = null,
-        IRecentCaptureCatalog? recentCaptureCatalog = null)
+        IRecentCaptureCatalog? recentCaptureCatalog = null,
+        IFileSystem? fileSystem = null)
     {
         var storage = new Mock<IStorageService>();
         storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(tempFolder);
@@ -164,9 +195,10 @@ public sealed class ImageCaptureWorkflowTests
         defaultSettings.Setup(service => service.Get(CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder)).Returns("");
 
         var fileNameGenerator = new ImageCaptureFileNameGenerator(TestClock.Instance);
+        var fileAllocator = new CaptureFileAllocator(fileSystem ?? TestFileSystem.Instance);
         var postProcessor = new ImageCapturePostProcessor(
             clipboard ?? Mock.Of<IClipboardService>(),
-            TestFileSystem.Instance,
+            fileAllocator,
             settings ?? defaultSettings.Object,
             storage.Object,
             taskEnvironment.Object,
@@ -177,6 +209,7 @@ public sealed class ImageCaptureWorkflowTests
 
         return new ImageCaptureWorkflow(
             storage.Object,
+            fileAllocator,
             screenCapture ?? Mock.Of<IScreenCapture>(),
             postProcessor,
             fileNameGenerator,

--- a/tests/CaptureTool.Application.Tests/Capture/VideoCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/VideoCaptureWorkflowTests.cs
@@ -8,6 +8,7 @@ using CaptureTool.Application.Abstractions.Settings;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.TaskEnvironment;
 using CaptureTool.Application.Abstractions.Telemetry;
+using CaptureTool.Application.Capture;
 using CaptureTool.Application.Capture.Video;
 using CaptureTool.Domain.Capture;
 using CaptureTool.Domain.FileSystem;
@@ -64,6 +65,9 @@ public sealed class VideoCaptureWorkflowTests
         act.Should().Throw<InvalidOperationException>();
         context.Workflow.IsRecording.Should().BeFalse();
         context.Workflow.IsFinalizing.Should().BeFalse();
+        context.FileSystem.Verify(
+            service => service.DeleteFile(It.Is<string>(path => path.EndsWith(".mp4", StringComparison.Ordinal))),
+            Times.Once);
     }
 
     [TestMethod]
@@ -432,9 +436,11 @@ public sealed class VideoCaptureWorkflowTests
         }
 
         var fileNameGenerator = new VideoCaptureFileNameGenerator(TestClock.Instance);
+        var fileSystem = new Mock<IFileSystem>();
+        var fileAllocator = new CaptureFileAllocator(fileSystem.Object);
         var postProcessor = new VideoCapturePostProcessor(
             Mock.Of<IClipboardService>(),
-            Mock.Of<IFileSystem>(),
+            fileAllocator,
             settings.Object,
             storage.Object,
             taskEnvironment.Object,
@@ -446,6 +452,7 @@ public sealed class VideoCaptureWorkflowTests
             screenRecorder.Object,
             settings.Object,
             storage.Object,
+            fileAllocator,
             backgroundTaskRunner.Object,
             supportService,
             new VideoCaptureStateStore(),
@@ -456,6 +463,7 @@ public sealed class VideoCaptureWorkflowTests
         return new TestWorkflowContext(
             workflow,
             screenRecorder,
+            fileSystem,
             backgroundTaskRunner,
             recentCaptureCatalog,
             () => finalizeAction);
@@ -480,12 +488,14 @@ public sealed class VideoCaptureWorkflowTests
     private sealed class TestWorkflowContext(
         VideoCaptureWorkflow workflow,
         Mock<IScreenRecorder> screenRecorder,
+        Mock<IFileSystem> fileSystem,
         Mock<IBackgroundTaskRunner> backgroundTaskRunner,
         Mock<IRecentCaptureCatalog> recentCaptureCatalog,
         Func<Action?> getFinalizeAction)
     {
         public VideoCaptureWorkflow Workflow { get; } = workflow;
         public Mock<IScreenRecorder> ScreenRecorder { get; } = screenRecorder;
+        public Mock<IFileSystem> FileSystem { get; } = fileSystem;
         public Mock<IBackgroundTaskRunner> BackgroundTaskRunner { get; } = backgroundTaskRunner;
         public Mock<IRecentCaptureCatalog> RecentCaptureCatalog { get; } = recentCaptureCatalog;
         public Action? FinalizeAction => getFinalizeAction();

--- a/tests/CaptureTool.Application.Tests/TestFileSystem.cs
+++ b/tests/CaptureTool.Application.Tests/TestFileSystem.cs
@@ -27,6 +27,11 @@ internal sealed class TestFileSystem : IFileSystem
 
     public void CreateDirectory(string folderPath) => Directory.CreateDirectory(folderPath);
 
+    public void CreateEmptyFile(string filePath)
+    {
+        using FileStream stream = new(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+    }
+
     public void CopyFile(string sourcePath, string destinationPath, bool overwrite) =>
         File.Copy(sourcePath, destinationPath, overwrite);
 

--- a/tests/CaptureTool.Infrastructure.Capture.Windows.Tests/WindowsScreenCaptureTests.cs
+++ b/tests/CaptureTool.Infrastructure.Capture.Windows.Tests/WindowsScreenCaptureTests.cs
@@ -1,0 +1,30 @@
+using CaptureKit.Abstractions;
+using Moq;
+using System.Drawing;
+
+namespace CaptureTool.Infrastructure.Capture.Windows.Tests;
+
+[TestClass]
+public sealed class WindowsScreenCaptureTests
+{
+    [TestMethod]
+    public void SaveImageToFile_WhenDestinationIsReserved_ReplacesReservation()
+    {
+        string filePath = Path.Combine(Path.GetTempPath(), $"CaptureTool-{Guid.NewGuid():N}.png");
+
+        try
+        {
+            File.Create(filePath).Dispose();
+            using var image = new Bitmap(2, 2);
+            var screenCapture = new WindowsScreenCapture(Mock.Of<IDisplayCaptureService>());
+
+            screenCapture.SaveImageToFile(image, filePath);
+
+            Assert.IsGreaterThan(0, new FileInfo(filePath).Length);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+}

--- a/tests/CaptureTool.Infrastructure.Tests/Files/LocalFileSystemTests.cs
+++ b/tests/CaptureTool.Infrastructure.Tests/Files/LocalFileSystemTests.cs
@@ -6,6 +6,34 @@ namespace CaptureTool.Infrastructure.Tests.Files;
 public sealed class LocalFileSystemTests
 {
     [TestMethod]
+    public async Task CreateEmptyFile_WhenDestinationExists_PreservesDestination()
+    {
+        var fileSystem = new LocalFileSystem();
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            "CaptureToolTests",
+            Guid.NewGuid().ToString("N"));
+        string destination = Path.Combine(root, "capture.png");
+
+        try
+        {
+            fileSystem.CreateDirectory(root);
+            await fileSystem.WriteAllTextAsync(destination, "existing capture", TestContext.CancellationToken);
+
+            Assert.ThrowsExactly<IOException>(() => fileSystem.CreateEmptyFile(destination));
+
+            Assert.AreEqual("existing capture", await File.ReadAllTextAsync(destination, TestContext.CancellationToken));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
     public async Task CopyFile_WhenDestinationExistsAndOverwriteIsFalse_PreservesDestination()
     {
         var fileSystem = new LocalFileSystem();

--- a/tests/CaptureTool.Infrastructure.Tests/Files/LocalFileSystemTests.cs
+++ b/tests/CaptureTool.Infrastructure.Tests/Files/LocalFileSystemTests.cs
@@ -6,6 +6,37 @@ namespace CaptureTool.Infrastructure.Tests.Files;
 public sealed class LocalFileSystemTests
 {
     [TestMethod]
+    public async Task CopyFile_WhenDestinationExistsAndOverwriteIsFalse_PreservesDestination()
+    {
+        var fileSystem = new LocalFileSystem();
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            "CaptureToolTests",
+            Guid.NewGuid().ToString("N"));
+        string source = Path.Combine(root, "source.txt");
+        string destination = Path.Combine(root, "destination.txt");
+
+        try
+        {
+            fileSystem.CreateDirectory(root);
+            await fileSystem.WriteAllTextAsync(source, "new capture", TestContext.CancellationToken);
+            await fileSystem.WriteAllTextAsync(destination, "existing capture", TestContext.CancellationToken);
+
+            Assert.ThrowsExactly<IOException>(() =>
+                fileSystem.CopyFile(source, destination, overwrite: false));
+
+            Assert.AreEqual("existing capture", await File.ReadAllTextAsync(destination, TestContext.CancellationToken));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
     public async Task FileAndDirectoryOperations_RoundTrip()
     {
         var fileSystem = new LocalFileSystem();


### PR DESCRIPTION
## Summary

- document the collision-safe capture identity requirements in a PRD
- give image, video, and audio captures a canonical full-timestamp plus GUID filename
- atomically reserve temporary capture destinations with create-new semantics
- copy auto-saved captures without overwrite and retry confirmed collisions up to 10 times
- clean up abandoned reservations when image save or recorder startup fails
- add parallel same-clock, allocator, workflow cleanup, adapter, and filesystem regression coverage

## Root cause

Capture filenames used `Capture_{yyyy-MM-dd}_{FFFFF}`, where `FFFFF` is only the fractional second. Captures on the same day could therefore reuse a path. Auto-save compounded the collision by copying with overwrite enabled. Randomized names alone did not close the remaining race between generating a temporary path and the capture adapter creating it.

## User impact

New captures retain readable timestamps while receiving process- and thread-independent identities. Temporary paths are reserved atomically, and existing temporary or auto-save files are never overwritten as a collision policy. Confirmed collisions receive a fresh generated candidate; startup failures remove only the abandoned app-owned reservation.

## Validation

- `CaptureTool.Application.Tests`: 269 passed
- `CaptureTool.Infrastructure.Tests`: 129 passed
- `CaptureTool.Infrastructure.Capture.Windows.Tests`: 19 passed
- `CaptureTool.Infrastructure.Edit.Windows.Tests`: 33 passed
- `CaptureTool.Presentation.Tests`: 139 passed
- `CaptureTool.Mcp.CaptureServer.Tests`: 17 passed

Total: 606 passed, 0 failed, 0 skipped.

The existing Win2D AnyCPU platform warning remains unchanged.

Fixes #406
