### PR TITLE
Fix video dirty state after save

### DIFF
--- a/docs/prd-417-video-edit-saved-snapshot.md
+++ b/docs/prd-417-video-edit-saved-snapshot.md
@@ -1,0 +1,101 @@
+# PRD: Video Dirty State Relative to Last Save
+
+- Issue: [#417](https://github.com/shanebweaver/CaptureTool/issues/417)
+- Architecture finding: `ARCH-12`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `APP-07`, `VID-02`, `VID-03`
+
+## Summary
+
+The video editor must derive `HasUnsavedChanges` by comparing the current edit state with the state captured at load or the last successful save. The saved state consists of the normalized trim range and active video variant (original or super-resolution).
+
+## Problem
+
+The current dirty-state calculation is relative to the original video. A successful save sets `HasUnsavedChanges` to false, but later trim changes recompute it as `IsTrimmed || IsVideoSuperResolutionActive`. This loses the saved baseline.
+
+After saving a trimmed range, restoring the full original range incorrectly reports a clean session even though the visible output differs from the last save. Conversely, returning to the saved trimmed range can remain dirty. Super-resolution tracking has the same problem because it considers generated-file existence or whether the enhanced variant is currently active rather than which variant was last saved.
+
+## Goals
+
+1. Make dirty state relative to the last successful save.
+2. Track trim and original/super-resolution variant changes in one value-semantic snapshot.
+3. Treat returning exactly to the saved state as clean.
+4. Treat switching away from the saved state as dirty, including switching back to the full original range.
+5. Preserve the saved baseline when save fails or is cancelled.
+6. Keep asynchronous video-duration discovery from marking a newly loaded full-range video dirty.
+
+## Non-goals
+
+- Changing video file output, trimming, or super-resolution generation.
+- Persisting edit-session metadata across application restarts.
+- Adding undo/redo to the video editor.
+- Changing copy or external-editor behavior.
+- Changing the existing trim comparison tolerance.
+
+## Functional requirements
+
+### Edit snapshot
+
+1. Add a value-semantic snapshot containing trim start, trim end, and active video variant.
+2. Normalize a full-duration range to no trim values so it remains equivalent as duration metadata is first discovered.
+3. Compare trim values using the existing `TrimComparisonToleranceSeconds` tolerance.
+4. Represent original and super-resolution variants explicitly; generated-file existence is not edit state.
+
+### Baseline lifecycle
+
+1. Capture the baseline after loading a video in its original, full-range state.
+2. Replace the baseline only after `SaveVideoFileResponse.Saved` is true.
+3. Do not replace the baseline after a failed or cancelled save.
+4. Reset the baseline when a different video is loaded.
+
+### Dirty-state derivation
+
+Recompute dirty state after:
+
+- trim start or end changes;
+- trim range reset caused by duration changes;
+- switching to the original variant;
+- generating, reusing, or switching to the super-resolution variant;
+- a successful save.
+
+## User experience
+
+- Saving trim `2s-8s`, then returning to the full `0s-10s` range shows an unsaved-work warning.
+- Returning from another range to the saved `2s-8s` range clears the warning.
+- Saving the enhanced variant makes the original variant dirty; switching back to enhanced clears the warning.
+- Saving the original variant makes enhanced dirty; switching back to original clears the warning.
+- Failed saves leave the existing warning and baseline unchanged.
+
+## Reliability requirements
+
+- Initial media-duration loading must not create a false dirty state.
+- Equivalent floating-point trim positions within the existing tolerance compare as equal.
+- Cached super-resolution output must not make the original variant dirty unless the active variant differs from the saved baseline.
+- Dirty-state updates remain synchronous with user-visible trim and variant properties.
+
+## Test plan
+
+Add focused presentation tests for:
+
+- save trimmed range, then restore full range;
+- save trimmed range, change it, then return to the saved range;
+- save enhanced variant, switch to original, then return to enhanced;
+- save original with enhanced output cached, switch to enhanced, then return to original;
+- failed save retaining the previous baseline;
+- initial duration discovery remaining clean.
+
+Run all non-UI test projects and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] Dirty state is derived from the last loaded or successfully saved edit snapshot.
+- [x] Full-range and saved-range transitions report the correct dirty state.
+- [x] Original and super-resolution saved variants report the correct dirty state.
+- [x] Failed saves do not change the baseline.
+- [x] Initial duration discovery remains clean.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+
+## Rollout
+
+No migration or feature flag is required. The corrected dirty-state calculation applies to video edit sessions immediately.

