### PR TITLE
Queue redirected startup activations

### DIFF
--- a/docs/prd-412-queue-redirected-startup-activations.md
+++ b/docs/prd-412-queue-redirected-startup-activations.md
@@ -1,0 +1,84 @@
+# PRD: Queue redirected startup activations
+
+- Issue: [#412](https://github.com/shanebweaver/CaptureTool/issues/412)
+- Finding: `ARCH-07`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `APP-01`
+
+## Summary
+
+Redirected activation arguments must be materialized in the `AppInstance.Activated` callback and retained until the WinUI application and its dispatcher are ready. Startup will use an ordered queue that accepts redirects before `App` exists, then attaches the application consumer after the primary launch activation completes.
+
+This removes the startup-time dependency on `App.Current`, preserves the lifetime-sensitive activation data before the redirecting process exits, and guarantees that the primary activation is handled before immediately redirected work.
+
+## Problem
+
+The primary `AppInstance` subscribes to redirected activation before `Microsoft.UI.Xaml.Application.Start`, but its event handler calls `App.Current.Activate(e)`. During that interval `Application.Current` has not been initialized because `new App()` has not run. A secondary process that redirects quickly enough can therefore dereference a nonexistent application or lose the activation.
+
+Redirected `AppActivationArguments` may also expose data through a COM proxy owned by the redirecting process. Retaining the raw argument object until later is unsafe; the durable activation kind and protocol URI must be copied before the event callback returns.
+
+## Goals
+
+1. Accept redirected activations before the WinUI `App` instance exists.
+2. Materialize all lifetime-sensitive activation data inside the lifecycle callback.
+3. Preserve redirected activations in FIFO order until the UI dispatcher is initialized.
+4. Process the primary launch activation before draining startup redirects.
+5. Keep malformed activation failures explicit and log them once application logging is available.
+
+## Non-goals
+
+- Do not change single-instance registration or secondary-process foreground behavior.
+- Do not change protocol routing, navigation destinations, or activation telemetry.
+- Do not persist queued activations across process termination.
+- Do not introduce retries for activation-handler failures.
+
+## Functional requirements
+
+### Lifecycle callback
+
+- Register the primary instance's `Activated` event before WinUI startup.
+- Materialize the activation kind and protocol URI before the callback returns.
+- Represent invalid data or materialization exceptions as a queued failure rather than dereferencing application services that do not exist yet.
+- Enqueue the materialized result without reading `App.Current`.
+
+### Ordered startup queue
+
+- Accept items before or after a consumer is attached.
+- Drain pre-attachment items in FIFO order when the consumer attaches.
+- Preserve ordering when items arrive while a drain is in progress.
+- Reject a second consumer attachment explicitly.
+- Retain the current item if the consumer throws so later work cannot silently overtake it.
+
+### Application startup
+
+- Construct `App` with the redirected-activation queue.
+- Handle the primary activation through the existing awaited activation path.
+- Attach the queue consumer only after primary handling completes.
+- Dispatch drained and future redirects through the app's UI dispatcher.
+- Log queued materialization warnings or exceptions through the normal application log service.
+
+## Reliability requirements
+
+- No redirected activation path may dereference `Application.Current` before `new App()` completes.
+- Returning from the lifecycle callback must not leave required data backed only by the redirecting process.
+- An activation arriving concurrently with consumer attachment must be handled exactly once and in FIFO order.
+- A dispatcher enqueue failure must remain visible through the existing warning log.
+
+## Test plan
+
+- Queue a redirected protocol activation before attaching the application consumer, process the primary launch, attach, and verify primary-then-protocol order.
+- Verify multiple pre-start redirects drain in FIFO order.
+- Verify an activation enqueued reentrantly during drain cannot overtake pending work.
+- Verify duplicate consumer attachment fails explicitly.
+- Run every non-UI test project.
+- Build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] An immediate redirected activation cannot access a nonexistent `App.Current`.
+- [x] Redirected arguments are materialized before the lifecycle callback returns.
+- [x] The primary activation completes before queued redirects are dispatched.
+- [x] Queued and concurrent redirects retain FIFO order without loss.
+- [x] Materialization and dispatcher failures remain observable through application logging.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Presentation.Windows.WinUI/Activation/ActivationMaterializer.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Activation/ActivationMaterializer.cs
@@ -1,0 +1,55 @@
+using Microsoft.Windows.AppLifecycle;
+
+namespace CaptureTool.Presentation.Windows.WinUI.Activation;
+
+internal static class ActivationMaterializer
+{
+    public static ActivationMaterializationResult Materialize(AppActivationArguments args)
+    {
+        try
+        {
+            ExtendedActivationKind kind = args.Kind;
+            Uri? protocolUri = null;
+
+            if (kind == ExtendedActivationKind.Protocol)
+            {
+                if (args.Data is not global::Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs protocolArgs)
+                {
+                    return ActivationMaterializationResult.Failed(
+                        "Protocol activation data is not of expected type.");
+                }
+
+                protocolUri = new Uri(protocolArgs.Uri.AbsoluteUri);
+            }
+
+            return ActivationMaterializationResult.Succeeded(
+                new MaterializedActivation(kind, protocolUri));
+        }
+        catch (Exception exception)
+        {
+            return ActivationMaterializationResult.Failed(
+                "Failed to read activation data.",
+                exception);
+        }
+    }
+}
+
+internal readonly record struct MaterializedActivation(
+    ExtendedActivationKind Kind,
+    Uri? ProtocolUri);
+
+internal readonly record struct ActivationMaterializationResult(
+    MaterializedActivation? Activation,
+    string? FailureMessage,
+    Exception? FailureException)
+{
+    public static ActivationMaterializationResult Succeeded(MaterializedActivation activation)
+    {
+        return new(activation, null, null);
+    }
+
+    public static ActivationMaterializationResult Failed(string message, Exception? exception = null)
+    {
+        return new(null, message, exception);
+    }
+}

