### PR TITLE
Clip cross-monitor window selections

### DIFF
--- a/docs/prd-414-cross-monitor-window-selection.md
+++ b/docs/prd-414-cross-monitor-window-selection.md
@@ -1,0 +1,109 @@
+# PRD: Clip cross-monitor window selections and preserve window identity
+
+- Issue: [#414](https://github.com/shanebweaver/CaptureTool/issues/414)
+- Finding: `ARCH-09`
+- Severity: Medium
+- Status: Proposed
+- Affected features: `CAP-01`, `CAP-02`, `CAP-04`
+
+## Summary
+
+Window capture selection must show and submit only the portion of a window that is visible on the monitor hosting the selection overlay. The selected native window handle must travel with that selection as explicit identity rather than being recovered later by comparing rectangles.
+
+The change will centralize physical-screen-to-monitor-canvas projection, clip on all four monitor edges, preserve sub-DIP intersections with deterministic rounding, and carry the handle and area together from the overlay control to the capture request.
+
+## Problem
+
+`SelectionOverlayHost` projects every intersecting native window into monitor-local logical coordinates without first clipping it to the monitor. The overlay control and view model compensate only for negative left and top coordinates. A window crossing the right or bottom edge therefore produces a selection rectangle outside the overlay canvas and can request a crop outside the captured monitor image.
+
+For video window capture, the view model then searches the original window list for a rectangle equal to the completed selection rectangle. Clipping and DPI rounding can change that rectangle, so geometry is not a reliable identifier. A failed match silently produces a zero handle and changes the recording target from a native window to a monitor rectangle.
+
+## Goals
+
+1. Keep every selectable window rectangle within its monitor-local overlay canvas on the left, top, right, and bottom edges.
+2. Preserve visible intersections when physical coordinates map to less than one logical pixel at non-96 DPI.
+3. Carry the native window handle with the completed window selection.
+4. Keep rectangle and full-screen capture selections handle-free.
+5. Make the geometry rules independently testable without a WinUI runtime.
+
+## Non-goals
+
+- Do not change native window enumeration, z-order, or overlap precedence.
+- Do not change the minimum 40-by-40 logical-pixel selection requirement.
+- Do not combine portions of one window across multiple monitor captures.
+- Do not redesign the selection overlay or toolbar.
+- Do not change native window-recording behavior after a valid handle reaches the video workflow.
+
+## Functional requirements
+
+### Monitor projection and clipping
+
+For each monitor/window pair:
+
+1. Intersect the native window's physical screen rectangle with the monitor's physical bounds before projection.
+2. Exclude windows with an empty physical intersection.
+3. Translate the intersection relative to the monitor origin, including monitors with negative desktop coordinates.
+4. Divide physical coordinates by the monitor scale to obtain overlay logical coordinates.
+5. Round leading edges down and trailing edges up so a non-empty physical intersection remains non-empty after projection.
+6. Clamp the result to the monitor's logical canvas bounds on all four edges.
+7. Preserve the original native window handle and title on the projected entry.
+
+The same projected entries must drive pointer hit testing, visual selection, and capture identity. The control must not apply a second, different clipping formula.
+
+### Selection identity
+
+A completed selection must contain:
+
+- the monitor-local logical capture area; and
+- the selected native window handle, or zero for rectangle/full-screen selections.
+
+The view model must update these values atomically. Clearing a selection, changing capture options, or completing a non-window selection must clear any previous window handle. Starting video window capture must use the stored handle directly and must not search by rectangle equality.
+
+### Multi-monitor coordination
+
+When one overlay receives a non-empty selection, the other monitor overlays must clear both their area and selected handle. Existing primary/secondary coordination and all-screens behavior remain unchanged.
+
+## Reliability and edge cases
+
+- Windows crossing the left, top, right, or bottom edge are clipped to the visible monitor portion.
+- Windows crossing two or more edges are clipped on every edge.
+- Monitors with negative desktop origins use the same local coordinates as positive-origin monitors.
+- Mixed-DPI projection cannot create negative sizes or coordinates outside the logical canvas.
+- A one-physical-pixel intersection remains represented by at least one logical pixel before the existing minimum-selection rule is applied.
+- Empty or non-intersecting windows are not selectable on that monitor.
+- Duplicate projected rectangles retain distinct handles; the clicked entry supplies identity.
+
+## Test plan
+
+### Pure geometry tests
+
+- window entirely within a 96-DPI monitor;
+- clipping at each of the four edges;
+- clipping at opposing/corner edges;
+- negative-origin monitor translation;
+- mixed-DPI projection with leading-edge floor and trailing-edge ceiling;
+- one-pixel intersection at each trailing/leading edge;
+- non-intersecting and edge-touching windows are excluded;
+- original handle/title are preserved.
+
+### View-model tests
+
+- window selection sends its explicit handle to video capture even when another window has the same rectangle;
+- rectangle/full-screen selection sends a zero handle;
+- clearing or replacing a selection clears a stale handle;
+- image capture continues to use the selected area.
+
+### Build and regression validation
+
+- run the Presentation test project;
+- run all non-UI test projects;
+- build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [ ] Cross-monitor window selections never extend outside the local overlay canvas.
+- [ ] Left, top, right, bottom, negative-origin, mixed-DPI, and one-pixel intersections have regression coverage.
+- [ ] Window identity is carried explicitly from pointer selection to `NewCaptureArgs`.
+- [ ] Rectangle equality is no longer used to recover a selected handle.
+- [ ] Clearing or changing selections cannot reuse a stale window handle.
+- [ ] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/docs/prd-414-cross-monitor-window-selection.md
+++ b/docs/prd-414-cross-monitor-window-selection.md
@@ -3,7 +3,7 @@
 - Issue: [#414](https://github.com/shanebweaver/CaptureTool/issues/414)
 - Finding: `ARCH-09`
 - Severity: Medium
-- Status: Proposed
+- Status: Implemented
 - Affected features: `CAP-01`, `CAP-02`, `CAP-04`
 
 ## Summary
@@ -101,9 +101,9 @@ When one overlay receives a non-empty selection, the other monitor overlays must
 
 ## Acceptance criteria
 
-- [ ] Cross-monitor window selections never extend outside the local overlay canvas.
-- [ ] Left, top, right, bottom, negative-origin, mixed-DPI, and one-pixel intersections have regression coverage.
-- [ ] Window identity is carried explicitly from pointer selection to `NewCaptureArgs`.
-- [ ] Rectangle equality is no longer used to recover a selected handle.
-- [ ] Clearing or changing selections cannot reuse a stale window handle.
-- [ ] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+- [x] Cross-monitor window selections never extend outside the local overlay canvas.
+- [x] Left, top, right, bottom, negative-origin, mixed-DPI, and one-pixel intersections have regression coverage.
+- [x] Window identity is carried explicitly from pointer selection to `NewCaptureArgs`.
+- [x] Rectangle equality is no longer used to recover a selected handle.
+- [x] Clearing or changing selections cannot reuse a stale window handle.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/SelectionOverlay.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/SelectionOverlay.xaml.cs
@@ -1,4 +1,5 @@
 using CaptureTool.Domain.Capture;
+using CaptureTool.Presentation.Features.SelectionOverlay;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -13,6 +14,7 @@ public sealed partial class SelectionOverlay : UserControlBase
     private Point _newSelectionAnchor;
 
     private Rectangle _selectionRect = Rectangle.Empty;
+    private nint _selectedWindowHandle;
     public Rectangle SelectionRect
     {
         get => _selectionRect;
@@ -40,21 +42,21 @@ public sealed partial class SelectionOverlay : UserControlBase
         }
     }
 
-    private IEnumerable<Rectangle> _windowRects = [];
-    public IEnumerable<Rectangle> WindowRects
+    private IEnumerable<WindowInfo> _windows = [];
+    public IEnumerable<WindowInfo> Windows
     {
-        get => _windowRects;
+        get => _windows;
         set
         {
-            if (_windowRects != value)
+            if (_windows != value)
             {
-                _windowRects = value;
+                _windows = value;
                 RaisePropertyChanged();
             }
         }
     }
 
-    public event EventHandler<Rectangle>? SelectionComplete;
+    public event EventHandler<SelectionOverlaySelection>? SelectionComplete;
 
     public SelectionOverlay()
     {
@@ -94,6 +96,11 @@ public sealed partial class SelectionOverlay : UserControlBase
 
     public void UpdateSelectionRect(Rectangle rect)
     {
+        if (rect.IsEmpty)
+        {
+            _selectedWindowHandle = 0;
+        }
+
         SelectionRect = rect;
         UpdateSelectionBoundary();
     }
@@ -126,6 +133,7 @@ public sealed partial class SelectionOverlay : UserControlBase
             {
                 _isCreatingNewSelection = true;
                 _newSelectionAnchor = pointerPos;
+                _selectedWindowHandle = 0;
 
                 // Start with a 1x1 rectangle at the pointer position
                 UpdateSelectionRect(new Rectangle(
@@ -242,7 +250,8 @@ public sealed partial class SelectionOverlay : UserControlBase
             }
             else
             {
-                SelectionComplete?.Invoke(this, SelectionRect);
+                nint windowHandle = CaptureType == CaptureType.Window ? _selectedWindowHandle : 0;
+                SelectionComplete?.Invoke(this, new SelectionOverlaySelection(SelectionRect, windowHandle));
             }
 
             _isCreatingNewSelection = false;
@@ -274,18 +283,14 @@ public sealed partial class SelectionOverlay : UserControlBase
     {
         var pointerPoint = new System.Drawing.Point((int)pointerPos.X, (int)pointerPos.Y);
 
-        foreach (var windowRect in WindowRects)
+        foreach (WindowInfo window in Windows)
         {
+            Rectangle windowRect = window.Position;
             if (windowRect.Contains(pointerPoint))
             {
-                var adjusted = new Rectangle(
-                    Math.Max(windowRect.X, 0),
-                    Math.Max(windowRect.Y, 0),
-                    windowRect.Width + Math.Min(windowRect.X, 0),
-                    windowRect.Height + Math.Min(windowRect.Y, 0));
-
-                UpdateSelectionRect(adjusted);
-                return IsValidSelection(adjusted);
+                _selectedWindowHandle = window.Handle;
+                UpdateSelectionRect(windowRect);
+                return IsValidSelection(windowRect);
             }
         }
 

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/SelectionOverlayWindowView.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/SelectionOverlayWindowView.xaml.cs
@@ -37,8 +37,8 @@ public sealed partial class SelectionOverlayWindowView : SelectionOverlayWindowV
 
         if (ViewModel.IsLoaded)
         {
-            SelectionOverlay.WindowRects = ViewModel.MonitorWindows;
-            SelectionOverlay.SelectionRect = ViewModel.CaptureArea;
+            SelectionOverlay.Windows = ViewModel.MonitorWindows;
+            SelectionOverlay.UpdateSelectionRect(ViewModel.CaptureArea);
 
             CaptureType? selectedCaptureType = ViewModel.GetSelectedCaptureType();
             if (selectedCaptureType != null)
@@ -116,10 +116,10 @@ public sealed partial class SelectionOverlayWindowView : SelectionOverlayWindowV
                 UpdateSelectionOverlayCursor();
                 break;
             case nameof(SelectionOverlayWindowViewModel.CaptureArea):
-                SelectionOverlay.SelectionRect = ViewModel.CaptureArea;
+                SelectionOverlay.UpdateSelectionRect(ViewModel.CaptureArea);
                 break;
             case nameof(SelectionOverlayWindowViewModel.MonitorWindows):
-                SelectionOverlay.WindowRects = ViewModel.MonitorWindows;
+                SelectionOverlay.Windows = ViewModel.MonitorWindows;
                 break;
         }
     }
@@ -148,11 +148,11 @@ public sealed partial class SelectionOverlayWindowView : SelectionOverlayWindowV
         };
     }
 
-    private void SelectionOverlay_SelectionComplete(object? _, Rectangle captureArea)
+    private void SelectionOverlay_SelectionComplete(object? _, SelectionOverlaySelection selection)
     {
-        ViewModel.UpdateCaptureAreaCommand.Execute(captureArea);
+        ViewModel.UpdateSelectionCommand.Execute(selection);
 
-        if (captureArea.Height >= 40 && captureArea.Width >= 40)
+        if (selection.Area.Height >= 40 && selection.Area.Width >= 40)
         {
             ViewModel.RequestCaptureCommand.Execute(_);
         }

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/SelectionOverlayHost.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/SelectionOverlayHost.cs
@@ -3,7 +3,6 @@ using CaptureTool.Infrastructure.Capture.Windows;
 using CaptureTool.Presentation.Features.SelectionOverlay;
 using CaptureTool.Presentation.Windows.WinUI.Utils;
 using Microsoft.UI.Xaml;
-using System.Drawing;
 using Windows.Win32;
 
 namespace CaptureTool.Presentation.Windows.WinUI.Xaml.Windows;
@@ -57,23 +56,16 @@ internal sealed partial class SelectionOverlayHost : IDisposable
 
             _monitors.Add(monitor);
 
-            // Scale window dimensions per monitor.
-            Rectangle monitorBounds = monitor.MonitorBounds;
-            float scale = monitor.Scale;
-            IEnumerable<WindowInfo> monitorWindows = allWindows
-                .Where(w =>
-                    monitorBounds.IntersectsWith(w.Position) ||
-                    monitorBounds.Contains(w.Position))
-                .Select(w => new WindowInfo(
-                    w.Handle,
-                    w.Title,
-                    new Rectangle(
-                        (int)((w.Position.X - monitorBounds.X) / scale),
-                        (int)((w.Position.Y - monitorBounds.Y) / scale),
-                        (int)(w.Position.Width / scale),
-                        (int)(w.Position.Height / scale))));
+            List<WindowInfo> monitorWindows = [];
+            foreach (WindowInfo candidateWindow in allWindows)
+            {
+                if (SelectionOverlayWindowGeometry.TryProjectToMonitor(candidateWindow, monitor, out WindowInfo projectedWindow))
+                {
+                    monitorWindows.Add(projectedWindow);
+                }
+            }
 
-            SelectionOverlayWindowOptions overlayOptions = new(monitor, [.. monitorWindows], options);
+            SelectionOverlayWindowOptions overlayOptions = new(monitor, monitorWindows, options);
             SelectionOverlayWindow window = new(overlayOptions);
             _windows.Add(window);
 

--- a/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayHostViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayHostViewModel.cs
@@ -199,7 +199,7 @@ public sealed partial class SelectionOverlayHostViewModel : ViewModelBase
             if (ReferenceEquals(target, windowVM))
                 continue;
 
-            target.UpdateCaptureAreaCommand.Execute(Rectangle.Empty);
+            target.UpdateSelectionCommand.Execute(SelectionOverlaySelection.Empty);
         }
     }
 
@@ -215,7 +215,7 @@ public sealed partial class SelectionOverlayHostViewModel : ViewModelBase
             if (ReferenceEquals(target, windowVM))
                 continue;
 
-            target.UpdateCaptureAreaCommand.Execute(Rectangle.Empty);
+            target.UpdateSelectionCommand.Execute(SelectionOverlaySelection.Empty);
         }
     }
 }

