### PR TITLE
Fix selection overlay host disposal

### DIFF
--- a/docs/prd-413-selection-overlay-host-lifecycle.md
+++ b/docs/prd-413-selection-overlay-host-lifecycle.md
@@ -1,0 +1,94 @@
+# PRD: Selection Overlay Host Lifecycle Cleanup
+
+- Issue: [#413](https://github.com/shanebweaver/CaptureTool/issues/413)
+- Architecture finding: `ARCH-08`
+- Severity: Medium
+- Status: Implemented
+- Affected feature: `CAP-01`
+
+## Summary
+
+`SelectionOverlayHost.Close` and `SelectionOverlayHost.Dispose` must converge on one idempotent cleanup path. Disposing the host without an earlier explicit close must stop foreground monitoring, detach and dispose view models, close overlay windows, and release monitor capture buffers exactly once.
+
+## Problem
+
+`SelectionOverlayHost.Dispose` currently marks `_disposed` before calling `Close`. `Close` immediately returns when `_disposed` is true, so a dispose-only caller skips every resource cleanup step. The normal navigation path calls `Close` before `Dispose`, which masks the defect during ordinary use.
+
+A dispose-only or exceptional teardown path can therefore retain native overlay windows, XAML islands, timer subscriptions, view-model subscriptions, window handles, and large per-monitor pixel buffers.
+
+## Goals
+
+1. Make dispose-only teardown perform the same cleanup as an explicit close.
+2. Execute host cleanup at most once across any sequence of `Close` and `Dispose` calls.
+3. Keep cleanup safe when initialization stopped before any resources were created.
+4. Preserve the existing best-effort handling for individual overlay-window close failures.
+5. Add non-UI lifecycle regression tests that do not require native windows or monitor capture.
+
+## Non-goals
+
+- Redesigning overlay creation, activation, focus monitoring, or capture behavior.
+- Changing `SelectionOverlayWindow` or `CaptureOverlayHost` ownership.
+- Adding finalizers for UI or native resources.
+- Making WinUI and Win32 resources safe to tear down from arbitrary threads.
+- Changing application navigation semantics.
+
+## Functional requirements
+
+### Unified close path
+
+1. Move resource teardown into a private `CloseCore` method.
+2. `Close` invokes `CloseCore` through a close-once lifecycle boundary.
+3. `Dispose` invokes the same lifecycle boundary before suppressing finalization.
+4. Disposal state must not prevent the first close operation from running.
+
+### Idempotence
+
+1. Dispose-only calls cleanup once.
+2. Close followed by Dispose calls cleanup once.
+3. Repeated Dispose calls cleanup once.
+4. Repeated Close calls cleanup once.
+5. Close after Dispose is a no-op.
+6. The close-once transition is atomic so reentrant or competing calls cannot enter cleanup twice.
+
+### Resource release
+
+The existing cleanup responsibilities remain intact:
+
+- stop and detach the foreground timer;
+- clear the primary-window reference;
+- detach and dispose the host view model;
+- close every overlay window on a best-effort basis;
+- clear window, handle, and monitor collections so captured pixel buffers can be reclaimed.
+
+## Reliability requirements
+
+- An uninitialized host can be closed or disposed without throwing.
+- Lifecycle state changes before cleanup begins so reentrant close notifications cannot duplicate teardown.
+- One overlay-window close failure does not prevent remaining windows and collections from being cleaned.
+- `GC.SuppressFinalize` is called for every first successful disposal request even though the class has no finalizer today.
+
+## Test plan
+
+Add focused tests for the lifecycle boundary:
+
+- Dispose-only invokes cleanup once and records closed/disposed state.
+- Close then Dispose invokes cleanup once.
+- Repeated Dispose invokes cleanup once.
+- Repeated Close and Close-after-Dispose invoke cleanup once.
+- A no-op cleanup delegate represents a partially initialized host and completes safely.
+- A reentrant Close from inside cleanup does not invoke cleanup again.
+
+Run all non-UI test projects and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] `SelectionOverlayHost.Dispose` cannot skip host cleanup.
+- [x] All Close/Dispose call orders are idempotent.
+- [x] Partially initialized hosts tear down safely.
+- [x] Overlay cleanup responsibilities remain unchanged.
+- [x] Lifecycle regression tests pass.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+
+## Rollout
+
+No migration or feature flag is required. The corrected lifecycle behavior applies whenever a selection overlay host is closed or disposed.

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/SelectionOverlayHost.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/SelectionOverlayHost.cs
@@ -17,10 +17,15 @@ internal sealed partial class SelectionOverlayHost : IDisposable
     private readonly HashSet<MonitorCaptureResult> _monitors = [];
     private readonly HashSet<SelectionOverlayWindow> _windows = [];
     private readonly HashSet<nint> _windowHandles = [];