--- a/src/CaptureTool.Presentation.Windows.WinUI/App.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/App.xaml.cs
@@ -1,6 +1,8 @@
 using CaptureTool.Application.Abstractions.Activation;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Themes;
+using CaptureTool.Presentation.Activation;
+using CaptureTool.Presentation.Windows.WinUI.Activation;
 using CaptureTool.Presentation.Windows.WinUI.UiTests;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -12,11 +14,18 @@ public partial class App : Microsoft.UI.Xaml.Application
 {
     internal new static App Current => (App)Microsoft.UI.Xaml.Application.Current;
 
+    private readonly StartupActivationQueue<ActivationMaterializationResult> _redirectedActivations;
+
     internal AppServiceProvider ServiceProvider { get; }
     internal DispatcherQueue DispatcherQueue { get; }
 
-    public App()
+    public App() : this(new StartupActivationQueue<ActivationMaterializationResult>())
     {
+    }
+
+    internal App(StartupActivationQueue<ActivationMaterializationResult> redirectedActivations)
+    {
+        _redirectedActivations = redirectedActivations;
         UnhandledException += App_UnhandledException;
         DispatcherQueue = DispatcherQueue.GetForCurrentThread();
         ServiceProvider = new();
@@ -47,25 +56,15 @@ public partial class App : Microsoft.UI.Xaml.Application
         }
 
         AppActivationArguments args = AppInstance.GetCurrent().GetActivatedEventArgs();
-        if (TryMaterializeActivation(args, out MaterializedActivation activation))
-        {
-            await ActivateAsync(activation);
-        }
+        await HandleMaterializedActivationAsync(ActivationMaterializer.Materialize(args));
+        _redirectedActivations.Attach(Activate);
     }
 
-    internal void Activate(AppActivationArguments args)
+    internal void Activate(ActivationMaterializationResult activation)
     {
-        // Redirected activation data can be backed by a COM proxy to the process
-        // performing the redirect. Materialize it before this callback returns and
-        // that process is allowed to exit.
-        if (!TryMaterializeActivation(args, out MaterializedActivation activation))
-        {
-            return;
-        }
-
         bool enqueued = DispatcherQueue.TryEnqueue(async () =>
         {
-            await ActivateAsync(activation);
+            await HandleMaterializedActivationAsync(activation);
         });
 
         if (!enqueued)
@@ -74,35 +73,22 @@ public partial class App : Microsoft.UI.Xaml.Application
         }
     }
 
-    private bool TryMaterializeActivation(
-        AppActivationArguments args,
-        out MaterializedActivation activation)
+    private async Task HandleMaterializedActivationAsync(ActivationMaterializationResult result)
     {
-        try
+        if (result.Activation is MaterializedActivation activation)
         {
-            ExtendedActivationKind kind = args.Kind;
-            Uri? protocolUri = null;
-
-            if (kind == ExtendedActivationKind.Protocol)
-            {
-                if (args.Data is not global::Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs protocolArgs)
-                {
-                    ServiceProvider.GetService<ILogService>().LogWarning("Protocol activation data is not of expected type.");
-                    activation = default;
-                    return false;
-                }
-
-                protocolUri = new Uri(protocolArgs.Uri.AbsoluteUri);
-            }
-
-            activation = new MaterializedActivation(kind, protocolUri);
-            return true;
+            await ActivateAsync(activation);
+            return;
         }
-        catch (Exception e)
+
+        string message = result.FailureMessage ?? "Activation data is unavailable.";
+        if (result.FailureException is Exception exception)
         {
-            ServiceProvider.GetService<ILogService>().LogException(e, "Failed to read activation data.");
-            activation = default;
-            return false;
+            ServiceProvider.GetService<ILogService>().LogException(exception, message);
+        }
+        else
+        {
+            ServiceProvider.GetService<ILogService>().LogWarning(message);
         }
     }
 
