### PR TITLE
Fix atomic image save-to-source

### DIFF
--- a/docs/prd-410-atomic-image-save-to-source.md
+++ b/docs/prd-410-atomic-image-save-to-source.md
@@ -1,0 +1,107 @@
+# PRD: Atomic Image Save to Source
+
+- Issue: [#410](https://github.com/shanebweaver/CaptureTool/issues/410)
+- Architecture finding: `ARCH-05`
+- Severity: High
+- Status: Implemented
+- Affected features: `APP-05`, `APP-06`, `IMG-01`, `IMG-15`
+
+## Summary
+
+Image Save to Source must commit one rendered image without overwriting the live editor base. When an editor has a distinct persistent source, the persistent file is the only save destination and the temporary working copy remains immutable. When the working file is itself the source, the save is committed atomically and the editor is rebased to that flattened image before editing continues.
+
+## Problem
+
+`ImageEditPageViewModel.SaveToSourceAsync` currently renders independently to the working file and then to the associated persistent file. The first write mutates the file referenced by the active base `ImageDrawable`, while annotations, crop, orientation, and undo history remain live. Win2D normally hides the mismatch behind its cached bitmap, but resource recreation reloads the flattened file and applies the still-live edits again.
+
+The two writes also form a partial commit. If the persistent write fails, the working file has already changed even though the operation reports failure and retains a dirty retry state.
+
+## Goals
+
+1. Keep a distinct editor working file immutable for the lifetime of its edit session.
+2. Ensure a failed Save to Source leaves every source destination unchanged.
+3. Render the current edit state once per save operation.
+4. Preserve the current session and undo history when saving to a distinct persistent source.
+5. Rebase the session safely when the working file is the only source that can be saved.
+6. Keep Save As behavior and existing image format selection intact.
+
+## Non-goals
+
+- Redesigning Save As, clipboard, share, or print output.
+- Adding a cross-filesystem transaction for unrelated destinations.
+- Persisting editable annotation metadata alongside the flattened image.
+- Changing capture auto-save or recent-capture identity behavior.
+- Changing the confirmation UI introduced for unsaved edit sessions.
+
+## User experience
+
+- Saving an opened or auto-saved image updates its persistent source while the editor continues to use its unchanged temporary working copy.
+- Saving a temporary-only capture updates that capture atomically, then presents the saved pixels as a clean new editing baseline.
+- A failed save keeps the editor dirty and leaves the previous source bytes available for retry.
+- Continuing to edit after a successful save cannot duplicate crop, orientation, chroma key, or annotations after canvas resource recreation.
+
+## Functional requirements
+
+### Destination selection
+
+1. If `PersistentFilePath` identifies a path distinct from `FilePath`, Save to Source writes only `PersistentFilePath`.
+2. The working `FilePath` remains unchanged and continues to back the live base drawable.
+3. If no distinct persistent path exists, Save to Source writes `FilePath` and treats it as the sole source.
+
+### Atomic output
+
+1. The exporter renders the drawable snapshot once to an in-memory encoded image.
+2. Encoded bytes are written to a uniquely named temporary sibling of the destination.
+3. The destination is replaced only after the temporary file has been fully written and accepted by the platform file-update API.
+4. A staging or replacement failure removes the temporary sibling on a best-effort basis and leaves the previous destination intact.
+5. The temporary sibling retains the destination extension so image format selection is unchanged.
+
+### Session consistency
+
+1. Saving to a distinct persistent source does not replace the base drawable, geometry, annotations, or undo history.
+2. Saving to the sole working source rebases the editor to the saved flattened file.
+3. Rebase creates one base image drawable, resets crop and orientation to the saved dimensions, clears annotation effects and undo/redo history, and reloads canvas resources.
+4. Only a fully successful commit marks the session clean.
+
+## Reliability requirements
+
+- The existing destination must not be truncated before the staged file is ready.
+- A failed persistent save must not write the working file.
+- Temporary-file cleanup must not mask the original save failure.
+- Source path comparison remains full-path and case-insensitive on Windows.
+- Cancellation observed before commit must retain the dirty session.
+
+## Test plan
+
+### Presentation regression tests
+
+- A distinct persistent source is the only exporter destination; the working path is never written.
+- A persistent-source failure keeps unsaved changes and never attempts a working-file write.
+- A successful persistent save retains annotations and undo history over the immutable working base.
+- A temporary-only source save rebases to a single base drawable with default orientation/crop and cleared undo/redo state.
+- A second output after rebase contains only the new baseline plus edits added after the save.
+
+### Exporter validation
+
+- The existing file remains intact when staging fails.
+- Successful staging replaces the destination and removes the sibling temporary file.
+- Temporary-file cleanup is best effort and does not alter the reported failure.
+
+### Repository validation
+
+- Run all non-UI test projects.
+- Build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] A distinct working image is never overwritten by Save to Source.
+- [x] The persistent source is replaced only after a complete staged write.
+- [x] Failure leaves the previous working and persistent sources recoverable.
+- [x] Resource recreation after save cannot reapply edits already flattened into the source.
+- [x] Temporary-only sources are rebased to a clean, single-image session after save.
+- [x] Save As behavior remains unchanged.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+
+## Rollout
+
+No migration or feature flag is required. The new save behavior applies immediately to image edit sessions and does not change stored file formats.

