### PR TITLE
Commit navigation after host acceptance

### DIFF
--- a/docs/prd-409-transactional-navigation-host-acceptance.md
+++ b/docs/prd-409-transactional-navigation-host-acceptance.md
@@ -2,7 +2,7 @@
 
 - Issue: [#409](https://github.com/shanebweaver/CaptureTool/issues/409)
 - Severity: High
-- Status: Ready for implementation
+- Status: Implemented
 - Affected features: `APP-02`, `APP-07`, `CAP-05`
 
 ## Summary
@@ -112,10 +112,10 @@ State queries must remain safe while an asynchronous transition is pending and m
 
 ## Acceptance criteria
 
-- [ ] Declining active-video cancellation leaves the capture overlay route committed and its controls eligible.
-- [ ] History, telemetry, and `Navigated` commit only after host acceptance.
-- [ ] Rejection, cancellation, and host failure leave the last committed navigation state intact.
-- [ ] Navigation exceptions flow through awaited use-case/activation error boundaries.
-- [ ] Navigate, back, and back-to operations use the same transactional contract.
-- [ ] #408 leave guards and transition serialization remain intact.
-- [ ] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+- [x] Declining active-video cancellation leaves the capture overlay route committed and its controls eligible.
+- [x] History, telemetry, and `Navigated` commit only after host acceptance.
+- [x] Rejection, cancellation, and host failure leave the last committed navigation state intact.
+- [x] Navigation exceptions flow through awaited use-case/activation error boundaries.
+- [x] Navigate, back, and back-to operations use the same transactional contract.
+- [x] #408 leave guards and transition serialization remain intact.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/docs/prd-409-transactional-navigation-host-acceptance.md
+++ b/docs/prd-409-transactional-navigation-host-acceptance.md
@@ -1,0 +1,121 @@
+# PRD: Commit navigation only after host acceptance
+
+- Issue: [#409](https://github.com/shanebweaver/CaptureTool/issues/409)
+- Severity: High
+- Status: Ready for implementation
+- Affected features: `APP-02`, `APP-07`, `CAP-05`
+
+## Summary
+
+Navigation history, completion telemetry, and the `Navigated` event must describe the route the UI host actually accepted. Every navigation operation will prepare a candidate transition, await an explicit host result, and commit application navigation state only when the host accepts it.
+
+The change replaces the synchronous `void` navigation dispatch contract with awaited results, removes `async void` from the top-level WinUI navigation handler, and preserves the serialization and leave-policy behavior introduced by #408.
+
+## Problem
+
+`NavigationService` currently mutates its stack before calling `INavigationHandler`. The handler returns `void`, while `AppNavigationHandler` is implemented as `async void` and can reject a request later when the user declines cancellation of an active video recording. It can also fail after an asynchronous host operation.
+
+The service therefore reports navigation as complete before acceptance is known. A rejected transition can leave the recording overlay visible while `CurrentRequest` names a different route, causing route-based commands to disable controls that are still on screen. Exceptions escape the awaited use-case boundary, and telemetry/events can claim a transition that did not happen.
+
+## Goals
+
+1. Keep `CurrentRequest`, back history, telemetry, and `Navigated` synchronized with accepted host state.
+2. Make host rejection, no-change, cancellation, and failure explicit to navigation callers.
+3. Await WinUI host transitions so exceptions return through the initiating use case or activation boundary.
+4. Preserve #408's edit/audio leave policy and single-transition serialization.
+5. Preserve existing accepted navigation, back, clear-history, protocol activation, and capture-completion behavior.
+
+## Non-goals
+
+- Do not redesign edit or capture confirmation UI.
+- Do not change which routes are hosted by the main window, selection overlay, or capture overlay.
+- Do not persist navigation history across application launches.
+- Do not add arbitrary retry behavior after platform/window failures.
+- Do not claim that every platform side effect can be reversed after a host throws; the application navigation model must remain uncommitted, and the host must recover to a usable state where practical.
+
+## Navigation result contract
+
+Add an explicit result with these outcomes:
+
+- **Accepted:** the host accepted the requested route and application navigation state may commit.
+- **Rejected:** the host deliberately retained its current UI, such as when active-video cancellation is declined.
+- **No change:** no target exists or the requested route/parameter already matches the current request.
+
+Exceptions and cancellation remain exceptions/cancellation rather than being collapsed into rejection, allowing existing awaited boundaries to log or classify them correctly.
+
+## Functional requirements
+
+### Navigation service transaction
+
+For navigate, back, and back-to operations:
+
+1. Serialize the entire operation.
+2. Inspect current history and prepare a candidate request without mutating history.
+3. Return No change without dispatch when the request is an exact duplicate or a back target is unavailable.
+4. Await `INavigationHandler` with the caller's cancellation token.
+5. On Accepted, commit the prepared history mutation, then emit navigation-completed telemetry and `Navigated`.
+6. On Rejected, cancellation, or exception, leave history unchanged and emit neither completion telemetry nor `Navigated`.
+
+State queries must remain safe while an asynchronous transition is pending and must continue to expose the last committed request.
+
+### Application coordinator and callers
+
+- `INavigationCoordinator` continues to expose its existing Boolean accepted/not-accepted API to application use cases.
+- It awaits the low-level navigation result and reports true only for an accepted transition; its exact-request shortcut remains successful without dispatch.
+- Back operations report false for Rejected or No change.
+- Trusted post-capture transitions still bypass abandonment guards, but they must await host acceptance.
+- Error and UI-test bootstrap navigation must use the awaited service contract rather than fire-and-forget synchronous dispatch.
+
+### WinUI host acceptance
+
+- Replace `AppNavigationHandler.HandleNavigationRequest` `async void` with an awaited method.
+- Thread cancellation through host serialization and active-video cancellation.
+- Return Rejected before changing hosts when video-capture cancellation is declined.
+- Return Accepted only after the requested top-level host has been created/updated or the main-window route has been handed to the main-window host.
+- Return Rejected when an already-active capture host cannot apply a different request.
+- Allow exceptions from host creation, disposal, or route dispatch to propagate to the awaited caller; keep `_activeHost` aligned with the host that remains usable where practical.
+
+## Reliability requirements
+
+- A rejected transition cannot alter stack count, `CurrentRequest`, or `CanGoBack`.
+- A rejected transition cannot emit `navigation.completed` or raise `Navigated`.
+- A handler exception or cancellation cannot alter navigation history or emit completion signals.
+- The navigation serialization gate is released after acceptance, rejection, no-change, cancellation, or exception.
+- A later request can succeed after any rejected or failed request.
+- No top-level navigation handler remains `async void`.
+
+## Test plan
+
+### Navigation service
+
+- accepted navigation commits history, telemetry, and event after handler completion;
+- handler rejection retains the current request and history and emits no completion signals;
+- handler exception and cancellation retain state and release serialization;
+- pending host acceptance leaves `CurrentRequest` unchanged;
+- rejected back and back-to retain the original stack;
+- accepted back and clear-history preserve existing semantics;
+- exact duplicate and missing targets return No change without host dispatch.
+
+### Coordinator and use cases
+
+- coordinator returns false for host rejection and true for acceptance;
+- guards still run once before host dispatch;
+- concurrent requests remain serialized through host completion;
+- trusted audio/video completion use cases await and expose rejected navigation results.
+
+### WinUI integration/build
+
+- active video cancellation rejection returns Rejected before overlay disposal or host switch;
+- accepted host paths return Accepted;
+- all non-UI test projects pass;
+- the WinUI x64 Debug project builds without `async void` navigation dispatch.
+
+## Acceptance criteria
+
+- [ ] Declining active-video cancellation leaves the capture overlay route committed and its controls eligible.
+- [ ] History, telemetry, and `Navigated` commit only after host acceptance.
+- [ ] Rejection, cancellation, and host failure leave the last committed navigation state intact.
+- [ ] Navigation exceptions flow through awaited use-case/activation error boundaries.
+- [ ] Navigate, back, and back-to operations use the same transactional contract.
+- [ ] #408 leave guards and transition serialization remain intact.
+- [ ] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Application.Abstractions/Navigation/INavigationHandler.cs
+++ b/src/CaptureTool.Application.Abstractions/Navigation/INavigationHandler.cs
@@ -2,5 +2,7 @@ namespace CaptureTool.Application.Abstractions.Navigation;
 
 public interface INavigationHandler
 {
-    void HandleNavigationRequest(INavigationRequest request);
+    Task<NavigationResult> HandleNavigationRequestAsync(
+        INavigationRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/CaptureTool.Application.Abstractions/Navigation/INavigationService.cs
+++ b/src/CaptureTool.Application.Abstractions/Navigation/INavigationService.cs
@@ -6,7 +6,13 @@ public interface INavigationService
     INavigationRequest? CurrentRequest { get; }
     bool CanGoBack { get; }
     void SetNavigationHandler(INavigationHandler handler);
-    void Navigate(object route, object? parameter = null, bool clearHistory = false);
-    bool TryGoBack();
-    bool TryGoBackTo(Func<INavigationRequest, bool> assessRequest);
+    Task<NavigationResult> NavigateAsync(
+        object route,
+        object? parameter = null,
+        bool clearHistory = false,
+        CancellationToken cancellationToken = default);
+    Task<NavigationResult> TryGoBackAsync(CancellationToken cancellationToken = default);
+    Task<NavigationResult> TryGoBackToAsync(
+        Func<INavigationRequest, bool> assessRequest,
+        CancellationToken cancellationToken = default);
 }

--- a/src/CaptureTool.Application.Abstractions/Navigation/NavigationResult.cs
+++ b/src/CaptureTool.Application.Abstractions/Navigation/NavigationResult.cs
@@ -1,0 +1,8 @@
+namespace CaptureTool.Application.Abstractions.Navigation;
+
+public enum NavigationResult
+{
+    NoChange,
+    Accepted,
+    Rejected
+}

--- a/src/CaptureTool.Application/Capture/Audio/StopAudioCapture/StopAudioCaptureUseCase.cs
+++ b/src/CaptureTool.Application/Capture/Audio/StopAudioCapture/StopAudioCaptureUseCase.cs
@@ -26,13 +26,16 @@ internal sealed class StopAudioCaptureUseCase : IStopAudioCaptureUseCase
     {
         return _useCaseExecutor.ExecuteAsync(
             activityId: ActivityId,
-            useCase: () =>
+            useCase: async token =>
             {
                 var audioFile = _audioCaptureWorkflow.StopCapture();
                 // This is the successful completion of the active audio workflow,
                 // not an attempt to abandon it; the audio leave guard must not run.
-                _navigationService.Navigate(NavigationRoute.AudioEdit, audioFile);
-                return new StopAudioCaptureResponse();
+                NavigationResult navigationResult = await _navigationService.NavigateAsync(
+                    NavigationRoute.AudioEdit,
+                    audioFile,
+                    cancellationToken: token);
+                return new StopAudioCaptureResponse(navigationResult == NavigationResult.Accepted);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Capture/Video/StopVideoCapture/StopVideoCaptureUseCase.cs
+++ b/src/CaptureTool.Application/Capture/Video/StopVideoCapture/StopVideoCaptureUseCase.cs
@@ -32,13 +32,16 @@ internal sealed class StopVideoCaptureUseCase : IStopVideoCaptureUseCase
     {
         return _useCaseExecutor.ExecuteAsync(
             activityId: ActivityId,
-            useCase: () =>
+            useCase: async token =>
             {
                 var pendingVideo = _videoCaptureWorkflow.StopVideoCapture();
                 // This is the successful completion of the active video workflow,
                 // so it intentionally bypasses user-initiated leave confirmation.
-                _navigationService.Navigate(NavigationRoute.VideoEdit, pendingVideo);
-                return new StopVideoCaptureResponse();
+                NavigationResult navigationResult = await _navigationService.NavigateAsync(
+                    NavigationRoute.VideoEdit,
+                    pendingVideo,
+                    cancellationToken: token);
+                return new StopVideoCaptureResponse(navigationResult == NavigationResult.Accepted);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Navigation/NavigationCoordinator.cs
+++ b/src/CaptureTool.Application/Navigation/NavigationCoordinator.cs
@@ -48,11 +48,8 @@ internal sealed class NavigationCoordinator : INavigationCoordinator
 
         return ExecuteGuardedTransitionAsync(
             canSkipLeavePolicy: () => RequestsMatch(_navigationService.CurrentRequest, route, parameter),
-            transition: _ =>
-            {
-                _navigationService.Navigate(route, parameter, clearHistory);
-                return Task.FromResult(true);
-            },
+            transition: async token =>
+                await _navigationService.NavigateAsync(route, parameter, clearHistory, token) == NavigationResult.Accepted,
             cancellationToken);
     }
 
@@ -60,7 +57,8 @@ internal sealed class NavigationCoordinator : INavigationCoordinator
     {
         return ExecuteGuardedTransitionAsync(
             canSkipLeavePolicy: () => !_navigationService.CanGoBack,
-            transition: _ => Task.FromResult(_navigationService.TryGoBack()),
+            transition: async token =>
+                await _navigationService.TryGoBackAsync(token) == NavigationResult.Accepted,
             cancellationToken,
             skippedResult: false);
     }
@@ -73,7 +71,8 @@ internal sealed class NavigationCoordinator : INavigationCoordinator
 
         return ExecuteGuardedTransitionAsync(
             canSkipLeavePolicy: () => !_navigationService.CanGoBack,
-            transition: _ => Task.FromResult(_navigationService.TryGoBackTo(assessRequest)),
+            transition: async token =>
+                await _navigationService.TryGoBackToAsync(assessRequest, token) == NavigationResult.Accepted,
             cancellationToken,
             skippedResult: false);
     }

--- a/src/CaptureTool.Infrastructure/Navigation/NavigationRequest.cs
+++ b/src/CaptureTool.Infrastructure/Navigation/NavigationRequest.cs
@@ -13,11 +13,11 @@ public readonly struct NavigationRequest : INavigationRequest
         object route,
         object? parameter = null,
         bool isBackNavigation = false,
-        bool clearHistroy = false)
+        bool clearHistory = false)
     {
         Route = route;
         Parameter = parameter;
         IsBackNavigation = isBackNavigation;
-        ClearHistory = clearHistroy;
+        ClearHistory = clearHistory;
     }
 }

--- a/src/CaptureTool.Infrastructure/Navigation/NavigationService.cs
+++ b/src/CaptureTool.Infrastructure/Navigation/NavigationService.cs
@@ -6,14 +6,34 @@ namespace CaptureTool.Infrastructure.Navigation;
 public class NavigationService : INavigationService
 {
     private readonly Stack<NavigationRequest> _navigationStack = new();
-    private readonly Lock _navigationLock = new();
+    private readonly Lock _stateLock = new();
+    private readonly SemaphoreSlim _transitionGate = new(1, 1);
     private readonly ITelemetryService? _telemetryService;
     private INavigationHandler? _navigationHandler;
 
     public event EventHandler<INavigationEventArgs>? Navigated;
 
-    public INavigationRequest? CurrentRequest => _navigationStack.Count == 0 ? null : _navigationStack.Peek();
-    public bool CanGoBack => _navigationStack.Count > 1;
+    public INavigationRequest? CurrentRequest
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                return _navigationStack.Count == 0 ? null : _navigationStack.Peek();
+            }
+        }
+    }
+
+    public bool CanGoBack
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                return _navigationStack.Count > 1;
+            }
+        }
+    }
 
     public NavigationService(ITelemetryService? telemetryService = null)
     {
@@ -22,110 +42,182 @@ public class NavigationService : INavigationService
 
     public void SetNavigationHandler(INavigationHandler navigationHandler)
     {
-        _navigationHandler = navigationHandler;
-    }
+        ArgumentNullException.ThrowIfNull(navigationHandler);
 
-    public bool TryGoBack()
-    {
-        lock (_navigationLock)
+        lock (_stateLock)
         {
-            if (_navigationStack.Count <= 1)
-            {
-                return false;
-            }
-
-            INavigationRequest currentRequest = _navigationStack.Pop();
-            INavigationRequest backRequest = _navigationStack.Peek();
-
-            bool requestsMatch = CompareRequests(currentRequest, backRequest);
-            if (!requestsMatch)
-            {
-                RequestNavigation(
-                    new NavigationRequest(backRequest.Route, backRequest.Parameter, true, false),
-                    currentRequest.Route);
-            }
-
-            return true;
+            _navigationHandler = navigationHandler;
         }
     }
 
-    public bool TryGoBackTo(Func<INavigationRequest, bool> assesRequest)
+    public async Task<NavigationResult> NavigateAsync(
+        object route,
+        object? parameter = null,
+        bool clearHistory = false,
+        CancellationToken cancellationToken = default)
     {
-        lock (_navigationLock)
+        ArgumentNullException.ThrowIfNull(route);
+
+        await _transitionGate.WaitAsync(cancellationToken);
+        try
         {
-            if (_navigationStack.Count <= 1)
+            NavigationRequest? currentRequest;
+            lock (_stateLock)
             {
-                return false;
+                currentRequest = _navigationStack.Count == 0 ? null : _navigationStack.Peek();
             }
 
-            var entries = _navigationStack.ToArray();
-            int targetIndex = -1;
-            for (int i = 1; i < entries.Length; i++)
+            NavigationRequest newRequest = new(route, parameter, false, clearHistory);
+            if (CompareRequests(currentRequest, newRequest))
             {
-                if (assesRequest(entries[i]))
+                return NavigationResult.NoChange;
+            }
+
+            NavigationResult result = await DispatchAsync(newRequest, cancellationToken);
+            if (result != NavigationResult.Accepted)
+            {
+                return result;
+            }
+
+            lock (_stateLock)
+            {
+                if (clearHistory)
                 {
-                    targetIndex = i;
-                    break;
+                    _navigationStack.Clear();
                 }
+
+                _navigationStack.Push(newRequest);
             }
 
-            if (targetIndex == -1)
+            CompleteNavigation(newRequest, currentRequest?.Route);
+            return NavigationResult.Accepted;
+        }
+        finally
+        {
+            _transitionGate.Release();
+        }
+    }
+
+    public async Task<NavigationResult> TryGoBackAsync(CancellationToken cancellationToken = default)
+    {
+        await _transitionGate.WaitAsync(cancellationToken);
+        try
+        {
+            NavigationRequest currentRequest;
+            NavigationRequest backRequest;
+            lock (_stateLock)
             {
-                return false;
+                if (_navigationStack.Count <= 1)
+                {
+                    return NavigationResult.NoChange;
+                }
+
+                NavigationRequest[] entries = _navigationStack.ToArray();
+                currentRequest = entries[0];
+                backRequest = entries[1];
             }
 
-            var currentRequest = _navigationStack.Peek();
-            var targetRequest = entries[targetIndex];
-            if (CompareRequests(currentRequest, targetRequest))
+            NavigationRequest candidate = new(
+                backRequest.Route,
+                backRequest.Parameter,
+                isBackNavigation: true,
+                clearHistory: false);
+            NavigationResult result = await DispatchAsync(candidate, cancellationToken);
+            if (result != NavigationResult.Accepted)
             {
-                return false;
+                return result;
             }
 
-            for (int i = 0; i < targetIndex; i++)
+            lock (_stateLock)
             {
                 _navigationStack.Pop();
             }
 
-            NavigationRequest actualTop = _navigationStack.Peek();
-            RequestNavigation(
-                new NavigationRequest(actualTop.Route, actualTop.Parameter, isBackNavigation: true),
-                currentRequest.Route);
-            return true;
+            CompleteNavigation(candidate, currentRequest.Route);
+            return NavigationResult.Accepted;
+        }
+        finally
+        {
+            _transitionGate.Release();
         }
     }
 
-    public void Navigate(object route, object? parameter = null, bool clearHistory = false)
+    public async Task<NavigationResult> TryGoBackToAsync(
+        Func<INavigationRequest, bool> assessRequest,
+        CancellationToken cancellationToken = default)
     {
-        lock (_navigationLock)
+        ArgumentNullException.ThrowIfNull(assessRequest);
+
+        await _transitionGate.WaitAsync(cancellationToken);
+        try
         {
-            NavigationRequest? currentRequest = _navigationStack.Count == 0 ? null : _navigationStack.Peek();
-            NavigationRequest newRequest = new(route, parameter, false, clearHistory);
-
-            bool requestsMatch = CompareRequests(currentRequest, newRequest);
-            if (requestsMatch)
+            NavigationRequest currentRequest;
+            NavigationRequest targetRequest;
+            NavigationRequest[] entries;
+            int targetIndex;
+            lock (_stateLock)
             {
-                return;
+                if (_navigationStack.Count <= 1)
+                {
+                    return NavigationResult.NoChange;
+                }
+
+                entries = _navigationStack.ToArray();
             }
 
-            if (clearHistory)
+            targetIndex = Array.FindIndex(entries, 1, request => assessRequest(request));
+            if (targetIndex == -1)
             {
-                _navigationStack.Clear();
+                return NavigationResult.NoChange;
             }
 
-            _navigationStack.Push(newRequest);
+            currentRequest = entries[0];
+            targetRequest = entries[targetIndex];
 
-            RequestNavigation(newRequest, currentRequest?.Route);
+            NavigationRequest candidate = new(
+                targetRequest.Route,
+                targetRequest.Parameter,
+                isBackNavigation: true,
+                clearHistory: false);
+            NavigationResult result = await DispatchAsync(candidate, cancellationToken);
+            if (result != NavigationResult.Accepted)
+            {
+                return result;
+            }
+
+            lock (_stateLock)
+            {
+                for (int i = 0; i < targetIndex; i++)
+                {
+                    _navigationStack.Pop();
+                }
+            }
+
+            CompleteNavigation(candidate, currentRequest.Route);
+            return NavigationResult.Accepted;
+        }
+        finally
+        {
+            _transitionGate.Release();
         }
     }
 
-    private void RequestNavigation(NavigationRequest request, object? fromRoute)
+    private Task<NavigationResult> DispatchAsync(
+        NavigationRequest request,
+        CancellationToken cancellationToken)
     {
-        if (_navigationHandler is null)
+        INavigationHandler handler;
+        lock (_stateLock)
         {
-            throw new InvalidOperationException("Unable to navigate. No navigation handler is set.");
+            handler = _navigationHandler ??
+                throw new InvalidOperationException("Unable to navigate. No navigation handler is set.");
         }
 
-        _navigationHandler.HandleNavigationRequest(request);
+        return handler.HandleNavigationRequestAsync(request, cancellationToken);
+    }
+
+    private void CompleteNavigation(NavigationRequest request, object? fromRoute)
+    {
         TrackNavigation(request, fromRoute);
         Navigated?.Invoke(this, new NavigationEventArgs(request));
     }

--- a/src/CaptureTool.Presentation.Windows.WinUI/AppNavigationHandler.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/AppNavigationHandler.cs
@@ -20,7 +20,6 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
 
     private readonly IShutdownHandler _shutdownHandler;
     private readonly ICancelVideoCaptureUseCase _cancelVideoCaptureCommand;
-    private readonly INavigationService _navigationService;
     private readonly IShowMainWindowUseCase _showMainWindowCommand;
 
     private readonly SemaphoreSlim _semaphoreNavigation = new(1, 1);
@@ -33,47 +32,54 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
     public AppNavigationHandler(
         IShutdownHandler shutdownHandler,
         ICancelVideoCaptureUseCase cancelVideoCaptureCommand,
-        INavigationService navigationService,
         IShowMainWindowUseCase showMainWindowCommand)
     {
         _shutdownHandler = shutdownHandler;
         _cancelVideoCaptureCommand = cancelVideoCaptureCommand;
-        _navigationService = navigationService;
         _showMainWindowCommand = showMainWindowCommand;
     }
 
-    public async void HandleNavigationRequest(INavigationRequest request)
+    public async Task<NavigationResult> HandleNavigationRequestAsync(
+        INavigationRequest request,
+        CancellationToken cancellationToken = default)
     {
-        await _semaphoreNavigation.WaitAsync();
+        await _semaphoreNavigation.WaitAsync(cancellationToken);
 
         try
         {
             if (CaptureToolNavigationRouteHelper.IsMainWindowRoute(request.Route))
             {
-                switch (_activeHost)
+                UXHost previousHost = _activeHost;
+                if (previousHost == UXHost.CaptureOverlay &&
+                    !await TryCancelVideoCaptureAsync(cancellationToken))
                 {
-                    case UXHost.MainWindow:
-                        break;
-
-                    case UXHost.SelectionOverlay:
-                        await DisposeSelectionOverlayHostAsync();
-                        _mainWindowHost.ExcludeWindowFromCapture(false);
-                        break;
-
-                    case UXHost.CaptureOverlay:
-                        if (!await TryCancelVideoCaptureAsync())
-                        {
-                            return;
-                        }
-
-                        await DisposeCaptureOverlayHostAsync();
-                        _mainWindowHost.ExcludeWindowFromCapture(false);
-                        break;
+                    return NavigationResult.Rejected;
                 }
 
+                NavigationResult mainWindowResult = await _mainWindowHost.HandleNavigationRequestAsync(
+                    request,
+                    cancellationToken);
+                if (mainWindowResult == NavigationResult.Rejected)
+                {
+                    return mainWindowResult;
+                }
+
+                if (previousHost == UXHost.SelectionOverlay)
+                {
+                    await DisposeSelectionOverlayHostAsync();
+                }
+                else if (previousHost == UXHost.CaptureOverlay)
+                {
+                    await DisposeCaptureOverlayHostAsync();
+                }
+
+                _mainWindowHost.ExcludeWindowFromCapture(false);
                 _mainWindowHost.Show();
-                _mainWindowHost.HandleNavigationRequest(request);
+
+                // NoChange means the requested page was already visible in the hidden main window.
+                // Switching back from an overlay still accepts the application-level transition.
                 _activeHost = UXHost.MainWindow;
+                return NavigationResult.Accepted;
             }
             else if (request.Route is NavigationRoute imageRoute && imageRoute == NavigationRoute.SelectionOverlay)
             {
@@ -87,17 +93,17 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
                     case UXHost.MainWindow:
                         _mainWindowHost.ExcludeWindowFromCapture(true);
                         _mainWindowHost.Hide();
-                        await Task.Delay(200);
+                        await Task.Delay(200, cancellationToken);
                         break;
 
                     case UXHost.SelectionOverlay:
                         _selectionOverlayHost?.UpdateOptions(options);
-                        return;
+                        return NavigationResult.Accepted;
 
                     case UXHost.CaptureOverlay:
-                        if (!await TryCancelVideoCaptureAsync())
+                        if (!await TryCancelVideoCaptureAsync(cancellationToken))
                         {
-                            return;
+                            return NavigationResult.Rejected;
                         }
 
                         await DisposeCaptureOverlayHostAsync();
@@ -107,6 +113,7 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
                 // Create fresh instance using factory pattern
                 await CreateSelectionOverlayHostAsync(options);
                 _activeHost = UXHost.SelectionOverlay;
+                return NavigationResult.Accepted;
             }
             else if (request.Route is NavigationRoute videoRoute && videoRoute == NavigationRoute.CaptureOverlay)
             {
@@ -120,7 +127,7 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
                     case UXHost.MainWindow:
                         _mainWindowHost.ExcludeWindowFromCapture(true);
                         _mainWindowHost.Hide();
-                        await Task.Delay(200);
+                        await Task.Delay(200, cancellationToken);
                         break;
 
                     case UXHost.SelectionOverlay:
@@ -128,12 +135,13 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
                         break;
 
                     case UXHost.CaptureOverlay:
-                        return;
+                        return NavigationResult.Rejected;
                 }
 
                 // Create fresh instance using factory pattern
                 await CreateCaptureOverlayHostAsync(args);
                 _activeHost = UXHost.CaptureOverlay;
+                return NavigationResult.Accepted;
             }
             else
             {
@@ -146,9 +154,11 @@ internal partial class AppNavigationHandler : INavigationHandler, IWindowHandleP
         }
     }
 
-    private async Task<bool> TryCancelVideoCaptureAsync()
+    private async Task<bool> TryCancelVideoCaptureAsync(CancellationToken cancellationToken)
     {
-        var response = await _cancelVideoCaptureCommand.ExecuteAsync(new CancelVideoCaptureRequest());
+        var response = await _cancelVideoCaptureCommand.ExecuteAsync(
+            new CancelVideoCaptureRequest(),
+            cancellationToken);
         return response.Value?.Succeeded == true;
     }
 

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/PageBase.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/PageBase.cs
@@ -62,7 +62,7 @@ public abstract class PageBase<VM> : Page where VM : IViewModel
         catch (Exception ex)
         {
             _logService.LogException(ex, "Failed to load page.");
-            _navigationService.Navigate(NavigationRoute.Error, ex);
+            await _navigationService.NavigateAsync(NavigationRoute.Error, ex);
         }
 
         base.OnNavigatedTo(e);

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/MainWindow.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/MainWindow.xaml.cs
@@ -80,7 +80,6 @@ public sealed partial class MainWindow : Window
         Activated += OnActivated;
         AppWindow.Closing += OnAppWindowClosing;
         Closed += OnClosed;
-        ViewModel.NavigationRequested += OnViewModelNavigationRequested;
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
 
         UpdateRequestedAppTheme();
@@ -154,13 +153,20 @@ public sealed partial class MainWindow : Window
         }
 
         _uiTestLaunchNavigationHandled = true;
