### PR TITLE
Own image resources during export

### DIFF
--- a/docs/prd-411-export-owned-image-render-resources.md
+++ b/docs/prd-411-export-owned-image-render-resources.md
@@ -1,0 +1,74 @@
+# PRD: Export-owned image render resources
+
+- Issue: [#411](https://github.com/shanebweaver/CaptureTool/issues/411)
+- Finding: `ARCH-06`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `IMG-01`, `IMG-09`, `IMG-11`, `IMG-15`
+
+## Summary
+
+Image export must render from the edit session's `ImageFile` inputs without depending on resources prepared by the WinUI `ImageCanvas`. Each export operation will load its image drawables into a short-lived Win2D resource scope created on the same device as the export render target, use those resources for the render, and dispose them when encoding completes.
+
+The interactive canvas can continue to cache preview resources for its own lifetime. The shared renderer will no longer treat a missing image resource as a drawable that can be silently skipped.
+
+## Problem
+
+`Win2DImageCanvasRenderer` currently resolves each `ImageDrawable` through a `ConditionalWeakTable` populated asynchronously by the WinUI canvas `CreateResources` event. `Win2DImageCanvasExporter` calls the renderer without preparing resources of its own. If an output command runs before preview preparation completes, during device-resource recreation, or in a headless path where no canvas exists, the renderer omits the base image and still produces a successful output.
+
+Copy, save, share, external editing, OCR, and image-description paths consume the exporter, so a successful-looking operation can receive an annotation-only or effectively blank raster. The dependency also couples application output to a particular control and GPU-resource lifetime.
+
+## Goals
+
+1. Make export independent of `ImageCanvas` creation and resource timing.
+2. Load every exported `ImageDrawable` from its current `ImageFile` on the export render device.
+3. Keep export resources scoped to one operation and dispose them on success or failure.
+4. Fail explicitly when an image resource cannot be loaded or resolved.
+5. Preserve orientation, crop, annotation, chroma-key, file-format, clipboard, and save behavior.
+
+## Non-goals
+
+- Do not move Win2D objects into domain or application-layer models.
+- Do not replace the interactive canvas preview cache or redesign WinUI resource recreation.
+- Do not add a user-visible render-readiness gate; export-owned loading removes the timing dependency.
+- Do not redesign the broader image rendering pipeline or change output formats.
+
+## Functional requirements
+
+### Export resource scope
+
+- Before drawing, collect the `ImageDrawable` instances in the requested drawable set.
+- Load each distinct drawable's current file into a Win2D bitmap using the export render target's device.
+- Resolve renderer image requests from the operation-owned resource map.
+- Dispose all loaded bitmaps after output encoding, including partially loaded resources when preparation fails.
+- Do not populate, replace, or consume the WinUI preview-resource cache.
+
+### Renderer contract
+
+- Allow a render caller to supply the image-resource resolver used for that operation.
+- Preserve the existing renderer entry point for WinUI preview and print callers.
+- Throw an explicit exception if an `ImageDrawable` has no resource in the active rendering context.
+- Continue applying image effects and offsets using the resolved image.
+
+### Failure behavior
+
+- Missing, unreadable, invalid, or unsupported image files must fault the export task.
+- Existing view-model command boundaries remain responsible for presenting or recovering from export failures.
+- No file or clipboard output may be reported as successful after a required base image was omitted.
+
+## Test plan
+
+- Render a colored source image through `Win2DImageCanvasExporter` without constructing `ImageCanvas` or calling preview preparation.
+- Decode the exported stream and verify that it contains the source raster.
+- Verify the drawable still has no UI-prepared resource after export, proving the exporter used its own scope.
+- Export an `ImageDrawable` whose file does not exist and verify the operation fails explicitly.
+- Run the infrastructure edit test project and all non-UI tests.
+- Build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] Export of an image drawable succeeds without an `ImageCanvas` instance or preview resource.
+- [x] Export loads the drawable's current `ImageFile` on the export device.
+- [x] Missing image content fails the operation instead of producing annotation-only output.
+- [x] Export resources have an operation-bounded lifetime and do not mutate UI preview state.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageCanvasExporter.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageCanvasExporter.cs
@@ -82,10 +82,12 @@ public sealed partial class Win2DImageCanvasExporter : IImageCanvasExporter
         float renderWidth = options.CropRect.Width;
         float renderHeight = options.CropRect.Height;
 