--- a/src/CaptureTool.Infrastructure.Edit.Windows/AtomicImageFileWriter.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/AtomicImageFileWriter.cs
@@ -1,0 +1,40 @@
+namespace CaptureTool.Infrastructure.Edit.Windows;
+
+internal static class AtomicImageFileWriter
+{
+    public static async Task WriteAsync(string filePath, Func<string, Task> writeTemporaryFileAsync)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(writeTemporaryFileAsync);
+
+        string destinationPath = Path.GetFullPath(filePath);
+        string directoryPath = Path.GetDirectoryName(destinationPath)
+            ?? throw new InvalidOperationException("The image destination does not have a parent directory.");
+        Directory.CreateDirectory(directoryPath);
+
+        string temporaryFilePath = Path.Combine(
+            directoryPath,
+            $".{Path.GetFileNameWithoutExtension(destinationPath)}.{Guid.NewGuid():N}.tmp{Path.GetExtension(destinationPath)}");
+
+        try
+        {
+            using (FileStream _ = new(temporaryFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+            }
+
+            await writeTemporaryFileAsync(temporaryFilePath);
+            File.Move(temporaryFilePath, destinationPath, true);
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryFilePath);
+            }
+            catch
+            {
+                // Temporary-file cleanup is best effort and must not hide the save failure.
+            }
+        }
+    }
+}

--- a/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageCanvasExporter.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/Win2DImageCanvasExporter.cs
@@ -46,32 +46,29 @@ public sealed partial class Win2DImageCanvasExporter : IImageCanvasExporter
             options,
             GetFileFormat(filePath));
 
-        string? directoryPath = Path.GetDirectoryName(filePath);
-        if (!string.IsNullOrWhiteSpace(directoryPath))
-        {
-            Directory.CreateDirectory(directoryPath);
-        }
+        await SaveStreamAtomicallyAsync(filePath, stream);
+    }
 