-        DispatcherQueue.TryEnqueue(() =>
+        DispatcherQueue.TryEnqueue(async () =>
         {
-            INavigationService navigationService = App.Current.ServiceProvider.GetService<INavigationService>();
-            navigationService.Navigate(
-                NavigationRoute.ImageEdit,
-                new ImageFile(options.ImageFilePath),
-                true);
+            try
+            {
+                INavigationService navigationService = App.Current.ServiceProvider.GetService<INavigationService>();
+                await navigationService.NavigateAsync(
+                    NavigationRoute.ImageEdit,
+                    new ImageFile(options.ImageFilePath),
+                    true);
+            }
+            catch (Exception ex)
+            {
+                _logService.LogException(ex, "Failed to navigate to the UI test image.");
+            }
         });
     }
 
@@ -339,7 +345,6 @@ public sealed partial class MainWindow : Window
         _notificationTimer.Stop();
         _notificationTimer.Tick -= NotificationTimer_Tick;
 
-        ViewModel.NavigationRequested -= OnViewModelNavigationRequested;
         ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
 
         ViewModel.Dispose();
@@ -375,40 +380,85 @@ public sealed partial class MainWindow : Window
         }
     }
 
-    public void HandleNavigationRequest(INavigationRequest request)
+    public async Task<NavigationResult> HandleNavigationRequestAsync(
+        INavigationRequest request,
+        CancellationToken cancellationToken = default)
     {
-        bool navigationRequested = ViewModel.HandleNavigationRequest(request);
-        if (!navigationRequested)
+        if (ViewModel.IsCurrentNavigationRequest(request))
         {
             DispatcherQueue.TryEnqueue(ResumeMediaPlayback);
+            return NavigationResult.NoChange;
         }
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool enqueued = DispatcherQueue.TryEnqueue(() =>
+        {
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Type pageType = PageLocator.GetPageType(request.Route);
+                int backTargetIndex = request.IsBackNavigation
+                    ? FindBackTargetIndex(pageType, request.Parameter)
+                    : -1;
+                if (backTargetIndex >= 0)
+                {
+                    while (NavigationFrame.BackStack.Count - 1 > backTargetIndex)
+                    {
+                        NavigationFrame.BackStack.RemoveAt(NavigationFrame.BackStack.Count - 1);
+                    }
+
+                    NavigationFrame.GoBack();
+                    NavigationFrame.ForwardStack.Clear();
+                    GC.Collect();
+                }
+                else
+                {
+                    NavigationFrame.Navigate(pageType, request.Parameter);
+                }
+
+                if (request.ClearHistory)
+                {
+                    NavigationFrame.ForwardStack.Clear();
+                    NavigationFrame.BackStack.Clear();
+                    GC.Collect();
+                }
+
+                ResumeMediaPlayback();
+                completion.SetResult();
+            }
+            catch (OperationCanceledException ex)
+            {
+                completion.SetCanceled(ex.CancellationToken);
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+        });
+
+        if (!enqueued)
+        {
+            return NavigationResult.Rejected;
+        }
+
+        await completion.Task;
+        ViewModel.CommitNavigationRequest(request);
+        return NavigationResult.Accepted;
     }
 