-        using CanvasRenderTarget renderTarget = new(CanvasDevice.GetSharedDevice(), renderWidth, renderHeight, options.Dpi);
+        CanvasDevice device = CanvasDevice.GetSharedDevice();
+        using CanvasRenderTarget renderTarget = new(device, renderWidth, renderHeight, options.Dpi);
+        using Win2DImageRenderResourceScope imageResources = await Win2DImageRenderResourceScope.CreateAsync(drawables, device);
         using CanvasDrawingSession drawingSession = renderTarget.CreateDrawingSession();
 
-        Win2DImageCanvasRenderer.Render(drawables, options, drawingSession);
+        Win2DImageCanvasRenderer.Render(drawables, options, drawingSession, imageResources.GetImage);
 
         drawingSession.Flush();
 

--- a/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageCanvasRenderer.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageCanvasRenderer.cs
@@ -3,7 +3,6 @@ using CaptureTool.Domain.Edit.Drawable;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Effects;
 using Microsoft.Graphics.Canvas.Text;
-using Microsoft.UI;
 using System.Numerics;
 using Windows.Foundation;
 using Windows.Storage.Streams;
@@ -13,11 +12,22 @@ namespace CaptureTool.Infrastructure.Edit.Windows;
 
 public static partial class Win2DImageCanvasRenderer
 {
-    private static readonly Color ClearColor = Colors.Transparent;
+    private static readonly Color ClearColor = Color.FromArgb(0, 0, 0, 0);
+    private static readonly Color ImageBackgroundColor = Color.FromArgb(255, 255, 255, 255);
     private const float TextPadding = 2f;
     private const float TextCornerRadius = 4f;
 
     public static void Render(IDrawable[] drawables, ImageCanvasRenderOptions options, CanvasDrawingSession drawingSession, float scale = 1f)
+    {
+        Render(drawables, options, drawingSession, GetPreparedImage, scale);
+    }
+
+    internal static void Render(
+        IDrawable[] drawables,
+        ImageCanvasRenderOptions options,
+        CanvasDrawingSession drawingSession,
+        Func<ImageDrawable, ICanvasImage> imageResolver,
+        float scale = 1f)
     {
         drawingSession.Clear(ClearColor);
 
@@ -30,7 +40,7 @@ public static partial class Win2DImageCanvasRenderer
 
             foreach (IDrawable drawable in drawables)
             {
-                Draw(drawable, tempSession);
+                Draw(drawable, tempSession, imageResolver);
             }
         }
 
@@ -60,6 +70,14 @@ public static partial class Win2DImageCanvasRenderer
 
     public static void Draw(IDrawable drawable, CanvasDrawingSession drawingSession)
     {
+        Draw(drawable, drawingSession, GetPreparedImage);
+    }
+
+    private static void Draw(
+        IDrawable drawable,
+        CanvasDrawingSession drawingSession,
+        Func<ImageDrawable, ICanvasImage> imageResolver)
+    {
         if (drawable is TextDrawable textDrawable)
             DrawText(textDrawable, drawingSession);
         else if (drawable is RectangleDrawable rectangleDrawable)
@@ -71,7 +89,7 @@ public static partial class Win2DImageCanvasRenderer
         else if (drawable is ArrowDrawable arrowDrawable)
             DrawArrow(arrowDrawable, drawingSession);
         else if (drawable is ImageDrawable imageDrawable)
-            DrawImage(imageDrawable, drawingSession);
+            DrawImage(imageDrawable, drawingSession, imageResolver(imageDrawable));
     }
 
     private static void DrawText(TextDrawable drawable, CanvasDrawingSession drawingSession)
@@ -201,30 +219,32 @@ public static partial class Win2DImageCanvasRenderer
         drawingSession.DrawLine(endPoint, arrowRight, strokeColor, drawable.StrokeWidth);
     }
 