--- a/src/CaptureTool.Presentation/Features/VideoEdit/VideoEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/VideoEdit/VideoEditPageViewModel.cs
@@ -22,6 +22,35 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
 {
     private const double TrimComparisonToleranceSeconds = 0.01;
 
+    private enum VideoVariant
+    {
+        Original,
+        SuperResolution,
+    }
+
+    private readonly record struct VideoEditSnapshot(
+        double? TrimStartSeconds,
+        double? TrimEndSeconds,
+        VideoVariant Variant)
+    {
+        public bool IsEquivalentTo(VideoEditSnapshot other)
+        {
+            return Variant == other.Variant &&
+                AreEquivalent(TrimStartSeconds, other.TrimStartSeconds) &&
+                AreEquivalent(TrimEndSeconds, other.TrimEndSeconds);
+        }
+
+        private static bool AreEquivalent(double? first, double? second)
+        {
+            if (!first.HasValue || !second.HasValue)
+            {
+                return first.HasValue == second.HasValue;
+            }
+
+            return Math.Abs(first.Value - second.Value) <= TrimComparisonToleranceSeconds;
+        }
+    }
+
     public IAsyncRelayCommand SaveCommand { get; }
     public IAsyncRelayCommand CopyCommand { get; }
     public IAsyncRelayCommand EditInClipchampCommand { get; }
@@ -133,6 +162,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
     private readonly ITelemetryService? _telemetryService;
     private string? _originalVideoPath;
     private string? _superResolutionVideoPath;
+    private VideoEditSnapshot? _savedEditSnapshot;
 
     public string EditSessionName => "video edit session";
 
@@ -197,6 +227,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
 
         _originalVideoPath = video.FilePath;
         _superResolutionVideoPath = null;
+        _savedEditSnapshot = null;
         VideoPath = _originalVideoPath;
         IsVideoSuperResolutionActive = false;
         IsVideoSuperResolutionGenerating = false;
@@ -204,7 +235,8 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         IsVideoSuperResolutionFeatureEnabled =
             _videoSuperResolutionFeatureAvailability.IsVideoSuperResolutionEnabled;
         ResetTrimRange(0);
-        HasUnsavedChanges = false;
+        _savedEditSnapshot = CaptureEditSnapshot();
+        UpdateHasUnsavedChanges();
 
         if (video is PendingVideoFile pendingVideo)
         {
@@ -286,6 +318,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         TrimEndSeconds = durationSeconds;
         PlayheadSeconds = 0;
         RaisePropertyChanged(nameof(IsTrimmed));
+        UpdateHasUnsavedChanges();
     }
 
     private void KeepPlayheadInTrimRange()
@@ -317,7 +350,8 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
                 TrackEditTool("trim", TelemetryOutcomes.Succeeded);
             }
 
-            HasUnsavedChanges = false;
+            _savedEditSnapshot = CaptureEditSnapshot();
+            UpdateHasUnsavedChanges();
             return true;
         }
 
@@ -460,7 +494,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
 
         VideoPath = _originalVideoPath;
         IsVideoSuperResolutionActive = false;
-        HasUnsavedChanges = IsTrimmed || !string.IsNullOrWhiteSpace(_superResolutionVideoPath);
+        UpdateHasUnsavedChanges();
         UpdateVideoSuperResolutionAvailability();
     }
 
@@ -469,7 +503,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         VideoPath = videoPath;
         IsVideoSuperResolutionActive = true;
         VideoSuperResolutionStatusMessage = string.Empty;
-        HasUnsavedChanges = true;
+        UpdateHasUnsavedChanges();
         UpdateVideoSuperResolutionAvailability();
         TrackEditTool("super_resolution", TelemetryOutcomes.Succeeded);
     }