-    private void OnViewModelNavigationRequested(object? sender, INavigationRequest navigationRequest)
+    private int FindBackTargetIndex(Type pageType, object? parameter)
     {
-        DispatcherQueue.TryEnqueue(() =>
+        for (int i = NavigationFrame.BackStack.Count - 1; i >= 0; i--)
         {
-            Type pageType = PageLocator.GetPageType(navigationRequest.Route);
-            if (navigationRequest.IsBackNavigation && NavigationFrame.CanGoBack)
+            var entry = NavigationFrame.BackStack[i];
+            if (entry.SourcePageType == pageType && Equals(entry.Parameter, parameter))
             {
-                NavigationFrame.GoBack();
-                NavigationFrame.ForwardStack.Clear();
-                GC.Collect();
+                return i;
             }
-            else
-            {
-                NavigationFrame.Navigate(pageType, navigationRequest.Parameter);
-            }
+        }
 
-            if (navigationRequest.ClearHistory)
-            {
-                NavigationFrame.ForwardStack.Clear();
-                NavigationFrame.BackStack.Clear();
-                GC.Collect();
-            }
-
-            ResumeMediaPlayback();
-        });
+        return -1;
     }
 
     private void RestoreAppWindowSizeAndPosition()

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/MainWindowHost.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/MainWindowHost.cs
@@ -3,7 +3,7 @@ using CaptureTool.Presentation.Windows.WinUI.Utils;
 
 namespace CaptureTool.Presentation.Windows.WinUI.Xaml.Windows;
 