--- a/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlaySelection.cs
+++ b/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlaySelection.cs
@@ -1,0 +1,8 @@
+using System.Drawing;
+
+namespace CaptureTool.Presentation.Features.SelectionOverlay;
+
+public readonly record struct SelectionOverlaySelection(Rectangle Area, nint WindowHandle = 0)
+{
+    public static SelectionOverlaySelection Empty { get; } = new(Rectangle.Empty);
+}

--- a/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayWindowGeometry.cs
+++ b/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayWindowGeometry.cs
@@ -1,0 +1,71 @@
+using CaptureTool.Domain.Capture;
+using System.Drawing;
+
+namespace CaptureTool.Presentation.Features.SelectionOverlay;
+
+public static class SelectionOverlayWindowGeometry
+{
+    public static bool TryProjectToMonitor(
+        WindowInfo window,
+        MonitorCaptureResult monitor,
+        out WindowInfo projectedWindow)
+    {
+        if (monitor.Scale <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(monitor), "Monitor scale must be greater than zero.");
+        }
+
+        Rectangle intersection = Rectangle.Intersect(window.Position, monitor.MonitorBounds);
+        if (intersection.Width <= 0 || intersection.Height <= 0)
+        {
+            projectedWindow = default;
+            return false;
+        }
+
+        int canvasWidth = Math.Max(1, (int)Math.Floor(monitor.MonitorBounds.Width / monitor.Scale));
+        int canvasHeight = Math.Max(1, (int)Math.Floor(monitor.MonitorBounds.Height / monitor.Scale));
+
+        int left = ProjectLeadingEdge(intersection.Left - monitor.MonitorBounds.Left, monitor.Scale, canvasWidth);
+        int top = ProjectLeadingEdge(intersection.Top - monitor.MonitorBounds.Top, monitor.Scale, canvasHeight);
+        int right = ProjectTrailingEdge(intersection.Right - monitor.MonitorBounds.Left, monitor.Scale, canvasWidth);
+        int bottom = ProjectTrailingEdge(intersection.Bottom - monitor.MonitorBounds.Top, monitor.Scale, canvasHeight);
+
+        PreservePhysicalIntersection(ref left, ref right, canvasWidth);
+        PreservePhysicalIntersection(ref top, ref bottom, canvasHeight);
+
+        if (right <= left || bottom <= top)
+        {
+            projectedWindow = default;
+            return false;
+        }
+
+        projectedWindow = new WindowInfo(
+            window.Handle,
+            window.Title,
+            Rectangle.FromLTRB(left, top, right, bottom));
+        return true;
+    }
+
+    private static int ProjectLeadingEdge(int physicalCoordinate, float scale, int logicalLimit)
+        => Math.Clamp((int)Math.Floor(physicalCoordinate / scale), 0, logicalLimit);
+
+    private static int ProjectTrailingEdge(int physicalCoordinate, float scale, int logicalLimit)
+        => Math.Clamp((int)Math.Ceiling(physicalCoordinate / scale), 0, logicalLimit);
+
+    private static void PreservePhysicalIntersection(ref int leadingEdge, ref int trailingEdge, int logicalLimit)
+    {
+        if (trailingEdge > leadingEdge)
+        {
+            return;
+        }
+
+        if (trailingEdge == logicalLimit)
+        {
+            leadingEdge = Math.Max(0, logicalLimit - 1);
+        }
+        else
+        {
+            trailingEdge = Math.Min(logicalLimit, leadingEdge + 1);
+        }
+    }
+}