@@ -138,8 +124,4 @@ public partial class App : Microsoft.UI.Xaml.Application
             ServiceProvider.GetService<ILogService>().LogException(e, "Activation failed.");
         }
     }
-
-    private readonly record struct MaterializedActivation(
-        ExtendedActivationKind Kind,
-        Uri? ProtocolUri);
 }

--- a/src/CaptureTool.Presentation.Windows.WinUI/Program.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Program.cs
@@ -1,3 +1,5 @@
+using CaptureTool.Presentation.Activation;
+using CaptureTool.Presentation.Windows.WinUI.Activation;
 using CaptureTool.Presentation.Windows.WinUI.UiTests;
 using Microsoft.UI.Dispatching;
 using Microsoft.Win32.SafeHandles;
@@ -18,6 +20,7 @@ public class Program
     public static int Main(string[] args)
     {
         UiTestLaunchOptions.Initialize(args);
+        var redirectedActivations = new StartupActivationQueue<ActivationMaterializationResult>();
 
         // Initialize COM wrappers and single-instance
         WinRT.ComWrappersSupport.InitializeComWrappers();
@@ -31,8 +34,10 @@ public class Program
                 return 0;
             }
 
-            // Subscribe before app startup
-            instance.Activated += (_, e) => App.Current.Activate(e);
+            // Materialize redirected data before the redirecting process can exit,
+            // then retain it until the primary launch and UI dispatcher are ready.
+            instance.Activated += (_, e) => redirectedActivations.Enqueue(
+                ActivationMaterializer.Materialize(e));
         }
 
         // Start WinUI app
@@ -41,7 +46,7 @@ public class Program
             SynchronizationContext.SetSynchronizationContext(
                 new DispatcherQueueSynchronizationContext(
                     DispatcherQueue.GetForCurrentThread()));
-            var app = new App();
+            var app = new App(redirectedActivations);
         });
 
         return 0;

--- a/src/CaptureTool.Presentation/Activation/StartupActivationQueue.cs
+++ b/src/CaptureTool.Presentation/Activation/StartupActivationQueue.cs
@@ -1,0 +1,96 @@
+namespace CaptureTool.Presentation.Activation;
+
+internal sealed class StartupActivationQueue<T>
+{
+    private readonly Lock _lock = new();
+    private readonly Queue<T> _pending = [];
+    private Action<T>? _consumer;
+    private bool _isDraining;
+
+    public void Enqueue(T activation)
+    {
+        bool shouldDrain;
+        lock (_lock)
+        {
+            _pending.Enqueue(activation);
+            shouldDrain = TryBeginDrain();
+        }
+
+        if (shouldDrain)
+        {
+            Drain();
+        }
+    }
+
+    public void Attach(Action<T> consumer)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+
+        bool shouldDrain;
+        lock (_lock)
+        {
+            if (_consumer is not null)
+            {
+                throw new InvalidOperationException("An activation consumer is already attached.");
+            }
+
+            _consumer = consumer;
+            shouldDrain = TryBeginDrain();
+        }
+
+        if (shouldDrain)
+        {
+            Drain();
+        }
+    }
+
+    private bool TryBeginDrain()
+    {
+        if (_consumer is null || _isDraining || _pending.Count == 0)
+        {
+            return false;
+        }
+
+        _isDraining = true;
+        return true;
+    }
+
+    private void Drain()
+    {
+        while (true)
+        {
+            T activation;
+            Action<T> consumer;
+            lock (_lock)
+            {
+                if (_pending.Count == 0)
+                {
+                    _isDraining = false;
+                    return;
+                }
+
+                activation = _pending.Peek();
+                consumer = _consumer!;
+            }
+
+            try
+            {
+                consumer(activation);
+            }
+            catch
+            {
+                lock (_lock)
+                {
+                    _isDraining = false;
+                }
+
+                throw;
+            }
+
+            lock (_lock)
+            {
+                _pending.Dequeue();
+            }
+        }
+    }
+}

--- a/src/CaptureTool.Presentation/Properties/AssemblyInfo.cs
+++ b/src/CaptureTool.Presentation/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("CaptureTool.Presentation.Tests")]
+[assembly: InternalsVisibleTo("CaptureTool.Presentation.Windows.WinUI")]