-internal sealed partial class MainWindowHost : INavigationHandler, IDisposable
+internal sealed partial class MainWindowHost : IDisposable
 {
     private MainWindow? _mainWindow;
 
@@ -73,8 +73,11 @@ internal sealed partial class MainWindowHost : INavigationHandler, IDisposable
         _mainWindow = null;
     }
 
-    public void HandleNavigationRequest(INavigationRequest request)
+    public Task<NavigationResult> HandleNavigationRequestAsync(
+        INavigationRequest request,
+        CancellationToken cancellationToken = default)
     {
-        _mainWindow?.HandleNavigationRequest(request);
+        Initialize();
+        return _mainWindow!.HandleNavigationRequestAsync(request, cancellationToken);
     }
 }

--- a/src/CaptureTool.Presentation/Shell/MainWindowViewModel.cs
+++ b/src/CaptureTool.Presentation/Shell/MainWindowViewModel.cs
@@ -11,8 +11,6 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private readonly IThemeService _themeService;
     private readonly IAppNotificationService _notificationService;
 
-    public event EventHandler<INavigationRequest>? NavigationRequested;
-
     public IRelayCommand DismissNotificationCommand { get; }
 
     public AppTheme CurrentAppTheme
@@ -72,16 +70,15 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         }
     }
 
-    public bool HandleNavigationRequest(INavigationRequest request)
+    public bool IsCurrentNavigationRequest(INavigationRequest request)
     {
-        if (_currentRequest?.Route == request.Route && _currentRequest?.Parameter == request.Parameter)
-        {
-            return false;
-        }
+        return _currentRequest?.Route == request.Route &&
+            _currentRequest?.Parameter == request.Parameter;
+    }
 
+    public void CommitNavigationRequest(INavigationRequest request)
+    {
         _currentRequest = request;
-        NavigationRequested?.Invoke(this, request);
-        return true;
     }
 
     public override void Dispose()
@@ -96,7 +93,6 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             _themeService.CurrentThemeChanged -= OnCurrentThemeChanged;
             _notificationService.PropertyChanged -= OnNotificationServicePropertyChanged;
             _currentRequest = null;