-    private static void DrawImage(ImageDrawable drawable, CanvasDrawingSession drawingSession)
+    private static void DrawImage(ImageDrawable drawable, CanvasDrawingSession drawingSession, ICanvasImage preparedImage)
     {
-        ICanvasImage? preparedImage = drawable.GetPreparedImage();
-        if (preparedImage != null)
+        if (drawable.ImageEffect is ImageChromaKeyEffect imageChromaKeyEffect && imageChromaKeyEffect.IsEnabled)
         {
-            if (drawable.ImageEffect is ImageChromaKeyEffect imageChromaKeyEffect && imageChromaKeyEffect.IsEnabled)
-            {
-                var keyColor = Color.FromArgb(
-                    imageChromaKeyEffect.Color.A,
-                    imageChromaKeyEffect.Color.R,
-                    imageChromaKeyEffect.Color.G,
-                    imageChromaKeyEffect.Color.B);
-                var tolerance = imageChromaKeyEffect.Tolerance;
-                var softness = imageChromaKeyEffect.Desaturation;
+            var keyColor = Color.FromArgb(
+                imageChromaKeyEffect.Color.A,
+                imageChromaKeyEffect.Color.R,
+                imageChromaKeyEffect.Color.G,
+                imageChromaKeyEffect.Color.B);
+            var tolerance = imageChromaKeyEffect.Tolerance;
+            var softness = imageChromaKeyEffect.Desaturation;
 
-                drawingSession.Clear(Colors.White);
-                drawable.GetChromaKeyProcessor().DrawChromaKeyMaskedImage(drawingSession, preparedImage, drawable.Offset, keyColor, tolerance, softness);
-            }
-            else
-            {
-                drawingSession.Clear(Colors.White);
-                drawingSession.DrawImage(preparedImage, drawable.Offset);
-            }
+            drawingSession.Clear(ImageBackgroundColor);
+            drawable.GetChromaKeyProcessor().DrawChromaKeyMaskedImage(drawingSession, preparedImage, drawable.Offset, keyColor, tolerance, softness);
         }
+        else
+        {
+            drawingSession.Clear(ImageBackgroundColor);
+            drawingSession.DrawImage(preparedImage, drawable.Offset);
+        }
+    }
+
+    private static ICanvasImage GetPreparedImage(ImageDrawable drawable)
+    {
+        return drawable.GetPreparedImage()
+            ?? throw new InvalidOperationException($"No render resource is available for image '{drawable.File.FilePath}'.");
     }
 
     public static async Task PrepareAsync(ImageDrawable imageDrawable, ICanvasResourceCreator resourceCreator)

--- a/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageRenderResourceScope.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageRenderResourceScope.cs
@@ -1,0 +1,74 @@
+using CaptureTool.Domain.Edit.Drawable;
+using Microsoft.Graphics.Canvas;
+
+namespace CaptureTool.Infrastructure.Edit.Windows;
+
+internal sealed class Win2DImageRenderResourceScope : IDisposable
+{
+    private readonly Dictionary<ImageDrawable, CanvasBitmap> _images;
+
+    private Win2DImageRenderResourceScope(Dictionary<ImageDrawable, CanvasBitmap> images)
+    {
+        _images = images;
+    }
+
+    public static async Task<Win2DImageRenderResourceScope> CreateAsync(
+        IEnumerable<IDrawable> drawables,
+        ICanvasResourceCreator resourceCreator)
+    {
+        var images = new Dictionary<ImageDrawable, CanvasBitmap>();
+
+        try
+        {
+            foreach (ImageDrawable drawable in drawables.OfType<ImageDrawable>())
+            {
+                if (images.ContainsKey(drawable))
+                {
+                    continue;
+                }
+
+                CanvasBitmap image;
+                try
+                {
+                    image = await CanvasBitmap.LoadAsync(resourceCreator, drawable.File.FilePath);
+                }
+                catch (Exception exception)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to load image '{drawable.File.FilePath}' for rendering.",
+                        exception);
+                }
+
+                images.Add(drawable, image);
+            }
+
+            return new Win2DImageRenderResourceScope(images);
+        }
+        catch
+        {
+            foreach (CanvasBitmap image in images.Values)
+            {
+                image.Dispose();
+            }
+
+            throw;
+        }
+    }
+
+    public ICanvasImage GetImage(ImageDrawable drawable)
+    {
+        return _images.TryGetValue(drawable, out CanvasBitmap? image)
+            ? image
+            : throw new InvalidOperationException($"No render resource is available for image '{drawable.File.FilePath}'.");
+    }
+
+    public void Dispose()
+    {
+        foreach (CanvasBitmap image in _images.Values)
+        {
+            image.Dispose();
+        }
+
+        _images.Clear();
+    }
+}