--- a/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayWindowViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/SelectionOverlay/SelectionOverlayWindowViewModel.cs
@@ -40,7 +40,7 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
     public IAsyncRelayCommand CloseOverlayCommand { get; }
     public IRelayCommand<(int Index, SelectionUpdateSource Source)> UpdateSelectedCaptureModeCommand { get; }
     public IRelayCommand<(int Index, SelectionUpdateSource Source)> UpdateSelectedCaptureTypeCommand { get; }
-    public IRelayCommand<Rectangle> UpdateCaptureAreaCommand { get; }
+    public IRelayCommand<SelectionOverlaySelection> UpdateSelectionCommand { get; }
     public IRelayCommand<CaptureOptions> UpdateCaptureOptionsCommand { get; }
 
     public event EventHandler<CaptureOptions>? CaptureOptionsUpdated;
@@ -117,17 +117,17 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         private set => Set(ref field, value);
     }
 
-    public IList<Rectangle> MonitorWindows
+    public IList<WindowInfo> MonitorWindows
     {
         get;
         private set => Set(ref field, value);
     }
 
-    private IList<WindowInfo> WindowInfos
+    public nint SelectedWindowHandle
     {
         get;
-        set;
-    } = [];
+        private set => Set(ref field, value);
+    }
 
     public AppTheme CurrentAppTheme
     {
@@ -180,7 +180,7 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         CloseOverlayCommand = new AsyncRelayCommand(CloseOverlayAsync, AsyncRelayCommandOptions.FlowExceptionsToTaskScheduler);
         UpdateSelectedCaptureModeCommand = new RelayCommand<(int Index, SelectionUpdateSource Source)>(UpdateSelectedCaptureMode);
         UpdateSelectedCaptureTypeCommand = new RelayCommand<(int Index, SelectionUpdateSource Source)>(UpdateSelectedCaptureType);
-        UpdateCaptureAreaCommand = new RelayCommand<Rectangle>(UpdateCaptureArea);
+        UpdateSelectionCommand = new RelayCommand<SelectionOverlaySelection>(UpdateSelection);
         UpdateCaptureOptionsCommand = new RelayCommand<CaptureOptions>(UpdateCaptureOptions);
 
         CaptureModeViewModel imageModeVM = captureModeViewModelFactory.Create(CaptureMode.Image);
@@ -198,8 +198,7 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         StartLoading();
 
         Monitor = options.Monitor;
-        WindowInfos = [.. options.MonitorWindows];
-        MonitorWindows = [.. WindowInfos.Select(w => w.Position)];
+        MonitorWindows = [.. options.MonitorWindows];
 
         var targetMode = SupportedCaptureModes.First(vm => vm.CaptureMode == options.CaptureOptions.CaptureMode);
         UpdateSelectedCaptureMode((_supportedCaptureModes.IndexOf(targetMode), SelectionUpdateSource.Programmatic));
@@ -229,9 +228,10 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         }
     }
 