-            NavigationRequested = null;
         }
         finally
         {

--- a/tests/CaptureTool.Application.Tests/Activation/ActivationHandlerTests.cs
+++ b/tests/CaptureTool.Application.Tests/Activation/ActivationHandlerTests.cs
@@ -83,7 +83,11 @@ public sealed class ActivationHandlerTests
             useCase => useCase.ExecuteAsync(It.IsAny<ShowHomePageRequest>(), It.IsAny<CancellationToken>()),
             Times.Never);
         fixture.NavigationService.Verify(
-            service => service.Navigate(target.Route, target.Parameter, target.ClearHistory),
+            service => service.NavigateAsync(
+                target.Route,
+                target.Parameter,
+                target.ClearHistory,
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -203,13 +207,18 @@ public sealed class ActivationHandlerTests
             new Uri("ms-screenclip://capture?source=PrintScreen"));
 
         navigation.Verify(
-            service => service.Navigate(
+            service => service.NavigateAsync(
                 NavigationRoute.SelectionOverlay,
                 It.Is<CaptureOptions>(options => options.CaptureMode == CaptureMode.Image),
-                false),
+                false,
+                It.IsAny<CancellationToken>()),
             shouldNavigate ? Times.Once : Times.Never);
         navigation.Verify(
-            service => service.Navigate(NavigationRoute.Home, null, true),
+            service => service.NavigateAsync(
+                NavigationRoute.Home,
+                null,
+                true,
+                It.IsAny<CancellationToken>()),
             shouldNavigate ? Times.Once : Times.Never);
         session.Verify(
             value => value.SaveToSourceAsync(It.IsAny<CancellationToken>()),
@@ -236,13 +245,18 @@ public sealed class ActivationHandlerTests
             new Uri("ms-screenclip://capture?source=ScreenRecorderHotKey"));
 
         navigation.Verify(
-            service => service.Navigate(
+            service => service.NavigateAsync(
                 NavigationRoute.SelectionOverlay,
                 It.Is<CaptureOptions>(options => options.CaptureMode == CaptureMode.Video),
-                false),
+                false,
+                It.IsAny<CancellationToken>()),
             shouldNavigate ? Times.Once : Times.Never);
         navigation.Verify(
-            service => service.Navigate(NavigationRoute.Home, null, true),
+            service => service.NavigateAsync(
+                NavigationRoute.Home,
+                null,
+                true,
+                It.IsAny<CancellationToken>()),
             shouldNavigate ? Times.Once : Times.Never);
         session.Verify(
             value => value.SaveAsync(It.IsAny<CancellationToken>()),
@@ -261,7 +275,11 @@ public sealed class ActivationHandlerTests
             new Uri("ms-screenclip://capture?source=Other"));
 
         navigation.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -280,7 +298,11 @@ public sealed class ActivationHandlerTests
         await handler.HandleLaunchActivationAsync();
 
         navigation.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -318,6 +340,7 @@ public sealed class ActivationHandlerTests
             .Setup(guard => guard.CanNavigateAwayFromActiveCaptureAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var coordinator = new NavigationCoordinator(navigation.Object, editGuard, audioGuard.Object);
         var openSelection = new OpenSelectionOverlayUseCase(coordinator, activeSession, TestUseCaseExecutor.Instance);
         var showHome = new ShowHomePageUseCase(coordinator, TestUseCaseExecutor.Instance);
@@ -342,6 +365,7 @@ public sealed class ActivationHandlerTests
     {
         public ActivationHandlerFixture()
         {
+            TestNavigationService.AcceptAll(NavigationService);
             OpenSelectionOverlay
                 .Setup(useCase => useCase.ExecuteAsync(It.IsAny<OpenSelectionOverlayRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(UseCaseResponse<OpenSelectionOverlayResponse>.Success(new OpenSelectionOverlayResponse()));

--- a/tests/CaptureTool.Application.Tests/Capture/Overlay/CaptureOverlayNavigationUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/Overlay/CaptureOverlayNavigationUseCaseTests.cs
@@ -39,6 +39,7 @@ public sealed class CaptureOverlayNavigationUseCaseTests
     public async Task OpenOverlayUseCases_NavigateToExpectedOverlayRoutes()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var captureOptions = CaptureOptions.VideoDefault;
         NewCaptureArgs captureArgs = CreateCaptureArgs();
         var audioCaptureNavigationGuard = new AllowAudioCaptureNavigationGuard();
@@ -61,9 +62,9 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         await openSelection.ExecuteAsync(new OpenSelectionOverlayRequest(captureOptions), TestContext.CancellationToken);
         await openCapture.ExecuteAsync(new OpenCaptureOverlayRequest(captureArgs), TestContext.CancellationToken);
 
-        navigation.Verify(service => service.Navigate(NavigationRoute.SelectionOverlay, captureOptions, false), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Home, null, true), Times.Never);
-        navigation.Verify(service => service.Navigate(NavigationRoute.CaptureOverlay, captureArgs, false), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.SelectionOverlay, captureOptions, false, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.Home, null, true, It.IsAny<CancellationToken>()), Times.Never);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.CaptureOverlay, captureArgs, false, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [TestMethod]
@@ -86,11 +87,16 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         INavigationRequest currentRequest = CreateNavigationRequest(NavigationRoute.ImageEdit);
         var navigationOrder = new List<(object Route, bool ClearHistory)>();
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.SetupGet(service => service.CurrentRequest).Returns(() => currentRequest);
         navigation.SetupGet(service => service.CanGoBack).Returns(true);
         navigation
-            .Setup(service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()))
-            .Callback<object, object?, bool>((route, _, clearHistory) =>
+            .Setup(service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<object, object?, bool, CancellationToken>((route, _, clearHistory, _) =>
             {
                 navigationOrder.Add((route, clearHistory));
                 currentRequest = CreateNavigationRequest((NavigationRoute)route);
@@ -98,15 +104,18 @@ public sealed class CaptureOverlayNavigationUseCaseTests
                 {
                     activeSession.ClearCurrentSession(session.Object);
                 }
-            });
+            })
+            .ReturnsAsync(NavigationResult.Accepted);
         navigation
-            .Setup(service => service.TryGoBackTo(It.IsAny<Func<INavigationRequest, bool>>()))
-            .Returns<Func<INavigationRequest, bool>>(assessRequest =>
+            .Setup(service => service.TryGoBackToAsync(
+                It.IsAny<Func<INavigationRequest, bool>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Func<INavigationRequest, bool>, CancellationToken>((assessRequest, _) =>
             {
                 INavigationRequest homeRequest = CreateNavigationRequest(NavigationRoute.Home);
                 Assert.IsTrue(assessRequest(homeRequest));
                 currentRequest = homeRequest;
-                return true;
+                return Task.FromResult(NavigationResult.Accepted);
             });
 
         var coordinator = new NavigationCoordinator(
@@ -139,7 +148,9 @@ public sealed class CaptureOverlayNavigationUseCaseTests
             service => service.ConfirmLeaveAsync(session.Object, It.IsAny<CancellationToken>()),
             Times.Once);
         navigation.Verify(
-            service => service.TryGoBackTo(It.IsAny<Func<INavigationRequest, bool>>()),
+            service => service.TryGoBackToAsync(
+                It.IsAny<Func<INavigationRequest, bool>>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -149,6 +160,7 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         var pendingVideo = new PendingVideoFile("capture.mp4");
         var videoCapture = new FakeVideoCaptureWorkflow { PendingVideo = pendingVideo };
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
         var useCase = new StopVideoCaptureUseCase(navigation.Object, videoCapture, TestUseCaseExecutor.Instance);
 
@@ -157,7 +169,37 @@ public sealed class CaptureOverlayNavigationUseCaseTests
 
         Assert.IsTrue(response.Succeeded);
         Assert.AreEqual(1, videoCapture.StopCallCount);
-        navigation.Verify(service => service.Navigate(NavigationRoute.VideoEdit, pendingVideo, false), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(
+                NavigationRoute.VideoEdit,
+                pendingVideo,
+                false,
+                TestContext.CancellationToken),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task StopVideoCaptureUseCase_WhenHostRejects_ReportsFailure()
+    {
+        var pendingVideo = new PendingVideoFile("capture.mp4");
+        var videoCapture = new FakeVideoCaptureWorkflow { PendingVideo = pendingVideo };
+        var navigation = new Mock<INavigationService>();
+        navigation.SetupGet(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
+        navigation
+            .Setup(service => service.NavigateAsync(
+                NavigationRoute.VideoEdit,
+                pendingVideo,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Rejected);
+        var useCase = new StopVideoCaptureUseCase(navigation.Object, videoCapture, TestUseCaseExecutor.Instance);
+
+        StopVideoCaptureResponse response = (await useCase.ExecuteAsync(
+            new StopVideoCaptureRequest(),
+            TestContext.CancellationToken)).Value!;
+
+        Assert.IsFalse(response.Succeeded);
+        Assert.AreEqual(1, videoCapture.StopCallCount);
     }
 
     [TestMethod]
@@ -278,9 +320,12 @@ public sealed class CaptureOverlayNavigationUseCaseTests
     {
         var videoCapture = new FakeVideoCaptureWorkflow { IsRecording = true };
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
         navigation.Setup(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
-        navigation.Setup(service => service.TryGoBack()).Returns(false);
+        navigation
+            .Setup(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.NoChange);
         ICancelVideoCaptureUseCase cancelUseCase = CreateCancelVideoCaptureUseCase(videoCapture, shouldWarnBeforeDiscard: false);
         var useCase = new GoBackFromCaptureOverlayUseCase(
             videoCapture,
@@ -293,7 +338,13 @@ public sealed class CaptureOverlayNavigationUseCaseTests
 
         Assert.IsTrue(response.VideoCaptureCanceled);
         Assert.AreEqual(1, videoCapture.CancelCallCount);
-        navigation.Verify(service => service.Navigate(NavigationRoute.SelectionOverlay, CaptureOptions.VideoDefault, true), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(
+                NavigationRoute.SelectionOverlay,
+                CaptureOptions.VideoDefault,
+                true,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [TestMethod]
@@ -305,7 +356,10 @@ public sealed class CaptureOverlayNavigationUseCaseTests
             .Setup(useCase => useCase.ExecuteAsync(It.IsAny<CancelVideoCaptureRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(UseCaseResponse<CancelVideoCaptureResponse>.Failure());
         var navigation = new Mock<INavigationService>();
-        navigation.Setup(service => service.TryGoBack()).Returns(true);
+        TestNavigationService.AcceptAll(navigation);
+        navigation
+            .Setup(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Accepted);
         var useCase = new GoBackFromCaptureOverlayUseCase(
             videoCapture,
             cancelUseCase.Object,
@@ -315,8 +369,14 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         GoBackFromCaptureOverlayResponse response = (await useCase.ExecuteAsync(new GoBackFromCaptureOverlayRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsFalse(response.VideoCaptureCanceled);
-        navigation.Verify(service => service.TryGoBack(), Times.Never);
-        navigation.Verify(service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()), Times.Never);
+        navigation.Verify(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()), Times.Never);
+        navigation.Verify(
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [TestMethod]
@@ -332,9 +392,12 @@ public sealed class CaptureOverlayNavigationUseCaseTests
             shouldWarnBeforeDiscard: true,
             confirmationService: confirmationService.Object);
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
         navigation.Setup(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
-        navigation.Setup(service => service.TryGoBack()).Returns(true);
+        navigation
+            .Setup(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Accepted);
         var useCase = new GoBackFromCaptureOverlayUseCase(
             videoCapture,
             cancelUseCase,
@@ -349,8 +412,14 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         confirmationService.Verify(
             service => service.ConfirmDiscardActiveCaptureAsync(TestContext.CancellationToken),
             Times.Once);
-        navigation.Verify(service => service.TryGoBack(), Times.Never);
-        navigation.Verify(service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()), Times.Never);
+        navigation.Verify(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()), Times.Never);
+        navigation.Verify(
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [TestMethod]
@@ -361,6 +430,7 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         var showMainWindow = new Mock<IShowMainWindowUseCase>();
         var shutdownHandler = new Mock<IShutdownHandler>();
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
         navigation.Setup(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
         showMainWindow
@@ -402,6 +472,7 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         var showMainWindow = new Mock<IShowMainWindowUseCase>();
         var shutdownHandler = new Mock<IShutdownHandler>();
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
         navigation.Setup(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
         var useCase = new CloseCaptureOverlayUseCase(
@@ -438,6 +509,7 @@ public sealed class CaptureOverlayNavigationUseCaseTests
             .ReturnsAsync(UseCaseResponse<ShowMainWindowResponse>.Success(new ShowMainWindowResponse(false)));
         var shutdownHandler = new Mock<IShutdownHandler>();
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
         navigation.Setup(service => service.CurrentRequest).Returns(CreateNavigationRequest(NavigationRoute.CaptureOverlay));
         var useCase = new CloseCaptureOverlayUseCase(
@@ -487,8 +559,13 @@ public sealed class CaptureOverlayNavigationUseCaseTests
     public async Task ShowMainWindowUseCase_WhenBackToMainWindowFails_NavigatesHomeAndClearsHistory()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
-        navigation.Setup(service => service.TryGoBackTo(It.IsAny<Func<INavigationRequest, bool>>())).Returns(false);
+        navigation
+            .Setup(service => service.TryGoBackToAsync(
+                It.IsAny<Func<INavigationRequest, bool>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.NoChange);
         var useCase = new ShowMainWindowUseCase(
             TestNavigationCoordinator.Create(navigation.Object),
             TestUseCaseExecutor.Instance);
@@ -497,15 +574,22 @@ public sealed class CaptureOverlayNavigationUseCaseTests
         ShowMainWindowResponse response = (await useCase.ExecuteAsync(new ShowMainWindowRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsTrue(response.Succeeded);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Home, null, true), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.Home, null, true, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [TestMethod]
     public async Task ShowMainWindowUseCase_WhenCreationIsDisabledAndNoMainWindowExists_DoesNotNavigate()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.Setup(service => service.CanGoBack).Returns(true);
-        navigation.Setup(service => service.TryGoBackTo(It.IsAny<Func<INavigationRequest, bool>>())).Returns(false);
+        navigation
+            .Setup(service => service.TryGoBackToAsync(
+                It.IsAny<Func<INavigationRequest, bool>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.NoChange);
         var useCase = new ShowMainWindowUseCase(
             TestNavigationCoordinator.Create(navigation.Object),
             TestUseCaseExecutor.Instance);
@@ -516,7 +600,11 @@ public sealed class CaptureOverlayNavigationUseCaseTests
 
         Assert.IsFalse(response.Succeeded);
         navigation.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/tests/CaptureTool.Application.Tests/Capture/Video/StartVideoCaptureUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/Video/StartVideoCaptureUseCaseTests.cs
@@ -16,6 +16,7 @@ public class StartVideoCaptureUseCaseTests
     public async Task ExecuteAsync_ShouldStartRecording_WithoutNavigating()
     {
         var navigationService = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigationService);
         var videoCaptureWorkflow = new FakeVideoCaptureWorkflow();
         var useCase = new StartVideoCaptureUseCase(navigationService.Object, videoCaptureWorkflow, TestUseCaseExecutor.Instance);
         var args = new NewCaptureArgs(
@@ -32,7 +33,11 @@ public class StartVideoCaptureUseCaseTests
 
         Assert.AreEqual(args, videoCaptureWorkflow.StartedCaptureArgs);
         navigationService.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -40,6 +45,7 @@ public class StartVideoCaptureUseCaseTests
     public async Task ExecuteAsync_WhenWorkflowReportsUnsupported_ReturnsStructuredResult()
     {
         var navigationService = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigationService);
         var videoCaptureWorkflow = new FakeVideoCaptureWorkflow
         {
             StartException = new VideoCaptureNotSupportedException(

--- a/tests/CaptureTool.Application.Tests/Edit/MediaEditUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Edit/MediaEditUseCaseTests.cs
@@ -76,6 +76,7 @@ public sealed class MediaEditUseCaseTests
         var audioFile = new AudioFile(audioPath);
         var videoFile = new VideoFile(@"C:\capture.mp4");
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var audioCaptureNavigationGuard = new AllowAudioCaptureNavigationGuard();
         INavigationCoordinator coordinator = TestNavigationCoordinator.Create(
             navigation.Object,
@@ -93,8 +94,8 @@ public sealed class MediaEditUseCaseTests
         await audioUseCase.ExecuteAsync(new OpenAudioEditPageRequest(audioFile), TestContext.CancellationToken);
         await videoUseCase.ExecuteAsync(new OpenVideoEditPageRequest(videoFile), TestContext.CancellationToken);
 
-        navigation.Verify(service => service.Navigate(NavigationRoute.AudioEdit, audioFile, false), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.VideoEdit, videoFile, false), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.AudioEdit, audioFile, false, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.VideoEdit, videoFile, false, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [TestMethod]

--- a/tests/CaptureTool.Application.Tests/Navigation/NavigationCoordinatorTests.cs
+++ b/tests/CaptureTool.Application.Tests/Navigation/NavigationCoordinatorTests.cs
@@ -13,6 +13,7 @@ public sealed class NavigationCoordinatorTests
     public async Task NavigateAsync_WhenGuardsAccept_DispatchesNavigation()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var editGuard = CreateGuard<IEditSessionGuard>(
             guard => guard.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()));
         var audioGuard = CreateGuard<IAudioCaptureNavigationGuard>(
@@ -25,7 +26,9 @@ public sealed class NavigationCoordinatorTests
             cancellationToken: TestContext.CancellationToken);
 
         Assert.IsTrue(navigated);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Home, null, true), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.Home, null, true, TestContext.CancellationToken),
+            Times.Once);
         editGuard.Verify(
             guard => guard.CanLeaveCurrentSessionAsync(TestContext.CancellationToken),
             Times.Once);
@@ -38,6 +41,7 @@ public sealed class NavigationCoordinatorTests
     public async Task NavigateAsync_WhenEditGuardRejects_DoesNotEvaluateAudioOrNavigate()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var editGuard = new Mock<IEditSessionGuard>();
         editGuard
             .Setup(guard => guard.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()))
@@ -54,7 +58,11 @@ public sealed class NavigationCoordinatorTests
             guard => guard.CanNavigateAwayFromActiveCaptureAsync(It.IsAny<CancellationToken>()),
             Times.Never);
         navigation.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -62,6 +70,7 @@ public sealed class NavigationCoordinatorTests
     public async Task NavigateAsync_WhenAudioGuardRejects_DoesNotNavigate()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var editGuard = CreateGuard<IEditSessionGuard>(
             guard => guard.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()));
         var audioGuard = new Mock<IAudioCaptureNavigationGuard>();
@@ -76,8 +85,43 @@ public sealed class NavigationCoordinatorTests
 
         Assert.IsFalse(navigated);
         navigation.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [TestMethod]
+    public async Task NavigateAsync_WhenHostRejects_ReturnsFalse()
+    {
+        var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
+        navigation
+            .Setup(service => service.NavigateAsync(
+                NavigationRoute.Store,
+                null,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Rejected);
+        var editGuard = CreateGuard<IEditSessionGuard>(
+            guard => guard.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()));
+        var audioGuard = CreateGuard<IAudioCaptureNavigationGuard>(
+            guard => guard.CanNavigateAwayFromActiveCaptureAsync(It.IsAny<CancellationToken>()));
+        var coordinator = new NavigationCoordinator(navigation.Object, editGuard.Object, audioGuard.Object);
+
+        bool navigated = await coordinator.NavigateAsync(
+            NavigationRoute.Store,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsFalse(navigated);
+        editGuard.Verify(
+            guard => guard.CanLeaveCurrentSessionAsync(TestContext.CancellationToken),
+            Times.Once);
+        audioGuard.Verify(
+            guard => guard.CanNavigateAwayFromActiveCaptureAsync(TestContext.CancellationToken),
+            Times.Once);
     }
 
     [TestMethod]
@@ -87,6 +131,7 @@ public sealed class NavigationCoordinatorTests
         currentRequest.SetupGet(request => request.Route).Returns(NavigationRoute.ImageEdit);
         currentRequest.SetupGet(request => request.Parameter).Returns("capture.png");
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         navigation.SetupGet(service => service.CurrentRequest).Returns(currentRequest.Object);
         var editGuard = new Mock<IEditSessionGuard>();
         var audioGuard = new Mock<IAudioCaptureNavigationGuard>();
@@ -102,7 +147,11 @@ public sealed class NavigationCoordinatorTests
             guard => guard.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()),
             Times.Never);
         navigation.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -110,6 +159,7 @@ public sealed class NavigationCoordinatorTests
     public async Task ExecuteTransitionAsync_NestedNavigation_EvaluatesLeavePolicyOnce()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var editGuard = CreateGuard<IEditSessionGuard>(
             guard => guard.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()));
         var audioGuard = CreateGuard<IAudioCaptureNavigationGuard>(
@@ -127,7 +177,9 @@ public sealed class NavigationCoordinatorTests
         audioGuard.Verify(
             guard => guard.CanNavigateAwayFromActiveCaptureAsync(TestContext.CancellationToken),
             Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.VideoEdit, null, false), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.VideoEdit, null, false, TestContext.CancellationToken),
+            Times.Once);
     }
 
     [TestMethod]
@@ -152,6 +204,7 @@ public sealed class NavigationCoordinatorTests
         var audioGuard = CreateGuard<IAudioCaptureNavigationGuard>(
             guard => guard.CanNavigateAwayFromActiveCaptureAsync(It.IsAny<CancellationToken>()));
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var coordinator = new NavigationCoordinator(navigation.Object, editGuard.Object, audioGuard.Object);
 
         Task<bool> first = coordinator.NavigateAsync(NavigationRoute.Home);
@@ -178,13 +231,16 @@ public sealed class NavigationCoordinatorTests
         var audioGuard = CreateGuard<IAudioCaptureNavigationGuard>(
             guard => guard.CanNavigateAwayFromActiveCaptureAsync(It.IsAny<CancellationToken>()));
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var coordinator = new NavigationCoordinator(navigation.Object, editGuard.Object, audioGuard.Object);
 
         await Assert.ThrowsExactlyAsync<InvalidOperationException>(
             () => coordinator.NavigateAsync(NavigationRoute.Home));
 
         Assert.IsTrue(await coordinator.NavigateAsync(NavigationRoute.Store));
-        navigation.Verify(service => service.Navigate(NavigationRoute.Store, null, false), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.Store, null, false, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [TestMethod]
@@ -200,13 +256,16 @@ public sealed class NavigationCoordinatorTests
         var audioGuard = CreateGuard<IAudioCaptureNavigationGuard>(
             guard => guard.CanNavigateAwayFromActiveCaptureAsync(It.IsAny<CancellationToken>()));
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var coordinator = new NavigationCoordinator(navigation.Object, editGuard.Object, audioGuard.Object);
 
         await Assert.ThrowsExactlyAsync<TaskCanceledException>(
             () => coordinator.NavigateAsync(NavigationRoute.Home));
 
         Assert.IsTrue(await coordinator.NavigateAsync(NavigationRoute.Store));
-        navigation.Verify(service => service.Navigate(NavigationRoute.Store, null, false), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.Store, null, false, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     private static Mock<TGuard> CreateGuard<TGuard>(System.Linq.Expressions.Expression<Func<TGuard, Task<bool>>> expression)

--- a/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
@@ -140,14 +140,19 @@ public sealed class SettingsPageUseCaseTests
     public async Task LeaveSettingsPageUseCase_WhenCannotGoBack_NavigatesHomeAndClearsHistory()
     {
         var navigation = new Mock<INavigationService>();
-        navigation.Setup(service => service.TryGoBack()).Returns(false);
+        TestNavigationService.AcceptAll(navigation);
+        navigation
+            .Setup(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.NoChange);
         INavigationCoordinator coordinator = TestNavigationCoordinator.Create(navigation.Object);
         var useCase = new LeaveSettingsPageUseCase(coordinator, TestUseCaseExecutor.Instance);
 
         LeaveSettingsPageResponse response = (await useCase.ExecuteAsync(new LeaveSettingsPageRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsTrue(response.Succeeded);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Home, null, true), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.Home, null, true, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [TestMethod]

--- a/tests/CaptureTool.Application.Tests/Shell/OpenFileUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Shell/OpenFileUseCaseTests.cs
@@ -42,7 +42,11 @@ public class OpenFileUseCaseTests
             service => service.PickFileAsync(It.IsAny<FilePickerType>(), It.IsAny<UserFolder>()),
             Times.Never);
         navigationService.Verify(
-            service => service.Navigate(It.IsAny<object>(), It.IsAny<object?>(), It.IsAny<bool>()),
+            service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -51,6 +55,7 @@ public class OpenFileUseCaseTests
     {
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
+        TestNavigationService.AcceptAll(navigationService);
         Mock<IStorageService> storageService = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
@@ -82,11 +87,13 @@ public class OpenFileUseCaseTests
 
         Assert.IsTrue(File.Exists(copiedPath));
         navigationService.Verify(
-            service => service.Navigate(
+            service => service.NavigateAsync(
                 NavigationRoute.ImageEdit,
                 It.Is<ImageFile>(file =>
                     file.FilePath == copiedPath &&
-                    file.PersistentFilePath == sourcePath)),
+                    file.PersistentFilePath == sourcePath),
+                false,
+                It.IsAny<CancellationToken>()),
             Times.Once);
         storageService.Verify(service => service.GetTemporaryFileName(), Times.Once);
         recentCaptureCatalog.Verify(
@@ -99,6 +106,7 @@ public class OpenFileUseCaseTests
     {
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
+        TestNavigationService.AcceptAll(navigationService);
         Mock<IStorageService> storageService = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
@@ -130,9 +138,11 @@ public class OpenFileUseCaseTests
 
         Assert.IsTrue(File.Exists(copiedPath));
         navigationService.Verify(
-            service => service.Navigate(
+            service => service.NavigateAsync(
                 NavigationRoute.AudioEdit,
-                It.Is<AudioFile>(file => file.FilePath == copiedPath)),
+                It.Is<AudioFile>(file => file.FilePath == copiedPath),
+                false,
+                It.IsAny<CancellationToken>()),
             Times.Once);
         storageService.Verify(service => service.GetTemporaryFileName(), Times.Once);
         recentCaptureCatalog.Verify(
@@ -145,6 +155,7 @@ public class OpenFileUseCaseTests
     {
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
+        TestNavigationService.AcceptAll(navigationService);
         Mock<IStorageService> storageService = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
@@ -176,9 +187,11 @@ public class OpenFileUseCaseTests
 
         Assert.IsTrue(File.Exists(copiedPath));
         navigationService.Verify(
-            service => service.Navigate(
+            service => service.NavigateAsync(
                 NavigationRoute.VideoEdit,
-                It.Is<VideoFile>(file => file.FilePath == copiedPath)),
+                It.Is<VideoFile>(file => file.FilePath == copiedPath),
+                false,
+                It.IsAny<CancellationToken>()),
             Times.Once);
         storageService.Verify(service => service.GetTemporaryFileName(), Times.Once);
         recentCaptureCatalog.Verify(
@@ -191,6 +204,7 @@ public class OpenFileUseCaseTests
     {
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
+        TestNavigationService.AcceptAll(navigationService);
         Mock<IStorageService> storageService = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
@@ -217,11 +231,13 @@ public class OpenFileUseCaseTests
 
         Assert.AreEqual(oldLastWriteTimeUtc, File.GetLastWriteTimeUtc(sourcePath));
         navigationService.Verify(
-            service => service.Navigate(
+            service => service.NavigateAsync(
                 NavigationRoute.ImageEdit,
                 It.Is<ImageFile>(file =>
                     file.FilePath == sourcePath &&
-                    file.PersistentFilePath == null)),
+                    file.PersistentFilePath == null),
+                false,
+                It.IsAny<CancellationToken>()),
             Times.Once);
         storageService.Verify(service => service.GetTemporaryFileName(), Times.Never);
         recentCaptureCatalog.Verify(

--- a/tests/CaptureTool.Application.Tests/Shell/SimpleApplicationUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Shell/SimpleApplicationUseCaseTests.cs
@@ -59,6 +59,7 @@ public sealed class SimpleApplicationUseCaseTests
     public async Task NavigationUseCases_NavigateToExpectedRoutes()
     {
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var editGuard = new Mock<IEditSessionGuard>();
         editGuard
             .Setup(service => service.CanLeaveCurrentSessionAsync(It.IsAny<CancellationToken>()))
@@ -83,19 +84,22 @@ public sealed class SimpleApplicationUseCaseTests
         await new OpenImageEditPageUseCase(coordinator, TestUseCaseExecutor.Instance)
             .ExecuteAsync(new OpenImageEditPageRequest(imageFile), TestContext.CancellationToken);
 
-        navigation.Verify(service => service.Navigate(NavigationRoute.About, null, false), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Home, null, true), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Store, null, false), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.Settings, null, false), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.AudioCapture, null, false), Times.Once);
-        navigation.Verify(service => service.Navigate(NavigationRoute.ImageEdit, imageFile, false), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.About, null, false, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.Home, null, true, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.Store, null, false, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.Settings, null, false, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.AudioCapture, null, false, It.IsAny<CancellationToken>()), Times.Once);
+        navigation.Verify(service => service.NavigateAsync(NavigationRoute.ImageEdit, imageFile, false, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [TestMethod]
     public async Task LeavePageUseCases_WhenBackFails_NavigateHomeAndClearHistory()
     {
         var navigation = new Mock<INavigationService>();
-        navigation.Setup(service => service.TryGoBack()).Returns(false);
+        TestNavigationService.AcceptAll(navigation);
+        navigation
+            .Setup(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.NoChange);
         INavigationCoordinator coordinator = TestNavigationCoordinator.Create(navigation.Object);
 
         await new LeaveAboutPageUseCase(coordinator, TestUseCaseExecutor.Instance)
@@ -103,7 +107,9 @@ public sealed class SimpleApplicationUseCaseTests
         await new LeaveStorePageUseCase(coordinator, TestUseCaseExecutor.Instance)
             .ExecuteAsync(new LeaveStorePageRequest(), TestContext.CancellationToken);
 
-        navigation.Verify(service => service.Navigate(NavigationRoute.Home, null, true), Times.Exactly(2));
+        navigation.Verify(
+            service => service.NavigateAsync(NavigationRoute.Home, null, true, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
     }
 
     [TestMethod]
@@ -159,6 +165,7 @@ public sealed class SimpleApplicationUseCaseTests
     {
         var audioCapture = new FakeAudioCaptureWorkflow();
         var navigation = new Mock<INavigationService>();
+        TestNavigationService.AcceptAll(navigation);
         var audioFile = new AudioFile("capture.wav");
         audioCapture.AudioFile = audioFile;
 
@@ -175,7 +182,41 @@ public sealed class SimpleApplicationUseCaseTests
         Assert.AreEqual(1, audioCapture.PauseCallCount);
         Assert.AreEqual(1, audioCapture.StopCallCount);
         Assert.AreEqual(1, audioCapture.ToggleLocalAudioCallCount);
-        navigation.Verify(service => service.Navigate(NavigationRoute.AudioEdit, audioFile, false), Times.Once);
+        navigation.Verify(
+            service => service.NavigateAsync(
+                NavigationRoute.AudioEdit,
+                audioFile,
+                false,
+                TestContext.CancellationToken),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task StopAudioCaptureUseCase_WhenHostRejects_ReportsFailure()
+    {
+        var audioCapture = new FakeAudioCaptureWorkflow
+        {
+            AudioFile = new AudioFile("capture.wav")
+        };
+        var navigation = new Mock<INavigationService>();
+        navigation
+            .Setup(service => service.NavigateAsync(
+                NavigationRoute.AudioEdit,
+                audioCapture.AudioFile,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Rejected);
+        var useCase = new StopAudioCaptureUseCase(
+            audioCapture,
+            navigation.Object,
+            TestUseCaseExecutor.Instance);
+
+        StopAudioCaptureResponse response = (await useCase.ExecuteAsync(
+            new StopAudioCaptureRequest(),
+            TestContext.CancellationToken)).Value!;
+
+        Assert.IsFalse(response.Succeeded);
+        Assert.AreEqual(1, audioCapture.StopCallCount);
     }
 
     [TestMethod]

--- a/tests/CaptureTool.Application.Tests/TestNavigationService.cs
+++ b/tests/CaptureTool.Application.Tests/TestNavigationService.cs
@@ -1,0 +1,26 @@
+using CaptureTool.Application.Abstractions.Navigation;
+using Moq;
+
+namespace CaptureTool.Application.Tests;
+
+internal static class TestNavigationService
+{
+    public static void AcceptAll(Mock<INavigationService> navigation)
+    {
+        navigation
+            .Setup(service => service.NavigateAsync(
+                It.IsAny<object>(),
+                It.IsAny<object?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Accepted);
+        navigation
+            .Setup(service => service.TryGoBackAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Accepted);
+        navigation
+            .Setup(service => service.TryGoBackToAsync(
+                It.IsAny<Func<INavigationRequest, bool>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NavigationResult.Accepted);
+    }
+}

--- a/tests/CaptureTool.Infrastructure.Tests/Navigation/MockNavigationHandler.cs
+++ b/tests/CaptureTool.Infrastructure.Tests/Navigation/MockNavigationHandler.cs
@@ -4,10 +4,17 @@ namespace CaptureTool.Infrastructure.Tests.Navigation;
 
 public class MockNavigationHandler : INavigationHandler
 {
-    public List<INavigationRequest> HandledRequests { get; } = new();
+    public List<INavigationRequest> HandledRequests { get; } = [];
 
-    public void HandleNavigationRequest(INavigationRequest request)
+    public NavigationResult Result { get; set; } = NavigationResult.Accepted;
+
+    public Func<INavigationRequest, CancellationToken, Task<NavigationResult>>? HandleAsync { get; set; }
+
+    public Task<NavigationResult> HandleNavigationRequestAsync(
+        INavigationRequest request,
+        CancellationToken cancellationToken = default)
     {
         HandledRequests.Add(request);
+        return HandleAsync?.Invoke(request, cancellationToken) ?? Task.FromResult(Result);
     }
 }

--- a/tests/CaptureTool.Infrastructure.Tests/Navigation/NavigationServiceTests.cs
+++ b/tests/CaptureTool.Infrastructure.Tests/Navigation/NavigationServiceTests.cs
@@ -15,174 +15,251 @@ public class NavigationServiceTests
     }
 
     [TestMethod]
-    public void Navigate_PushesNewRequest()
+    public async Task NavigateAsync_AfterHostAcceptance_CommitsRequest()
     {
         var service = new NavigationService();
         var handler = new MockNavigationHandler();
         service.SetNavigationHandler(handler);
 
-        service.Navigate(TestRoute.Home);
+        NavigationResult result = await service.NavigateAsync(TestRoute.Home);
 
-        Assert.IsNotNull(service.CurrentRequest);
+        Assert.AreEqual(NavigationResult.Accepted, result);
         Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
         Assert.HasCount(1, handler.HandledRequests);
     }
 
     [TestMethod]
-    public void Navigate_DoesNotNavigate_WhenRequestIsSame()
+    public async Task NavigateAsync_WhileHostAcceptanceIsPending_DoesNotCommitRequest()
     {
+        var acceptance = new TaskCompletionSource<NavigationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new MockNavigationHandler
+        {
+            HandleAsync = (_, _) => acceptance.Task
+        };
         var service = new NavigationService();
-        var handler = new MockNavigationHandler();
         service.SetNavigationHandler(handler);
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Home);
+        Task<NavigationResult> navigation = service.NavigateAsync(TestRoute.Home);
+        await WaitForAsync(() => handler.HandledRequests.Count == 1);
+        Task<NavigationResult> queuedNavigation = service.NavigateAsync(TestRoute.Settings);
+        await Task.Delay(20);
 
+        Assert.IsNull(service.CurrentRequest);
+        Assert.HasCount(1, handler.HandledRequests);
+
+        acceptance.SetResult(NavigationResult.Accepted);
+        Assert.AreEqual(NavigationResult.Accepted, await navigation);
+        Assert.AreEqual(NavigationResult.Accepted, await queuedNavigation);
+        Assert.AreEqual(TestRoute.Settings, service.CurrentRequest?.Route);
+    }
+
+    [TestMethod]
+    public async Task NavigateAsync_WhenHostRejects_RetainsStateAndEmitsNoCompletionSignals()
+    {
+        var telemetry = new RecordingTelemetryService();
+        var handler = new MockNavigationHandler();
+        var service = new NavigationService(telemetry);
+        service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        int navigatedCount = 0;
+        service.Navigated += (_, _) => navigatedCount++;
+        telemetry.Events.Clear();
+        handler.Result = NavigationResult.Rejected;
+
+        NavigationResult result = await service.NavigateAsync(TestRoute.Settings);
+
+        Assert.AreEqual(NavigationResult.Rejected, result);
+        Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
+        Assert.IsFalse(service.CanGoBack);
+        Assert.AreEqual(0, navigatedCount);
+        Assert.IsEmpty(telemetry.Events);
+    }
+
+    [TestMethod]
+    public async Task NavigateAsync_WhenHandlerThrows_RetainsStateAndReleasesGate()
+    {
+        int calls = 0;
+        var handler = new MockNavigationHandler
+        {
+            HandleAsync = (_, _) => Interlocked.Increment(ref calls) == 2
+                ? Task.FromException<NavigationResult>(new InvalidOperationException("host failed"))
+                : Task.FromResult(NavigationResult.Accepted)
+        };
+        var service = new NavigationService();
+        service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => service.NavigateAsync(TestRoute.Settings));
+
+        Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
+        Assert.AreEqual(NavigationResult.Accepted, await service.NavigateAsync(TestRoute.About));
+        Assert.AreEqual(TestRoute.About, service.CurrentRequest?.Route);
+    }
+
+    [TestMethod]
+    public async Task NavigateAsync_WhenHandlerIsCanceled_RetainsStateAndReleasesGate()
+    {
+        int calls = 0;
+        var handler = new MockNavigationHandler
+        {
+            HandleAsync = (_, _) => Interlocked.Increment(ref calls) == 2
+                ? Task.FromCanceled<NavigationResult>(new CancellationToken(canceled: true))
+                : Task.FromResult(NavigationResult.Accepted)
+        };
+        var service = new NavigationService();
+        service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(
+            () => service.NavigateAsync(TestRoute.Settings));
+
+        Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
+        Assert.AreEqual(NavigationResult.Accepted, await service.NavigateAsync(TestRoute.About));
+    }
+
+    [TestMethod]
+    public async Task NavigateAsync_ForExactRequest_ReturnsNoChangeWithoutDispatch()
+    {
+        var handler = new MockNavigationHandler();
+        var service = new NavigationService();
+        service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+
+        NavigationResult result = await service.NavigateAsync(TestRoute.Home);
+
+        Assert.AreEqual(NavigationResult.NoChange, result);
         Assert.HasCount(1, handler.HandledRequests);
     }
 
     [TestMethod]
-    public void Navigate_ClearsHistory_WhenRequested()
+    public async Task NavigateAsync_WithClearHistory_CommitsOnlyAfterAcceptance()
     {
-        var service = new NavigationService();
         var handler = new MockNavigationHandler();
+        var service = new NavigationService();
         service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        await service.NavigateAsync(TestRoute.Settings);
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Settings);
+        NavigationResult result = await service.NavigateAsync(TestRoute.About, clearHistory: true);
 
-        service.Navigate(TestRoute.About, null, clearHistory: true);
-
+        Assert.AreEqual(NavigationResult.Accepted, result);
         Assert.IsFalse(service.CanGoBack);
         Assert.AreEqual(TestRoute.About, service.CurrentRequest?.Route);
     }
 
     [TestMethod]
-    public void TryGoBack_GoesToPreviousRequest()
+    public async Task TryGoBackAsync_WhenAccepted_CommitsPreviousRequest()
     {
-        var service = new NavigationService();
         var handler = new MockNavigationHandler();
+        var service = new NavigationService();
         service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        await service.NavigateAsync(TestRoute.Settings);
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Settings);
+        NavigationResult result = await service.TryGoBackAsync();
 
-        bool result = service.TryGoBack();
-
-        Assert.IsTrue(result);
+        Assert.AreEqual(NavigationResult.Accepted, result);
         Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
         Assert.HasCount(3, handler.HandledRequests);
+        Assert.IsTrue(handler.HandledRequests.Last().IsBackNavigation);
     }
 
     [TestMethod]
-    public void TryGoBack_Throws_WhenNoPrevious()
+    public async Task TryGoBackAsync_WhenRejected_RetainsOriginalStack()
     {
-        var service = new NavigationService();
         var handler = new MockNavigationHandler();
+        var service = new NavigationService();
         service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        await service.NavigateAsync(TestRoute.Settings);
+        handler.Result = NavigationResult.Rejected;
 
-        service.Navigate(TestRoute.Home);
+        NavigationResult result = await service.TryGoBackAsync();
 
-        bool result = service.TryGoBack();
+        Assert.AreEqual(NavigationResult.Rejected, result);
+        Assert.AreEqual(TestRoute.Settings, service.CurrentRequest?.Route);
+        Assert.IsTrue(service.CanGoBack);
+    }
 
-        Assert.IsFalse(result);
+    [TestMethod]
+    public async Task TryGoBackAsync_WithoutHistory_ReturnsNoChange()
+    {
+        var handler = new MockNavigationHandler();
+        var service = new NavigationService();
+        service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+
+        NavigationResult result = await service.TryGoBackAsync();
+
+        Assert.AreEqual(NavigationResult.NoChange, result);
         Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
         Assert.HasCount(1, handler.HandledRequests);
     }
 
     [TestMethod]
-    public void TryGoBack_DoesNothing_WhenBackTargetMatchesCurrent()
+    public async Task TryGoBackToAsync_WhenAccepted_CommitsTargetRequest()
     {
-        var service = new NavigationService();
         var handler = new MockNavigationHandler();
+        var service = new NavigationService();
         service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        await service.NavigateAsync(TestRoute.Settings);
+        await service.NavigateAsync(TestRoute.About);
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Home);
+        NavigationResult result = await service.TryGoBackToAsync(request => Equals(request.Route, TestRoute.Home));
 
-        Assert.HasCount(1, handler.HandledRequests);
+        Assert.AreEqual(NavigationResult.Accepted, result);
+        Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
         Assert.IsFalse(service.CanGoBack);
     }
 
     [TestMethod]
-    public void TryGoBackTo_SkipsWhilePredicateTrue()
+    public async Task TryGoBackToAsync_WhenRejected_RetainsOriginalStack()
     {
-        var service = new NavigationService();
         var handler = new MockNavigationHandler();
+        var service = new NavigationService();
         service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        await service.NavigateAsync(TestRoute.Settings);
+        await service.NavigateAsync(TestRoute.About);
+        handler.Result = NavigationResult.Rejected;
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Settings);
-        service.Navigate(TestRoute.About);
+        NavigationResult result = await service.TryGoBackToAsync(request => Equals(request.Route, TestRoute.Home));
 
-        bool result = service.TryGoBackTo(
-            request => request.Route is TestRoute testRoute && testRoute == TestRoute.Home);
-
-        Assert.IsTrue(result);
-        Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
+        Assert.AreEqual(NavigationResult.Rejected, result);
+        Assert.AreEqual(TestRoute.About, service.CurrentRequest?.Route);
+        Assert.IsTrue(service.CanGoBack);
     }
 
     [TestMethod]
-    public void TryGoBackTo_ReturnsFalse_WhenPredicateDoesntSkip()
+    public async Task TryGoBackToAsync_WithoutTarget_ReturnsNoChange()
     {
-        var service = new NavigationService();
         var handler = new MockNavigationHandler();
+        var service = new NavigationService();
         service.SetNavigationHandler(handler);
+        await service.NavigateAsync(TestRoute.Home);
+        await service.NavigateAsync(TestRoute.Settings);
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Settings);
+        NavigationResult result = await service.TryGoBackToAsync(_ => false);
 
-        bool result = service.TryGoBackTo(request => false);
-
-        Assert.IsFalse(result);
+        Assert.AreEqual(NavigationResult.NoChange, result);
         Assert.AreEqual(TestRoute.Settings, service.CurrentRequest?.Route);
     }
 
     [TestMethod]
-    public void TryGoBackTo_Throws_WhenNoHistory()
-    {
-        var service = new NavigationService();
-        var handler = new MockNavigationHandler();
-        service.SetNavigationHandler(handler);
-
-        service.Navigate(TestRoute.Home);
-
-        bool result = service.TryGoBackTo(_ => true);
-
-        Assert.IsFalse(result);
-        Assert.AreEqual(TestRoute.Home, service.CurrentRequest?.Route);
-    }
-
-    [TestMethod]
-    public void Navigated_Event_IsRaised()
-    {
-        var service = new NavigationService();
-        var handler = new MockNavigationHandler();
-        service.SetNavigationHandler(handler);
-
-        INavigationRequest? receivedRequest = null;
-
-        service.Navigated += (sender, args) =>
-        {
-            receivedRequest = args.Request;
-        };
-
-        service.Navigate(TestRoute.Home);
-
-        Assert.IsNotNull(receivedRequest);
-        Assert.AreEqual(TestRoute.Home, receivedRequest?.Route);
-    }
-
-    [TestMethod]
-    public void Navigate_TracksSafeRouteAndParameterType()
+    public async Task NavigateAsync_AfterAcceptance_RaisesNavigatedAndTracksSafeMetadata()
     {
         var telemetry = new RecordingTelemetryService();
         var service = new NavigationService(telemetry);
         service.SetNavigationHandler(new MockNavigationHandler());
+        await service.NavigateAsync(TestRoute.Home);
+        INavigationRequest? receivedRequest = null;
+        service.Navigated += (_, args) => receivedRequest = args.Request;
 
-        service.Navigate(TestRoute.Home);
-        service.Navigate(TestRoute.Settings, new NavigationParameter("private-value"));
+        await service.NavigateAsync(TestRoute.Settings, new NavigationParameter("private-value"));
 
+        Assert.AreEqual(TestRoute.Settings, receivedRequest?.Route);
         var trackedEvent = telemetry.Events.Last();
         Assert.AreEqual(TelemetryEvents.NavigationCompleted, trackedEvent.Name);
         Assert.AreEqual(nameof(TestRoute.Home), trackedEvent.Properties[TelemetryProperties.FromRoute]);
@@ -192,20 +269,25 @@ public class NavigationServiceTests
     }
 
     [TestMethod]
-    public void Navigate_Throws_WhenNoHandlerSet()
+    public async Task NavigateAsync_WithoutHandler_ThrowsAndRetainsEmptyState()
     {
         var service = new NavigationService();
 
-        Assert.ThrowsExactly<InvalidOperationException>(() => service.Navigate(TestRoute.Home));
-    }
-
-    [TestMethod]
-    public void CurrentRequest_IsNull_WhenNoNavigation()
-    {
-        var service = new NavigationService();
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => service.NavigateAsync(TestRoute.Home));
 
         Assert.IsNull(service.CurrentRequest);
         Assert.IsFalse(service.CanGoBack);
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        for (int i = 0; i < 100 && !condition(); i++)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.IsTrue(condition());
     }
 
     private sealed record NavigationParameter(string Secret);


### PR DESCRIPTION
## Summary

- replace synchronous navigation dispatch with explicit `Accepted`, `Rejected`, and `NoChange` results
- serialize prepare → await host → commit operations for navigate, back, and back-to
- commit history, completion telemetry, and `Navigated` only after host acceptance
- replace the top-level WinUI `async void` handler with awaited host and main-frame dispatch
- preserve the active capture route when video cancellation is declined
- make trusted post-capture, error, and UI-test navigation await the same low-level contract
- include the implementation PRD and transactional regression coverage

## Root cause

`NavigationService` mutated its stack before invoking a `void` handler. The WinUI implementation was `async void` and could later reject a transition when active-video cancellation was declined, leaving `CurrentRequest` and route-based command eligibility out of sync with the visible capture overlay. Telemetry and `Navigated` were also emitted before acceptance, while asynchronous exceptions escaped the initiating boundary.

## User impact

Declining navigation away from an active recording now leaves the capture-overlay route committed and its controls enabled. Pending, rejected, canceled, or failed host transitions do not alter navigation history or emit completion signals. Host exceptions return through the existing awaited use-case or activation error boundary.

Main-window frame navigation is also awaited, and back-to transitions target the actual requested frame entry instead of accepting before the dispatcher runs.

## Validation

- `.github\scripts\run-managed-tests.ps1`: 657 passed
  - Application: 309
  - Capture Windows: 21
  - Edit Windows: 33
  - Infrastructure: 131
  - MCP Capture Server: 17
  - Presentation: 146
- WinUI x64 Debug project build: passed with 0 warnings and 0 errors
- `git diff --check`: passed

Fixes #409