--- a/tests/CaptureTool.Infrastructure.Edit.Windows.Tests/Win2DImageCanvasExporterTests.cs
+++ b/tests/CaptureTool.Infrastructure.Edit.Windows.Tests/Win2DImageCanvasExporterTests.cs
@@ -1,0 +1,73 @@
+using CaptureTool.Application.Abstractions.Clipboard;
+using CaptureTool.Application.Abstractions.Edit.Image.Rendering;
+using CaptureTool.Domain.Edit;
+using CaptureTool.Domain.Edit.Drawable;
+using CaptureTool.Domain.FileSystem;
+using FluentAssertions;
+using Moq;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Numerics;
+
+namespace CaptureTool.Infrastructure.Edit.Windows.Tests;
+
+[TestClass]
+public sealed class Win2DImageCanvasExporterTests
+{
+    [TestMethod]
+    public async Task RenderToStreamAsync_WithoutCanvasPreparedResource_RendersSourceImage()
+    {
+        string sourcePath = Path.Combine(TestContext.TestRunDirectory!, $"source-{Guid.NewGuid():N}.png");
+        try
+        {
+            using (var source = new Bitmap(2, 2))
+            {
+                source.SetPixel(0, 0, Color.Red);
+                source.SetPixel(1, 0, Color.Red);
+                source.SetPixel(0, 1, Color.Red);
+                source.SetPixel(1, 1, Color.Red);
+                source.Save(sourcePath, ImageFormat.Png);
+            }
+
+            var drawable = new ImageDrawable(Vector2.Zero, new ImageFile(sourcePath), new Size(2, 2));
+            var options = new ImageCanvasRenderOptions(
+                ImageOrientation.RotateNoneFlipNone,
+                new Size(2, 2),
+                new Rectangle(0, 0, 2, 2));
+            var exporter = new Win2DImageCanvasExporter(Mock.Of<IClipboardService>());
+
+            using MemoryStream rendered = await exporter.RenderToStreamAsync([drawable], options);
+            using var result = new Bitmap(rendered);
+
+            result.GetPixel(0, 0).ToArgb().Should().Be(Color.Red.ToArgb());
+            drawable.GetPreparedImage().Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [TestMethod]
+    public async Task RenderToStreamAsync_WhenSourceImageIsMissing_FailsExplicitly()
+    {
+        string sourcePath = Path.Combine(TestContext.TestRunDirectory!, $"missing-{Guid.NewGuid():N}.png");
+        var drawable = new ImageDrawable(Vector2.Zero, new ImageFile(sourcePath), new Size(2, 2));
+        var options = new ImageCanvasRenderOptions(
+            ImageOrientation.RotateNoneFlipNone,
+            new Size(2, 2),
+            new Rectangle(0, 0, 2, 2));
+        var exporter = new Win2DImageCanvasExporter(Mock.Of<IClipboardService>());
+
+        Func<Task> render = async () =>
+        {
+            using MemoryStream _ = await exporter.RenderToStreamAsync([drawable], options);
+        };
+
+        await render.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{sourcePath}*");
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+}


### PR DESCRIPTION
## Summary

- add the ARCH-06 PRD and document the export-owned resource design
- load each image drawable from its current `ImageFile` into an operation-scoped Win2D resource map on the export device
- make the renderer require an image resource instead of silently skipping a missing base raster
- cover canvas-free export and explicit missing-file failure with integration tests

## Why

Image export reused GPU resources prepared asynchronously by the WinUI `ImageCanvas`. Export could therefore run before preparation, during resource recreation, or without a canvas and still encode an annotation-only or blank image.

The exporter now owns the resources needed for its operation and disposes them after encoding. UI preview resources remain separate and unchanged.

Fixes #411.

## User and developer impact

Copy, save, share, external editing, OCR, and image-description flows no longer depend on the interactive canvas resource lifetime. Missing or unreadable source content faults the export with contextual information instead of reporting a successful output with no base image.

## Validation

- 654 non-UI tests passed across all six non-UI test projects
- `CaptureTool.Infrastructure.Edit.Windows.Tests`: 35 passed, including two new exporter regressions
- WinUI x64 Debug project build: succeeded with 0 warnings and 0 errors
- formatting/analyzer verification passed for both changed projects