-        if (!File.Exists(filePath))
+    private static async Task SaveStreamAtomicallyAsync(string filePath, IRandomAccessStream stream)
+    {
+        await AtomicImageFileWriter.WriteAsync(filePath, async temporaryFilePath =>
         {
-            using FileStream _ = File.Create(filePath);
-        }
+            StorageFile file = await StorageFile.GetFileFromPathAsync(temporaryFilePath);
+            CachedFileManager.DeferUpdates(file);
 
-        StorageFile file = await StorageFile.GetFileFromPathAsync(filePath);
-        CachedFileManager.DeferUpdates(file);
+            using (var fileStream = await file.OpenAsync(FileAccessMode.ReadWrite))
+            {
+                fileStream.Size = 0;
+                stream.Seek(0);
+                await RandomAccessStream.CopyAsync(stream, fileStream);
+            }
 
-        using (var fileStream = await file.OpenAsync(FileAccessMode.ReadWrite))
-        {
-            fileStream.Size = 0;
-            stream.Seek(0);
-            await RandomAccessStream.CopyAsync(stream, fileStream);
-        }
-
-        FileUpdateStatus status = await CachedFileManager.CompleteUpdatesAsync(file);
-        if (status != FileUpdateStatus.Complete)
-        {
-            throw new Exception("File could not be saved.");
-        }
+            FileUpdateStatus status = await CachedFileManager.CompleteUpdatesAsync(file);
+            if (status != FileUpdateStatus.Complete)
+            {
+                throw new Exception("File could not be saved.");
+            }
+        });
     }
 
     private static async Task<InMemoryRandomAccessStream> RenderToRandomAccessStreamAsync(

--- a/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
@@ -1421,16 +1421,19 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         {
             ImageCanvasRenderOptions options = GetImageCanvasRenderOptions();
             IDrawable[] drawables = [.. Drawables];
-            await _imageCanvasExporter.SaveImageAsync(_originalImageFile.FilePath, drawables, options);
-
             string? persistentFilePath = _originalImageFile.PersistentFilePath;
-            if (!string.IsNullOrWhiteSpace(persistentFilePath) &&
-                !string.Equals(
-                    Path.GetFullPath(persistentFilePath),
-                    Path.GetFullPath(_originalImageFile.FilePath),
-                    StringComparison.OrdinalIgnoreCase))
+            bool hasDistinctPersistentFile = !string.IsNullOrWhiteSpace(persistentFilePath) &&
+                !AreSamePath(persistentFilePath, _originalImageFile.FilePath);
+            string destinationPath = hasDistinctPersistentFile
+                ? persistentFilePath!
+                : _originalImageFile.FilePath;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await _imageCanvasExporter.SaveImageAsync(destinationPath, drawables, options);
+
+            if (!hasDistinctPersistentFile)
             {
-                await _imageCanvasExporter.SaveImageAsync(persistentFilePath, drawables, options);
+                RebaseToSavedSource(options.CropRect.Size);
             }
 
             MarkChangesSaved();
@@ -1443,6 +1446,45 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
             TrackOutput("save", TelemetryOutcomes.Failed);
             return false;
         }
+    }
+
+    private static bool AreSamePath(string firstPath, string secondPath)
+    {
+        return string.Equals(
+            Path.GetFullPath(firstPath),
+            Path.GetFullPath(secondPath),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void RebaseToSavedSource(Size savedImageSize)
+    {
+        if (_originalImageFile is null)
+        {
+            return;
+        }
+
+        CancelSuperResolutionWork();
+        _superResolutionImageFile = null;
+        _superResolutionImageSize = Size.Empty;
+        IsSuperResolutionActive = false;
+        IsSuperResolutionGenerating = false;
+        SuperResolutionStatusMessage = string.Empty;
+
+        _editSession = new ImageEditSession(savedImageSize);
+        _imageDrawable = new ImageDrawable(Vector2.Zero, _originalImageFile, savedImageSize);
+        _editSession.AddDrawable(_imageDrawable);
+        _originalImageSize = savedImageSize;
+        ImageFile = _originalImageFile;
+
+        _editHistory.Clear();
+        ChromaKeyTool.Reset();
+        IncrementEditRevision();
+        SyncImageGeometryFromSession();
+        SyncDrawablesFromSession();
+        UpdateUndoRedoStackProperties();
+        UpdateCanToggleSuperResolution();
+        RequestCanvasUpdate(CanvasUpdateMode.ReloadResources);
+        ForceZoomAndCenterRequested?.Invoke(this, EventArgs.Empty);
     }
 
     private async Task SaveAsCommandAsync()

--- a/tests/CaptureTool.Infrastructure.Edit.Windows.Tests/AtomicImageFileWriterTests.cs
+++ b/tests/CaptureTool.Infrastructure.Edit.Windows.Tests/AtomicImageFileWriterTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+
+namespace CaptureTool.Infrastructure.Edit.Windows.Tests;
+
+[TestClass]
+public sealed class AtomicImageFileWriterTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task WriteAsync_WhenStagingSucceeds_ReplacesDestinationAndRemovesTemporaryFile()
+    {
+        string directoryPath = CreateTestDirectory();
+        string destinationPath = Path.Combine(directoryPath, "image.png");
+        await File.WriteAllTextAsync(destinationPath, "old");
+        string? temporaryFilePath = null;
+
+        await AtomicImageFileWriter.WriteAsync(destinationPath, async path =>
+        {
+            temporaryFilePath = path;
+            Path.GetExtension(path).Should().Be(".png");
+            await File.WriteAllTextAsync(path, "new");
+        });
+
+        (await File.ReadAllTextAsync(destinationPath)).Should().Be("new");
+        File.Exists(temporaryFilePath).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_WhenStagingFails_PreservesDestinationAndRemovesTemporaryFile()
+    {
+        string directoryPath = CreateTestDirectory();
+        string destinationPath = Path.Combine(directoryPath, "image.png");
+        await File.WriteAllTextAsync(destinationPath, "old");
+        string? temporaryFilePath = null;
+
+        Func<Task> action = () => AtomicImageFileWriter.WriteAsync(destinationPath, async path =>
+        {
+            temporaryFilePath = path;
+            await File.WriteAllTextAsync(path, "incomplete");
+            throw new IOException("The staged write failed.");
+        });
+
+        await action.Should().ThrowAsync<IOException>();
+        (await File.ReadAllTextAsync(destinationPath)).Should().Be("old");
+        File.Exists(temporaryFilePath).Should().BeFalse();
+    }
+
+    private string CreateTestDirectory()
+    {
+        string directoryPath = Path.Combine(TestContext.TestRunDirectory!, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directoryPath);
+        return directoryPath;
+    }
+}

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelSaveTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelSaveTests.cs
@@ -11,6 +11,7 @@ using CaptureTool.Application.Abstractions.Settings;
 using CaptureTool.Application.Abstractions.Settings.OpenScreenshotsFolder;
 using CaptureTool.Application.Abstractions.Share;
 using CaptureTool.Application.Abstractions.Storage;
+using CaptureTool.Domain.Edit;
 using CaptureTool.Domain.Edit.Drawable;
 using CaptureTool.Domain.FileSystem;
 using CaptureTool.Presentation.Features.ImageEdit;
@@ -18,6 +19,7 @@ using CaptureTool.Presentation.Notifications;
 using FluentAssertions;
 using Moq;
 using System.Drawing;
+using System.Numerics;
 
 namespace CaptureTool.Presentation.Tests.Features;
 
@@ -25,7 +27,7 @@ namespace CaptureTool.Presentation.Tests.Features;
 public sealed class ImageEditPageViewModelSaveTests
 {
     [TestMethod]
-    public async Task SaveToSourceAsync_SavesWorkingAndPersistentFiles()
+    public async Task SaveToSourceAsync_WithPersistentSource_DoesNotModifyWorkingFile()
     {
         var exporter = new Mock<IImageCanvasExporter>();
         var picker = new Mock<IFilePickerService>();
@@ -44,7 +46,7 @@ public sealed class ImageEditPageViewModelSaveTests
         bool saved = await viewModel.SaveToSourceAsync();
 
         saved.Should().BeTrue();
-        savedPaths.Should().Equal("working.png", "original.png");
+        savedPaths.Should().Equal("original.png");
         viewModel.HasUnsavedChanges.Should().BeFalse();
         picker.Verify(
             service => service.PickSaveFileAsync(It.IsAny<FilePickerType>(), It.IsAny<UserFolder>()),
@@ -84,12 +86,6 @@ public sealed class ImageEditPageViewModelSaveTests
         var exporter = new Mock<IImageCanvasExporter>();
         exporter
             .Setup(service => service.SaveImageAsync(
-                "working.png",
-                It.IsAny<IDrawable[]>(),
-                It.IsAny<ImageCanvasRenderOptions>()))
-            .Returns(Task.CompletedTask);
-        exporter
-            .Setup(service => service.SaveImageAsync(
                 "original.png",
                 It.IsAny<IDrawable[]>(),
                 It.IsAny<ImageCanvasRenderOptions>()))
@@ -102,6 +98,92 @@ public sealed class ImageEditPageViewModelSaveTests
 
         saved.Should().BeFalse();
         viewModel.HasUnsavedChanges.Should().BeTrue();
+        exporter.Verify(
+            service => service.SaveImageAsync(
+                "working.png",
+                It.IsAny<IDrawable[]>(),
+                It.IsAny<ImageCanvasRenderOptions>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task SaveToSourceAsync_WithPersistentSource_PreservesLiveEditSession()
+    {
+        var exporter = new Mock<IImageCanvasExporter>();
+        exporter
+            .Setup(service => service.SaveImageAsync(
+                It.IsAny<string>(),
+                It.IsAny<IDrawable[]>(),
+                It.IsAny<ImageCanvasRenderOptions>()))
+            .Returns(Task.CompletedTask);
+        var imageFile = new ImageFile("working.png", "original.png");
+        ImageEditPageViewModel viewModel = await CreateLoadedViewModelAsync(imageFile, exporter.Object);
+        viewModel.RotateCommand.Execute(null);
+        var annotation = new RectangleDrawable(
+            Vector2.One,
+            new Size(10, 10),
+            Color.Red,
+            Color.Transparent,
+            2);
+        viewModel.AddDrawable(annotation);
+
+        bool saved = await viewModel.SaveToSourceAsync();
+
+        saved.Should().BeTrue();
+        viewModel.Drawables.Should().ContainInOrder(viewModel.Drawables.OfType<ImageDrawable>().Single(), annotation);
+        viewModel.Orientation.Should().Be(ImageOrientation.Rotate90FlipNone);
+        viewModel.HasUndoStack.Should().BeTrue();
+        viewModel.HasUnsavedChanges.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task SaveToSourceAsync_WithWorkingSource_RebasesFlattenedImageBeforeFurtherEdits()
+    {
+        var exporter = new Mock<IImageCanvasExporter>();
+        List<(string Path, int DrawableCount, ImageCanvasRenderOptions Options)> saves = [];
+        exporter
+            .Setup(service => service.SaveImageAsync(
+                It.IsAny<string>(),
+                It.IsAny<IDrawable[]>(),
+                It.IsAny<ImageCanvasRenderOptions>()))
+            .Callback<string, IDrawable[], ImageCanvasRenderOptions>(
+                (path, drawables, options) => saves.Add((path, drawables.Length, options)))
+            .Returns(Task.CompletedTask);
+        var imageFile = new ImageFile("working.png");
+        ImageEditPageViewModel viewModel = await CreateLoadedViewModelAsync(imageFile, exporter.Object);
+        viewModel.RotateCommand.Execute(null);
+        viewModel.AddDrawable(new RectangleDrawable(
+            Vector2.One,
+            new Size(10, 10),
+            Color.Red,
+            Color.Transparent,
+            2));
+        int reloadRequests = 0;
+        viewModel.ReloadCanvasResourcesRequested += (_, _) => reloadRequests++;
+
+        bool saved = await viewModel.SaveToSourceAsync();
+
+        saved.Should().BeTrue();
+        saves.Should().ContainSingle();
+        saves[0].Path.Should().Be("working.png");
+        saves[0].DrawableCount.Should().Be(2);
+        viewModel.Drawables.Should().ContainSingle().Which.Should().BeOfType<ImageDrawable>();
+        viewModel.Orientation.Should().Be(ImageOrientation.RotateNoneFlipNone);
+        viewModel.ImageSize.Should().Be(new Size(50, 100));
+        viewModel.CropRect.Should().Be(new Rectangle(Point.Empty, new Size(50, 100)));
+        viewModel.HasUndoStack.Should().BeFalse();
+        viewModel.HasRedoStack.Should().BeFalse();
+        viewModel.HasUnsavedChanges.Should().BeFalse();
+        reloadRequests.Should().Be(1);
+
+        viewModel.AddDrawable(new RectangleDrawable(
+            Vector2.One,
+            new Size(5, 5),
+            Color.Blue,
+            Color.Transparent,
+            1));
+
+        viewModel.Drawables.Should().HaveCount(2);
     }
 
     private static async Task<ImageEditPageViewModel> CreateLoadedViewModelAsync(


### PR DESCRIPTION
## Summary

- keep distinct image-editor working files immutable during Save to Source
- atomically stage and replace image output through a same-directory temporary file
- rebase temporary-only edit sessions to the flattened result before further editing
- document the ARCH-05 requirements and design in a PRD

## Why

Save to Source previously rendered over the live working image and then independently rendered to its persistent source. A later canvas resource reload could therefore load already-flattened pixels and apply the still-live crop, orientation, chroma key, or annotations again. If the second write failed, the working file had already been modified even though the editor reported failure and remained dirty.

The new destination policy writes only a distinct persistent source and leaves the working base untouched. When the working file is the sole source, the editor commits it atomically and rebases to a single clean base drawable.

## User impact

Users can continue editing after a successful source save without duplicated edits after resource recreation. Failed saves preserve the previous source bytes and retain a recoverable dirty session.

## Validation

- WinUI x64 Debug project build: passed
- all non-UI test projects: 656 passed
- focused presentation regressions: 5 passed
- focused atomic writer tests: 2 passed
- git diff --check: passed

Closes #410