-    private void UpdateCaptureArea(Rectangle area)
+    private void UpdateSelection(SelectionOverlaySelection selection)
     {
-        CaptureArea = area;
+        SelectedWindowHandle = selection.Area.IsEmpty ? 0 : selection.WindowHandle;
+        CaptureArea = selection.Area;
     }
 
     private void UpdateCaptureOptions(CaptureOptions options)
@@ -242,7 +242,7 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         var targetType = SupportedCaptureTypes.First(vm => vm.CaptureType == options.CaptureType);
         UpdateSelectedCaptureType((_supportedCaptureTypes.IndexOf(targetType), SelectionUpdateSource.Programmatic));
 
-        UpdateCaptureArea(Rectangle.Empty);
+        UpdateSelection(SelectionOverlaySelection.Empty);
 
         CaptureOptionsUpdated?.Invoke(this, options);
     }
@@ -330,28 +330,10 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         else if (SupportedCaptureModes[SelectedCaptureModeIndex].CaptureMode == CaptureMode.Video)
         {
             CaptureType captureType = GetSelectedCaptureType() ?? CaptureType.FullScreen;
-            NewCaptureArgs args = new(Monitor.Value, CaptureArea, captureType, GetSelectedWindowHandle(captureType, CaptureArea));
+            nint windowHandle = captureType == CaptureType.Window ? SelectedWindowHandle : 0;
+            NewCaptureArgs args = new(Monitor.Value, CaptureArea, captureType, windowHandle);
             await _openVideoCaptureOverlayCommand.ExecuteAsync(new OpenCaptureOverlayRequest(args), CancellationToken.None);
         }