--- a/tests/CaptureTool.Presentation.Tests/Activation/StartupActivationQueueTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Activation/StartupActivationQueueTests.cs
@@ -1,0 +1,119 @@
+using CaptureTool.Presentation.Activation;
+using FluentAssertions;
+
+namespace CaptureTool.Presentation.Tests.Activation;
+
+[TestClass]
+public sealed class StartupActivationQueueTests
+{
+    [TestMethod]
+    public void PrimaryStartup_WithImmediateRedirect_HandlesPrimaryBeforeRedirect()
+    {
+        var queue = new StartupActivationQueue<string>();
+        List<string> handled = [];
+
+        queue.Enqueue("redirected protocol");
+        handled.Add("primary launch");
+        queue.Attach(handled.Add);
+
+        handled.Should().Equal("primary launch", "redirected protocol");
+    }
+
+    [TestMethod]
+    public void Attach_WithMultiplePendingActivations_DrainsInFifoOrder()
+    {
+        var queue = new StartupActivationQueue<int>();
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+        queue.Enqueue(3);
+        List<int> handled = [];
+
+        queue.Attach(handled.Add);
+
+        handled.Should().Equal(1, 2, 3);
+    }
+
+    [TestMethod]
+    public void Enqueue_DuringDrain_DoesNotOvertakePendingActivations()
+    {
+        var queue = new StartupActivationQueue<int>();
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+        List<int> handled = [];
+
+        queue.Attach(activation =>
+        {
+            handled.Add(activation);
+            if (activation == 1)
+            {
+                queue.Enqueue(3);
+            }
+        });
+
+        handled.Should().Equal(1, 2, 3);
+    }
+
+    [TestMethod]
+    public async Task Enqueue_ConcurrentWithDrain_DoesNotLoseOrOvertakeActivation()
+    {
+        var queue = new StartupActivationQueue<int>();
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+        List<int> handled = [];
+        var firstActivationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowDrainToContinue = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task attachTask = Task.Run(() => queue.Attach(activation =>
+        {
+            handled.Add(activation);
+            if (activation == 1)
+            {
+                firstActivationStarted.SetResult(true);
+                allowDrainToContinue.Task.GetAwaiter().GetResult();
+            }
+        }));
+
+        await firstActivationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Run(() => queue.Enqueue(3)).WaitAsync(TimeSpan.FromSeconds(5));
+        allowDrainToContinue.SetResult(true);
+        await attachTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        handled.Should().Equal(1, 2, 3);
+    }
+
+    [TestMethod]
+    public void Attach_WhenConsumerIsAlreadyAttached_FailsExplicitly()
+    {
+        var queue = new StartupActivationQueue<int>();
+        queue.Attach(_ => { });
+
+        Action attachAgain = () => queue.Attach(_ => { });
+
+        attachAgain.Should().Throw<InvalidOperationException>();
+    }
+
+    [TestMethod]
+    public void ConsumerFailure_RetainsActivationAheadOfLaterWork()
+    {
+        var queue = new StartupActivationQueue<int>();
+        queue.Enqueue(1);
+        List<int> handled = [];
+        bool shouldFail = true;
+
+        Action attach = () => queue.Attach(activation =>
+        {
+            if (shouldFail)
+            {
+                shouldFail = false;
+                throw new InvalidOperationException("Consumer is unavailable.");
+            }
+
+            handled.Add(activation);
+        });
+
+        attach.Should().Throw<InvalidOperationException>();
+        queue.Enqueue(2);
+
+        handled.Should().Equal(1, 2);
+    }
+}


### PR DESCRIPTION
## Summary

- add the ARCH-07 PRD for startup-safe redirected activation
- materialize redirected `AppActivationArguments` inside the lifecycle callback before the secondary process can exit
- queue materialized activations until the primary launch completes and the WinUI dispatcher consumer is attached
- preserve FIFO order across startup, reentrant, and concurrent arrivals
- add regression coverage for immediate redirect, ordering, concurrent enqueue, duplicate attachment, and consumer failure

## Why

The primary `AppInstance.Activated` callback was registered before WinUI constructed `App`, but it immediately called `App.Current.Activate(e)`. A redirect during that startup window could dereference a nonexistent application or lose its activation data.

The callback now has no dependency on `Application.Current`. It copies the durable activation values immediately and places them in an ordered queue. `App.OnLaunched` handles the primary activation first, then attaches its dispatcher-backed consumer and drains redirects.

Fixes #412.

## User and developer impact

An immediately launched secondary instance can safely redirect a protocol activation while the primary process is still starting. Activations are processed once and in order, and malformed argument or dispatcher failures remain visible through normal application logging.

## Validation

- 669 non-UI tests passed across all six non-UI test projects
- `CaptureTool.Presentation.Tests`: 154 passed, including six new startup queue regressions
- WinUI x64 Debug project build: succeeded with 0 warnings and 0 errors
- formatting/analyzer verification passed for the changed Presentation, Presentation.Tests, and WinUI projects