@@ -587,7 +621,23 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
 
     private void OnTrimChanged()
     {
-        HasUnsavedChanges = IsTrimmed || IsVideoSuperResolutionActive;
+        UpdateHasUnsavedChanges();
+    }
+
+    private VideoEditSnapshot CaptureEditSnapshot()
+    {
+        return new VideoEditSnapshot(
+            IsTrimmed ? TrimStartSeconds : null,
+            IsTrimmed ? TrimEndSeconds : null,
+            IsVideoSuperResolutionActive
+                ? VideoVariant.SuperResolution
+                : VideoVariant.Original);
+    }
+
+    private void UpdateHasUnsavedChanges()
+    {
+        HasUnsavedChanges = _savedEditSnapshot.HasValue &&
+            !_savedEditSnapshot.Value.IsEquivalentTo(CaptureEditSnapshot());
     }
 
     private void TrackEditorOpened()

--- a/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelSuperResolutionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelSuperResolutionTests.cs
@@ -181,6 +181,68 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
         viewModel.TrimEndSeconds.Should().Be(8);
     }
 
+    [TestMethod]
+    public async Task SaveEnhancedVariant_ThenSwitchAwayAndBack_ShouldCompareWithSavedVariant()
+    {
+        string enhancedPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.mp4");
+        await File.WriteAllBytesAsync(enhancedPath, [0], TestContext.CancellationToken);
+        try
+        {
+            VideoEditPageViewModel viewModel = CreateViewModel(
+                service: CreateReadyService(enhancedPath),
+                saveAction: CreateSuccessfulSaveAction().Object);
+            viewModel.Load(new VideoFile("source.mp4"));
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+
+            (await viewModel.SaveAsync(TestContext.CancellationToken)).Should().BeTrue();
+            viewModel.HasUnsavedChanges.Should().BeFalse();
+
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+            viewModel.IsVideoSuperResolutionActive.Should().BeFalse();
+            viewModel.HasUnsavedChanges.Should().BeTrue();
+
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+            viewModel.IsVideoSuperResolutionActive.Should().BeTrue();
+            viewModel.HasUnsavedChanges.Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(enhancedPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task SaveOriginalVariant_WithEnhancedVideoCached_ShouldCompareWithSavedVariant()
+    {
+        string enhancedPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.mp4");
+        await File.WriteAllBytesAsync(enhancedPath, [0], TestContext.CancellationToken);
+        try
+        {
+            VideoEditPageViewModel viewModel = CreateViewModel(
+                service: CreateReadyService(enhancedPath),
+                saveAction: CreateSuccessfulSaveAction().Object);
+            viewModel.Load(new VideoFile("source.mp4"));
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+
+            (await viewModel.SaveAsync(TestContext.CancellationToken)).Should().BeTrue();
+            viewModel.IsVideoSuperResolutionActive.Should().BeFalse();
+            viewModel.HasUnsavedChanges.Should().BeFalse();
+
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+            viewModel.IsVideoSuperResolutionActive.Should().BeTrue();
+            viewModel.HasUnsavedChanges.Should().BeTrue();
+
+            await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+            viewModel.IsVideoSuperResolutionActive.Should().BeFalse();
+            viewModel.HasUnsavedChanges.Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(enhancedPath);
+        }
+    }
+
     private static Mock<IVideoSuperResolutionService> CreateReadyService(
         string outputPath,
         VideoSuperResolutionReadyState readyState = VideoSuperResolutionReadyState.Ready)
@@ -195,6 +257,17 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(VideoSuperResolutionResult.Success(new VideoFile(outputPath)));
         return service;
+    }
+
+    private static Mock<ISaveVideoFileUseCase> CreateSuccessfulSaveAction()
+    {
+        var saveAction = new Mock<ISaveVideoFileUseCase>();
+        saveAction
+            .Setup(action => action.ExecuteAsync(
+                It.IsAny<SaveVideoFileRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<SaveVideoFileResponse>.Success(new SaveVideoFileResponse()));
+        return saveAction;
     }
 
     private static VideoEditPageViewModel CreateViewModel(

--- a/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelTrimTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelTrimTests.cs
@@ -185,6 +185,93 @@ public class VideoEditPageViewModelTrimTests
         Assert.IsTrue(viewModel.HasUnsavedChanges);
     }
 
+    [TestMethod]
+    public void SetVideoDuration_AfterLoad_ShouldKeepFullRangeSessionClean()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.Load(new VideoFile("test.mp4"));
+
+        viewModel.SetVideoDuration(TimeSpan.FromSeconds(10));
+
+        Assert.IsFalse(viewModel.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public async Task SaveTrimmedRange_ThenRestoreFullRange_ShouldMarkSessionDirty()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.Load(new VideoFile("test.mp4"));
+        viewModel.SetVideoDuration(TimeSpan.FromSeconds(10));
+        viewModel.UpdateTrimStart(2);
+        viewModel.UpdateTrimEnd(8);
+
+        Assert.IsTrue(await viewModel.SaveAsync(TestContext.CancellationToken));
+        Assert.IsFalse(viewModel.HasUnsavedChanges);
+
+        viewModel.UpdateTrimStart(0);
+        viewModel.UpdateTrimEnd(10);
+
+        Assert.IsTrue(viewModel.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public async Task SaveTrimmedRange_ThenReturnToSavedRange_ShouldClearDirtyState()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.Load(new VideoFile("test.mp4"));
+        viewModel.SetVideoDuration(TimeSpan.FromSeconds(10));
+        viewModel.UpdateTrimStart(2);
+        viewModel.UpdateTrimEnd(8);
+        Assert.IsTrue(await viewModel.SaveAsync(TestContext.CancellationToken));
+
+        viewModel.UpdateTrimStart(3);
+        viewModel.UpdateTrimEnd(7);
+        Assert.IsTrue(viewModel.HasUnsavedChanges);
+
+        viewModel.UpdateTrimStart(2);
+        viewModel.UpdateTrimEnd(8);
+
+        Assert.IsFalse(viewModel.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public async Task SavedTrimRange_WithinComparisonTolerance_ShouldRemainClean()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.Load(new VideoFile("test.mp4"));
+        viewModel.SetVideoDuration(TimeSpan.FromSeconds(10));
+        viewModel.UpdateTrimStart(2);
+        viewModel.UpdateTrimEnd(8);
+        Assert.IsTrue(await viewModel.SaveAsync(TestContext.CancellationToken));
+
+        viewModel.UpdateTrimStart(2.005);
+        viewModel.UpdateTrimEnd(8.005);
+
+        Assert.IsFalse(viewModel.HasUnsavedChanges);
+    }
+
+    [TestMethod]
+    public async Task FailedSave_ShouldRetainLoadedBaseline()
+    {
+        var saveAction = new Mock<ISaveVideoFileUseCase>();
+        saveAction
+            .Setup(service => service.ExecuteAsync(
+                It.IsAny<SaveVideoFileRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<SaveVideoFileResponse>.Success(new SaveVideoFileResponse(false)));
+        var viewModel = CreateViewModel(saveAction: saveAction.Object);
+        viewModel.Load(new VideoFile("test.mp4"));
+        viewModel.SetVideoDuration(TimeSpan.FromSeconds(10));
+        viewModel.UpdateTrimStart(2);
+
+        Assert.IsFalse(await viewModel.SaveAsync(TestContext.CancellationToken));
+        Assert.IsTrue(viewModel.HasUnsavedChanges);
+
+        viewModel.UpdateTrimStart(0);
+
+        Assert.IsFalse(viewModel.HasUnsavedChanges);
+    }
+
     private static VideoEditPageViewModel CreateViewModel(
         ISaveVideoFileUseCase? saveAction = null,
         ICopyVideoFileUseCase? copyAction = null,


### PR DESCRIPTION
## Summary

- track video editor dirty state against a value-semantic snapshot captured at load and after each successful save
- normalize full-range trims and compare trim values using the existing tolerance
- distinguish the saved original and super-resolution variants without treating cached output as an edit
- document the ARCH-12 behavior and acceptance criteria in a PRD

## Why

The editor reset HasUnsavedChanges after saving, but later recomputed it from whether the video differed from the original. That discarded the last-saved baseline, causing both false-clean and false-dirty warnings after trim or variant changes.

## Impact

Users are warned exactly when the current trim or active video variant differs from the last successfully saved state. Failed saves leave the prior baseline intact, and asynchronous duration discovery remains clean.

## Validation

- focused video edit tests: 24 passed
- all non-UI tests: 699 passed
- WinUI x64 Debug build: succeeded with 0 warnings and 0 errors

Closes #417