-    }
-
-    private nint GetSelectedWindowHandle(CaptureType captureType, Rectangle captureArea)
-    {
-        if (captureType != CaptureType.Window)
-        {
-            return 0;
-        }
-
-        return WindowInfos.FirstOrDefault(w => GetSelectableWindowRectangle(w.Position) == captureArea).Handle;
-    }
-
-    private static Rectangle GetSelectableWindowRectangle(Rectangle windowRect)
-    {
-        return new Rectangle(
-            Math.Max(windowRect.X, 0),
-            Math.Max(windowRect.Y, 0),
-            windowRect.Width + Math.Min(windowRect.X, 0),
-            windowRect.Height + Math.Min(windowRect.Y, 0));
     }
 
     public override void Dispose()
@@ -359,6 +341,7 @@ public sealed partial class SelectionOverlayWindowViewModel : LoadableViewModelB
         // Explicitly null Monitor to release the ~100MB PixelBuffer reference
         Monitor = null;
         MonitorWindows = [];
+        SelectedWindowHandle = 0;
 
         // Clear collections to release any remaining references
         _supportedCaptureTypes.Clear();

--- a/tests/CaptureTool.Presentation.Tests/Features/SelectionOverlayWindowGeometryTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/SelectionOverlayWindowGeometryTests.cs
@@ -1,0 +1,124 @@
+using CaptureTool.Domain.Capture;
+using CaptureTool.Presentation.Features.SelectionOverlay;
+using System.Drawing;
+
+namespace CaptureTool.Presentation.Tests.Features;
+
+[TestClass]
+public sealed class SelectionOverlayWindowGeometryTests
+{
+    [TestMethod]
+    public void TryProjectToMonitor_WindowInsideMonitor_TranslatesToMonitorCoordinates()
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(100, 200, 800, 600));
+        WindowInfo window = new(42, "inside", new Rectangle(250, 350, 200, 100));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsTrue(projected);
+        Assert.AreEqual(new Rectangle(150, 150, 200, 100), result.Position);
+        Assert.AreEqual((nint)42, result.Handle);
+        Assert.AreEqual("inside", result.Title);
+    }
+
+    [TestMethod]
+    [DataRow(-20, 20, 120, 60, 0, 20, 100, 60)]
+    [DataRow(20, -20, 60, 120, 20, 0, 60, 100)]
+    [DataRow(750, 20, 100, 60, 750, 20, 50, 60)]
+    [DataRow(20, 550, 60, 100, 20, 550, 60, 50)]
+    public void TryProjectToMonitor_WindowCrossesOneEdge_ClipsToCanvas(
+        int x,
+        int y,
+        int width,
+        int height,
+        int expectedX,
+        int expectedY,
+        int expectedWidth,
+        int expectedHeight)
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(0, 0, 800, 600));
+        WindowInfo window = new(1, "edge", new Rectangle(x, y, width, height));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsTrue(projected);
+        Assert.AreEqual(new Rectangle(expectedX, expectedY, expectedWidth, expectedHeight), result.Position);
+    }
+
+    [TestMethod]
+    public void TryProjectToMonitor_WindowCrossesEveryEdge_ClipsToEntireCanvas()
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(0, 0, 800, 600));
+        WindowInfo window = new(1, "large", new Rectangle(-20, -30, 850, 660));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsTrue(projected);
+        Assert.AreEqual(new Rectangle(0, 0, 800, 600), result.Position);
+    }
+
+    [TestMethod]
+    public void TryProjectToMonitor_NegativeMonitorOrigin_TranslatesVisibleIntersection()
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(-1920, -200, 1920, 1080));
+        WindowInfo window = new(1, "negative", new Rectangle(-2000, -250, 200, 200));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsTrue(projected);
+        Assert.AreEqual(new Rectangle(0, 0, 120, 150), result.Position);
+    }
+
+    [TestMethod]
+    public void TryProjectToMonitor_MixedDpi_RoundsLeadingEdgesDownAndTrailingEdgesUp()
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(1000, 0, 1500, 900), dpi: 144);
+        WindowInfo window = new(1, "scaled", new Rectangle(1001, 1, 3, 3));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsTrue(projected);
+        Assert.AreEqual(new Rectangle(0, 0, 3, 3), result.Position);
+    }
+
+    [TestMethod]
+    [DataRow(-10, 100, 11, 100, 0, 66, 1, 68)]
+    [DataRow(1499, 100, 11, 100, 999, 66, 1, 68)]
+    [DataRow(100, -10, 100, 11, 66, 0, 68, 1)]
+    [DataRow(100, 899, 100, 11, 66, 599, 68, 1)]
+    public void TryProjectToMonitor_OnePhysicalPixelIntersection_RemainsRepresented(
+        int x,
+        int y,
+        int width,
+        int height,
+        int expectedX,
+        int expectedY,
+        int expectedWidth,
+        int expectedHeight)
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(0, 0, 1500, 900), dpi: 144);
+        WindowInfo window = new(1, "one pixel", new Rectangle(x, y, width, height));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsTrue(projected);
+        Assert.AreEqual(new Rectangle(expectedX, expectedY, expectedWidth, expectedHeight), result.Position);
+    }
+
+    [TestMethod]
+    [DataRow(1500, 0)]
+    [DataRow(-100, 0)]
+    public void TryProjectToMonitor_WindowDoesNotOverlap_ReturnsFalse(int x, int y)
+    {
+        MonitorCaptureResult monitor = CreateMonitor(new Rectangle(0, 0, 1500, 900), dpi: 144);
+        WindowInfo window = new(1, "outside", new Rectangle(x, y, 100, 100));
+
+        bool projected = SelectionOverlayWindowGeometry.TryProjectToMonitor(window, monitor, out WindowInfo result);
+
+        Assert.IsFalse(projected);
+        Assert.AreEqual(default, result);
+    }
+
+    private static MonitorCaptureResult CreateMonitor(Rectangle bounds, uint dpi = 96)
+        => new(1, [], dpi, bounds, bounds, true);
+}