+    private readonly SelectionOverlayHostLifetime _lifetime;
     private SelectionOverlayHostViewModel? _viewModel;
     private DispatcherTimer? _foregroundTimer;
     private SelectionOverlayWindow? _primaryWindow;
-    private bool _disposed;
+
+    public SelectionOverlayHost()
+    {
+        _lifetime = new SelectionOverlayHostLifetime(CloseCore);
+    }
 
     public event EventHandler? LostFocus;
 
@@ -144,23 +149,28 @@ internal sealed partial class SelectionOverlayHost : IDisposable
 
     public void Close()
     {
-        if (_disposed)
-        {
-            return;
-        }
+        _lifetime.Close();
+    }
 
+    private void CloseCore()
+    {
         StopForegroundMonitor();
 
-        if (_primaryWindow != null)
-        {
-            _primaryWindow = null;
-        }
+        _primaryWindow = null;
 
-        if (_viewModel != null)
+        SelectionOverlayHostViewModel? viewModel = _viewModel;
+        _viewModel = null;
+        if (viewModel != null)
         {
-            _viewModel.AllScreensCaptureRequested -= OnAllScreensCaptureRequested;
-            _viewModel.Dispose();
-            _viewModel = null;
+            try
+            {
+                viewModel.AllScreensCaptureRequested -= OnAllScreensCaptureRequested;
+                viewModel.Dispose();
+            }
+            catch
+            {
+                // Continue releasing native overlay resources if view-model teardown fails.
+            }
         }
 
         foreach (SelectionOverlayWindow window in _windows)
@@ -215,24 +225,25 @@ internal sealed partial class SelectionOverlayHost : IDisposable
 
     private void StopForegroundMonitor()
     {
-        if (_foregroundTimer != null)
+        DispatcherTimer? foregroundTimer = _foregroundTimer;
+        _foregroundTimer = null;
+        if (foregroundTimer != null)
         {
-            _foregroundTimer.Tick -= OnForegroundTimerTick;
-            _foregroundTimer.Stop();
-            _foregroundTimer = null;
+            try
+            {
+                foregroundTimer.Tick -= OnForegroundTimerTick;
+                foregroundTimer.Stop();
+            }
+            catch
+            {
+                // Continue host cleanup even if the dispatcher is already unavailable.
+            }
         }
     }
 
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-
-        Close();
+        _lifetime.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayHostLifetime.cs
+++ b/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayHostLifetime.cs
@@ -1,0 +1,38 @@
+namespace CaptureTool.Presentation.Features.SelectionOverlay;
+
+internal sealed class SelectionOverlayHostLifetime : IDisposable
+{
+    private readonly Action _closeCore;
+    private int _closed;
+    private int _disposed;
+
+    public SelectionOverlayHostLifetime(Action closeCore)
+    {
+        ArgumentNullException.ThrowIfNull(closeCore);
+        _closeCore = closeCore;
+    }
+
+    public bool IsClosed => Volatile.Read(ref _closed) != 0;
+
+    public bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+    public void Close()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+        {
+            return;
+        }
+
+        _closeCore();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        Close();
+    }
+}