--- a/tests/CaptureTool.Presentation.Tests/Features/SelectionOverlayWindowViewModelTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/SelectionOverlayWindowViewModelTests.cs
@@ -96,9 +96,80 @@ public sealed class SelectionOverlayWindowViewModelTests
         shutdownHandler.Verify(handler => handler.Shutdown(), Times.Once);
     }
 
+    [TestMethod]
+    public async Task RequestCaptureCommand_WindowSelection_UsesExplicitWindowHandle()
+    {
+        var openCaptureOverlay = new Mock<IOpenCaptureOverlayUseCase>();
+        OpenCaptureOverlayRequest? capturedRequest = null;
+        openCaptureOverlay
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<OpenCaptureOverlayRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<OpenCaptureOverlayRequest, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(UseCaseResponse<OpenCaptureOverlayResponse>.Success(new OpenCaptureOverlayResponse()));
+        Rectangle duplicateArea = new(20, 30, 400, 300);
+        WindowInfo[] windows =
+        [
+            new WindowInfo(111, "first", duplicateArea),
+            new WindowInfo(222, "second", duplicateArea),
+        ];
+        SelectionOverlayWindowViewModel viewModel = CreateViewModel(openCaptureOverlay: openCaptureOverlay);
+        viewModel.Load(CreateOptions(CaptureOptions.VideoDefault, windows));
+        viewModel.UpdateSelectedCaptureTypeCommand.Execute((1, SelectionUpdateSource.UserInteraction));
+        viewModel.UpdateSelectionCommand.Execute(new SelectionOverlaySelection(duplicateArea, 222));
+
+        await viewModel.RequestCaptureCommand.ExecuteAsync(null);
+
+        Assert.IsNotNull(capturedRequest);
+        Assert.AreEqual(CaptureType.Window, capturedRequest.CaptureArgs.CaptureType);
+        Assert.AreEqual(duplicateArea, capturedRequest.CaptureArgs.Area);
+        Assert.AreEqual((nint)222, capturedRequest.CaptureArgs.WindowHandle);
+    }
+
+    [TestMethod]
+    public async Task RequestCaptureCommand_NonWindowSelection_DoesNotReuseWindowHandle()
+    {
+        var openCaptureOverlay = new Mock<IOpenCaptureOverlayUseCase>();
+        OpenCaptureOverlayRequest? capturedRequest = null;
+        openCaptureOverlay
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<OpenCaptureOverlayRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<OpenCaptureOverlayRequest, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(UseCaseResponse<OpenCaptureOverlayResponse>.Success(new OpenCaptureOverlayResponse()));
+        SelectionOverlayWindowViewModel viewModel = CreateViewModel(openCaptureOverlay: openCaptureOverlay);
+        viewModel.Load(CreateOptions(CaptureOptions.VideoDefault));
+        viewModel.UpdateSelectionCommand.Execute(new SelectionOverlaySelection(new Rectangle(20, 30, 400, 300), 222));
+
+        await viewModel.RequestCaptureCommand.ExecuteAsync(null);
+
+        Assert.IsNotNull(capturedRequest);
+        Assert.AreEqual(CaptureType.FullScreen, capturedRequest.CaptureArgs.CaptureType);
+        Assert.AreEqual(nint.Zero, capturedRequest.CaptureArgs.WindowHandle);
+    }
+
+    [TestMethod]
+    public void UpdateSelectionCommand_ClearingOrReplacingSelection_ClearsWindowHandle()
+    {
+        SelectionOverlayWindowViewModel viewModel = CreateViewModel();
+        viewModel.Load(CreateOptions(CaptureOptions.VideoDefault));
+        viewModel.UpdateSelectionCommand.Execute(new SelectionOverlaySelection(new Rectangle(20, 30, 400, 300), 222));
+
+        viewModel.UpdateSelectionCommand.Execute(SelectionOverlaySelection.Empty);
+
+        Assert.AreEqual(Rectangle.Empty, viewModel.CaptureArea);
+        Assert.AreEqual(nint.Zero, viewModel.SelectedWindowHandle);
+
+        viewModel.UpdateSelectionCommand.Execute(new SelectionOverlaySelection(new Rectangle(40, 50, 500, 400)));
+
+        Assert.AreEqual(new Rectangle(40, 50, 500, 400), viewModel.CaptureArea);
+        Assert.AreEqual(nint.Zero, viewModel.SelectedWindowHandle);
+    }
+
     private static SelectionOverlayWindowViewModel CreateViewModel(
         Mock<IShowMainWindowUseCase>? showMainWindow = null,
-        Mock<IShutdownHandler>? shutdownHandler = null)
+        Mock<IShutdownHandler>? shutdownHandler = null,
+        Mock<IOpenCaptureOverlayUseCase>? openCaptureOverlay = null)
     {
         Mock<ILocalizationService> localizationService = new();
         localizationService
@@ -111,7 +182,7 @@ public sealed class SelectionOverlayWindowViewModelTests
 
         return new SelectionOverlayWindowViewModel(
             Mock.Of<IOpenImageEditPageUseCase>(),
-            Mock.Of<IOpenCaptureOverlayUseCase>(),
+            openCaptureOverlay?.Object ?? Mock.Of<IOpenCaptureOverlayUseCase>(),
             showMainWindow?.Object ?? Mock.Of<IShowMainWindowUseCase>(),
             Mock.Of<ICaptureImageUseCase>(),
             themeService.Object,
@@ -120,7 +191,9 @@ public sealed class SelectionOverlayWindowViewModelTests
             new CaptureTypeViewModelFactory(localizationService.Object));
     }
 
-    private static SelectionOverlayWindowOptions CreateOptions(CaptureOptions captureOptions)
+    private static SelectionOverlayWindowOptions CreateOptions(
+        CaptureOptions captureOptions,
+        IEnumerable<WindowInfo>? windows = null)
     {
         MonitorCaptureResult monitor = new(
             IntPtr.Zero,
@@ -130,6 +203,6 @@ public sealed class SelectionOverlayWindowViewModelTests
             new Rectangle(0, 0, 1920, 1080),
             true);
 
-        return new SelectionOverlayWindowOptions(monitor, [], captureOptions);
+        return new SelectionOverlayWindowOptions(monitor, windows ?? [], captureOptions);
     }
 }


### PR DESCRIPTION
## Summary

- clip native window bounds against each monitor before projecting them into overlay coordinates
- preserve small mixed-DPI intersections with deterministic leading/trailing edge rounding
- carry the selected window handle with the completed selection instead of recovering identity by rectangle equality
- clear stale window identity when selections are cleared or a non-window capture is requested
- document the behavior in the ARCH-09 PRD and add edge-focused regression coverage

## Root cause

Cross-monitor windows were projected without first intersecting them with the monitor. The overlay and view model only corrected negative left/top values, leaving right/bottom overflow possible. Video capture then recovered a native handle by comparing the resulting rectangle to the original projected rectangle, which failed after clipping or DPI rounding and silently fell back to rectangle capture.

## Impact

Window selections now stay within the monitor-local overlay on all four edges. Duplicate or rounded rectangles no longer lose native window identity because the clicked window's handle travels with the selected area.

## Validation

- 676 non-UI Release tests passed
  - Application: 309
  - Capture Windows: 21
  - Edit Windows: 35
  - Infrastructure: 131
  - MCP: 17
  - Presentation: 163
- WinUI x64 Debug build succeeded with 0 warnings and 0 errors

Closes #414