--- a/src/CaptureTool.Presentation/Properties/AssemblyInfo.cs
+++ b/src/CaptureTool.Presentation/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("CaptureTool.Presentation.Tests")]
+[assembly: InternalsVisibleTo("CaptureTool.Presentation.Windows.WinUI")]

--- a/tests/CaptureTool.Presentation.Tests/Features/SelectionOverlayHostLifetimeTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/SelectionOverlayHostLifetimeTests.cs
@@ -1,0 +1,89 @@
+using CaptureTool.Presentation.Features.SelectionOverlay;
+using FluentAssertions;
+
+namespace CaptureTool.Presentation.Tests.Features;
+
+[TestClass]
+public sealed class SelectionOverlayHostLifetimeTests
+{
+    [TestMethod]
+    public void Dispose_WithoutClose_InvokesCleanupOnce()
+    {
+        int cleanupCount = 0;
+        var lifetime = new SelectionOverlayHostLifetime(() => cleanupCount++);
+
+        lifetime.Dispose();
+
+        cleanupCount.Should().Be(1);
+        lifetime.IsClosed.Should().BeTrue();
+        lifetime.IsDisposed.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Close_ThenDispose_InvokesCleanupOnce()
+    {
+        int cleanupCount = 0;
+        var lifetime = new SelectionOverlayHostLifetime(() => cleanupCount++);
+
+        lifetime.Close();
+        lifetime.Dispose();
+
+        cleanupCount.Should().Be(1);
+        lifetime.IsClosed.Should().BeTrue();
+        lifetime.IsDisposed.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Dispose_Repeatedly_InvokesCleanupOnce()
+    {
+        int cleanupCount = 0;
+        var lifetime = new SelectionOverlayHostLifetime(() => cleanupCount++);
+
+        lifetime.Dispose();
+        lifetime.Dispose();
+        lifetime.Close();
+
+        cleanupCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public void Close_Repeatedly_InvokesCleanupOnce()
+    {
+        int cleanupCount = 0;
+        var lifetime = new SelectionOverlayHostLifetime(() => cleanupCount++);
+
+        lifetime.Close();
+        lifetime.Close();
+
+        cleanupCount.Should().Be(1);
+        lifetime.IsClosed.Should().BeTrue();
+        lifetime.IsDisposed.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Dispose_WithNoInitializedResources_CompletesSafely()
+    {
+        var lifetime = new SelectionOverlayHostLifetime(() => { });
+        Action action = lifetime.Dispose;
+
+        action.Should().NotThrow();
+        lifetime.IsClosed.Should().BeTrue();
+        lifetime.IsDisposed.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Close_WhenCleanupReentersClose_InvokesCleanupOnce()
+    {
+        int cleanupCount = 0;
+        SelectionOverlayHostLifetime? lifetime = null;
+        lifetime = new SelectionOverlayHostLifetime(() =>
+        {
+            cleanupCount++;
+            lifetime!.Close();
+        });
+
+        lifetime.Close();
+
+        cleanupCount.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

- route SelectionOverlayHost Close and Dispose through one atomic close-once lifecycle
- move host resource teardown into an idempotent CloseCore path
- continue native cleanup if dispatcher-timer or view-model teardown fails
- add lifecycle regression coverage and an ARCH-08 PRD

## Why

SelectionOverlayHost.Dispose previously marked the host disposed before calling Close. Close then returned immediately, so a dispose-only or exceptional teardown path could retain overlay windows, XAML islands, event subscriptions, native handles, and monitor pixel buffers.

The new lifetime boundary tracks close and disposal separately. Dispose can initiate the first close, while repeated, reentrant, and Close-then-Dispose sequences run cleanup exactly once.

## User impact

Selection overlays no longer leak native UI resources or captured monitor buffers when disposal occurs without an earlier explicit close. Normal navigation behavior remains unchanged.

## Validation

- WinUI x64 Debug project build: passed
- all non-UI test projects: 669 passed
- focused lifecycle regressions: 6 passed
- git diff --check: passed

Closes #413