### PR TITLE
[ARCH-16] Restore the persisted theme with Settings defaults

### DIFF
--- a/CaptureTool.slnx
+++ b/CaptureTool.slnx
@@ -56,6 +56,10 @@
       <Platform Solution="*|x64" Project="x64" />
     </Project>
     <Project Path="tests/CaptureTool.Infrastructure.Tests/CaptureTool.Infrastructure.Tests.csproj" />
+    <Project Path="tests/CaptureTool.Infrastructure.Windows.Tests/CaptureTool.Infrastructure.Windows.Tests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="tests/CaptureTool.Mcp.CaptureServer.Tests/CaptureTool.Mcp.CaptureServer.Tests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/docs/prd-421-restore-default-theme.md
+++ b/docs/prd-421-restore-default-theme.md
@@ -1,0 +1,76 @@
+# PRD: Restore the persisted application theme with Settings defaults
+
+- Issue: [#421](https://github.com/shanebweaver/CaptureTool/issues/421)
+- Architecture finding: `ARCH-16`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `PLT-01`, `PLT-03`
+
+## Summary
+
+Restore Defaults must reset the application theme to System Default immediately and remove the separately persisted Windows theme override so the reset survives an application restart.
+
+The theme remains in its early-startup Windows settings store because it must be available before the main settings repository initializes. The theme service will expose an explicit reset operation, and the restore-defaults use case will invoke it as part of the same application action that clears ordinary settings, telemetry consent, and the language override.
+
+## Problem
+
+The application theme is persisted under `themeSetting` in Windows local settings, outside `ISettingsService`. `RestoreDefaultsUseCase` clears only the main settings repository, telemetry consent, and language override. `SettingsPageViewModel` then selects System Default without updating the theme service or deleting its persisted override.
+
+The Settings page therefore appears reset, but the previous light or dark override is loaded again on the next launch.
+
+## Goals
+
+1. Apply System Default immediately when Restore Defaults succeeds.
+2. Remove the persisted Windows theme override so a new theme-service instance starts at System Default.
+3. Keep the existing early-startup theme-loading path.
+4. Notify active windows and overlays through the existing theme-change event.
+5. Keep restore failure explicit and prevent the Settings page from displaying defaults when the use case fails.
+6. Preserve telemetry behavior for an effective theme change.
+
+## Non-goals
+
+- Do not migrate all settings into Windows local settings.
+- Do not delay theme initialization until the JSON settings repository is available.
+- Do not change how the system light/dark preference is detected.
+- Do not change the available theme choices or restart-message policy.
+
+## Functional requirements
+
+### Theme service reset
+
+- Add an explicit reset operation to `IThemeService`.
+- Remove `themeSetting` from Windows local settings even if the current in-memory theme is already System Default.
+- Set the current theme to System Default.
+- Raise `CurrentThemeChanged` when the effective selected theme changes.
+- Track the resulting app-theme setting change using the existing telemetry event.
+
+### Restore Defaults integration
+
+- Inject `IThemeService` into `RestoreDefaultsUseCase`.
+- Reset the theme alongside clearing ordinary settings, telemetry consent, and language override.
+- Allow platform persistence failures to flow through `IUseCaseExecutor` as an explicit failed response.
+- Refresh Settings page values only after a successful restore response.
+
+### Persistence boundary
+
+- Encapsulate Windows local-settings access behind an internal theme settings store.
+- Keep production storage backed by `ApplicationData.LocalSettings` and the existing `themeSetting` key.
+- Allow deterministic tests to reuse one fake store across theme-service instances to represent an application restart.
+
+## Test plan
+
+- Verify `RestoreDefaultsUseCase` requests a theme reset and retains all existing reset/save behavior.
+- Verify resetting a stored non-default theme immediately selects System Default and raises the change event.
+- Verify the persisted override is removed and a new theme-service instance initializes to System Default.
+- Verify updating a theme still writes the selected override.
+- Verify a failed restore response does not make the Settings page appear reset.
+- Run all non-UI tests and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] Restore Defaults immediately applies System Default through the theme service.
+- [x] The Windows `themeSetting` override is removed.
+- [x] A subsequent theme-service initialization remains at System Default.
+- [x] Active theme consumers receive the existing change notification.
+- [x] Failed restore operations do not update the Settings page to apparent defaults.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Application.Abstractions/Themes/IThemeService.cs
+++ b/src/CaptureTool.Application.Abstractions/Themes/IThemeService.cs
@@ -10,4 +10,5 @@ public interface IThemeService
 
     void Initialize(AppTheme defualtTheme);
     void UpdateCurrentTheme(AppTheme appTheme);
+    void ResetCurrentTheme();
 }

--- a/src/CaptureTool.Application/Settings/RestoreDefaults/RestoreDefaultsUseCase.cs
+++ b/src/CaptureTool.Application/Settings/RestoreDefaults/RestoreDefaultsUseCase.cs
@@ -2,6 +2,7 @@ using CaptureTool.Application.Abstractions.Localization;
 using CaptureTool.Application.Abstractions.Settings;
 using CaptureTool.Application.Abstractions.Settings.RestoreDefaults;
 using CaptureTool.Application.Abstractions.Telemetry;
+using CaptureTool.Application.Abstractions.Themes;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Application.UseCases;
 
@@ -15,17 +16,20 @@ internal sealed class RestoreDefaultsUseCase : IRestoreDefaultsUseCase
     private readonly ISettingsService _settingsService;
     private readonly ILocalizationService _localizationService;
     private readonly ITelemetryConsentService _telemetryConsentService;
+    private readonly IThemeService _themeService;
 
     public RestoreDefaultsUseCase(
         ISettingsService settingsService,
         ILocalizationService localizationService,
         ITelemetryConsentService telemetryConsentService,
+        IThemeService themeService,
         IUseCaseExecutor useCaseExecutor)
     {
         _useCaseExecutor = useCaseExecutor;
         _settingsService = settingsService;
         _localizationService = localizationService;
         _telemetryConsentService = telemetryConsentService;
+        _themeService = themeService;
     }
 
     public bool CanExecute(RestoreDefaultsRequest request) => true;
@@ -36,6 +40,7 @@ internal sealed class RestoreDefaultsUseCase : IRestoreDefaultsUseCase
             activityId: ActivityId,
             useCase: async _ =>
             {
+                _themeService.ResetCurrentTheme();
                 _settingsService.ClearAllSettings();
                 _telemetryConsentService.SetState(TelemetryConsentState.Unknown);
                 _localizationService.OverrideLanguage(null);

--- a/src/CaptureTool.Infrastructure.Windows/Properties/AssemblyInfo.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CaptureTool.Infrastructure.Windows.Tests")]

--- a/src/CaptureTool.Infrastructure.Windows/Themes/IThemeSettingsStore.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Themes/IThemeSettingsStore.cs
@@ -1,0 +1,12 @@
+using CaptureTool.Application.Abstractions.Themes;
+
+namespace CaptureTool.Infrastructure.Windows.Themes;
+
+internal interface IThemeSettingsStore
+{
+    AppTheme? GetCurrentTheme();
+
+    void SetCurrentTheme(AppTheme appTheme);
+
+    void ResetCurrentTheme();
+}

--- a/src/CaptureTool.Infrastructure.Windows/Themes/WindowsThemeService.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Themes/WindowsThemeService.cs
@@ -1,6 +1,5 @@
 using CaptureTool.Application.Abstractions.Themes;
 using CaptureTool.Application.Abstractions.Telemetry;
-using Microsoft.Windows.Storage;
 using System.Diagnostics;
 
 namespace CaptureTool.Infrastructure.Windows.Themes;
@@ -8,6 +7,7 @@ namespace CaptureTool.Infrastructure.Windows.Themes;
 public sealed partial class WindowsThemeService : IThemeService
 {
     private readonly ITelemetryService? _telemetryService;
+    private readonly IThemeSettingsStore _settingsStore;
 
     public AppTheme DefaultTheme { get; private set; }
     public AppTheme StartupTheme { get; private set; }
@@ -16,7 +16,17 @@ public sealed partial class WindowsThemeService : IThemeService
     public event EventHandler<AppTheme>? CurrentThemeChanged;
 
     public WindowsThemeService(ITelemetryService? telemetryService = null)
+        : this(new WindowsThemeSettingsStore(), telemetryService)
     {
+    }
+
+    internal WindowsThemeService(
+        IThemeSettingsStore settingsStore,
+        ITelemetryService? telemetryService = null)
+    {
+        ArgumentNullException.ThrowIfNull(settingsStore);
+
+        _settingsStore = settingsStore;
         _telemetryService = telemetryService;
     }
 
@@ -25,15 +35,7 @@ public sealed partial class WindowsThemeService : IThemeService
         Debug.Assert(defaultTheme != AppTheme.SystemDefault);
         DefaultTheme = defaultTheme;
 
-        object? themeValue = ApplicationData.GetDefault().LocalSettings.Values["themeSetting"];
-        if (themeValue is int themeValueIndex)
-        {
-            CurrentTheme = (AppTheme)themeValueIndex;
-        }
-        else
-        {
-            CurrentTheme = AppTheme.SystemDefault;
-        }
+        CurrentTheme = _settingsStore.GetCurrentTheme() ?? AppTheme.SystemDefault;
 
         StartupTheme = CurrentTheme;
     }
@@ -43,15 +45,33 @@ public sealed partial class WindowsThemeService : IThemeService
         if (CurrentTheme != appTheme)
         {
             CurrentTheme = appTheme;
-            ApplicationData.GetDefault().LocalSettings.Values["themeSetting"] = (int)appTheme;
+            _settingsStore.SetCurrentTheme(appTheme);
             CurrentThemeChanged?.Invoke(this, appTheme);
-            _telemetryService?.TrackEvent(
-                TelemetryEvents.SettingsChanged,
-                new Dictionary<string, object?>
-                {
-                    [TelemetryProperties.Setting] = "app_theme",
-                    [TelemetryProperties.Value] = appTheme.ToString()
-                });
+            TrackThemeChanged(appTheme);
         }
+    }
+
+    public void ResetCurrentTheme()
+    {
+        _settingsStore.ResetCurrentTheme();
+        if (CurrentTheme == AppTheme.SystemDefault)
+        {
+            return;
+        }
+
+        CurrentTheme = AppTheme.SystemDefault;
+        CurrentThemeChanged?.Invoke(this, CurrentTheme);
+        TrackThemeChanged(CurrentTheme);
+    }
+
+    private void TrackThemeChanged(AppTheme appTheme)
+    {
+        _telemetryService?.TrackEvent(
+            TelemetryEvents.SettingsChanged,
+            new Dictionary<string, object?>
+            {
+                [TelemetryProperties.Setting] = "app_theme",
+                [TelemetryProperties.Value] = appTheme.ToString()
+            });
     }
 }

--- a/src/CaptureTool.Infrastructure.Windows/Themes/WindowsThemeSettingsStore.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Themes/WindowsThemeSettingsStore.cs
@@ -1,0 +1,27 @@
+using CaptureTool.Application.Abstractions.Themes;
+using Microsoft.Windows.Storage;
+
+namespace CaptureTool.Infrastructure.Windows.Themes;
+
+internal sealed class WindowsThemeSettingsStore : IThemeSettingsStore
+{
+    private const string ThemeSettingKey = "themeSetting";
+
+    public AppTheme? GetCurrentTheme()
+    {
+        object? themeValue = ApplicationData.GetDefault().LocalSettings.Values[ThemeSettingKey];
+        return themeValue is int themeValueIndex
+            ? (AppTheme)themeValueIndex
+            : null;
+    }
+
+    public void SetCurrentTheme(AppTheme appTheme)
+    {
+        ApplicationData.GetDefault().LocalSettings.Values[ThemeSettingKey] = (int)appTheme;
+    }
+
+    public void ResetCurrentTheme()
+    {
+        ApplicationData.GetDefault().LocalSettings.Values.Remove(ThemeSettingKey);
+    }
+}

--- a/src/CaptureTool.Presentation.Windows.WinUI/UiTests/UiTestThemeService.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/UiTests/UiTestThemeService.cs
@@ -27,4 +27,9 @@ internal sealed class UiTestThemeService : IThemeService
         CurrentTheme = appTheme;
         CurrentThemeChanged?.Invoke(this, appTheme);
     }
+
+    public void ResetCurrentTheme()
+    {
+        UpdateCurrentTheme(AppTheme.SystemDefault);
+    }
 }

--- a/src/CaptureTool.Presentation/Features/Settings/SettingsPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/Settings/SettingsPageViewModel.cs
@@ -731,7 +731,11 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
 
     private async Task RestoreDefaultSettingsAsync()
     {
-        await _restoreDefaultsAction.ExecuteAsync(new RestoreDefaultsRequest(), CancellationToken.None);
+        var response = await _restoreDefaultsAction.ExecuteAsync(new RestoreDefaultsRequest(), CancellationToken.None);
+        if (response.Value?.Succeeded != true)
+        {
+            return;
+        }
 
         ImageCaptureAutoCopy = _settingsService.Get(CaptureToolSettings.Settings_ImageCapture_AutoCopy);
         ImageCaptureAutoSave = _settingsService.Get(CaptureToolSettings.Settings_ImageCapture_AutoSave);

--- a/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
@@ -28,6 +28,7 @@ using CaptureTool.Application.Abstractions.Settings.UpdateVideoCaptureDefaultLoc
 using CaptureTool.Application.Abstractions.Shutdown;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.Telemetry;
+using CaptureTool.Application.Abstractions.Themes;
 using CaptureTool.Application.Settings.ChangeAudioFolder;
 using CaptureTool.Application.Settings.ChangeScreenshotsFolder;
 using CaptureTool.Application.Settings.ChangeVideosFolder;
@@ -204,15 +205,17 @@ public sealed class SettingsPageUseCaseTests
     }
 
     [TestMethod]
-    public async Task RestoreDefaultsUseCase_ClearsSettingsLanguageOverrideAndSaves()
+    public async Task RestoreDefaultsUseCase_ClearsSettingsLanguageThemeOverrideAndSaves()
     {
         var settings = new Mock<ISettingsService>();
         var localization = new Mock<ILocalizationService>();
         var telemetryConsent = new Mock<ITelemetryConsentService>();
+        var themes = new Mock<IThemeService>();
         var useCase = new RestoreDefaultsUseCase(
             settings.Object,
             localization.Object,
             telemetryConsent.Object,
+            themes.Object,
             TestUseCaseExecutor.Instance);
 
         RestoreDefaultsResponse response = (await useCase.ExecuteAsync(new RestoreDefaultsRequest(), TestContext.CancellationToken)).Value!;
@@ -223,6 +226,7 @@ public sealed class SettingsPageUseCaseTests
         telemetryConsent.Verify(
             service => service.SetState(TelemetryConsentState.Unknown),
             Times.Once);
+        themes.Verify(service => service.ResetCurrentTheme(), Times.Once);
         settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
     }
 

--- a/tests/CaptureTool.Infrastructure.Windows.Tests/CaptureTool.Infrastructure.Windows.Tests.csproj
+++ b/tests/CaptureTool.Infrastructure.Windows.Tests/CaptureTool.Infrastructure.Windows.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="MSTest.Sdk/4.0.2">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <Platforms>x64;ARM64</Platforms>
+    <UseVSTest>true</UseVSTest>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CaptureTool.Infrastructure.Windows\CaptureTool.Infrastructure.Windows.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeCoverage" />
+    <PackageReference Update="MSTest.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/CaptureTool.Infrastructure.Windows.Tests/MSTestSettings.cs
+++ b/tests/CaptureTool.Infrastructure.Windows.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/tests/CaptureTool.Infrastructure.Windows.Tests/WindowsThemeServiceTests.cs
+++ b/tests/CaptureTool.Infrastructure.Windows.Tests/WindowsThemeServiceTests.cs
@@ -1,0 +1,78 @@
+using CaptureTool.Application.Abstractions.Themes;
+using CaptureTool.Application.Abstractions.Telemetry;
+using CaptureTool.Infrastructure.Windows.Themes;
+
+namespace CaptureTool.Infrastructure.Windows.Tests;
+
+[TestClass]
+public sealed class WindowsThemeServiceTests
+{
+    [TestMethod]
+    public void ResetCurrentTheme_ShouldApplyImmediatelyAndRemoveNextLaunchOverride()
+    {
+        var settingsStore = new TestThemeSettingsStore { CurrentTheme = AppTheme.Dark };
+        var telemetry = new RecordingTelemetryService();
+        var service = new WindowsThemeService(settingsStore, telemetry);
+        service.Initialize(AppTheme.Light);
+        AppTheme? changedTheme = null;
+        service.CurrentThemeChanged += (_, appTheme) => changedTheme = appTheme;
+
+        service.ResetCurrentTheme();
+
+        Assert.AreEqual(AppTheme.SystemDefault, service.CurrentTheme);
+        Assert.AreEqual(AppTheme.SystemDefault, changedTheme);
+        Assert.IsNull(settingsStore.CurrentTheme);
+        Assert.AreEqual(1, settingsStore.ResetCount);
+        Assert.HasCount(1, telemetry.Events);
+        Assert.AreEqual(
+            AppTheme.SystemDefault.ToString(),
+            telemetry.Events[0].Properties[TelemetryProperties.Value]);
+
+        var nextLaunchService = new WindowsThemeService(settingsStore);
+        nextLaunchService.Initialize(AppTheme.Dark);
+
+        Assert.AreEqual(AppTheme.SystemDefault, nextLaunchService.CurrentTheme);
+    }
+
+    [TestMethod]
+    public void UpdateCurrentTheme_ShouldPersistSelectedTheme()
+    {
+        var settingsStore = new TestThemeSettingsStore();
+        var service = new WindowsThemeService(settingsStore);
+        service.Initialize(AppTheme.Light);
+
+        service.UpdateCurrentTheme(AppTheme.Dark);
+
+        Assert.AreEqual(AppTheme.Dark, service.CurrentTheme);
+        Assert.AreEqual(AppTheme.Dark, settingsStore.CurrentTheme);
+    }
+
+    private sealed class RecordingTelemetryService : ITelemetryService
+    {
+        public List<(string Name, IReadOnlyDictionary<string, object?> Properties)> Events { get; } = [];
+
+        public void TrackEvent(
+            string eventName,
+            IReadOnlyDictionary<string, object?>? properties = null)
+        {
+            Events.Add((eventName, properties ?? new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed class TestThemeSettingsStore : IThemeSettingsStore
+    {
+        public AppTheme? CurrentTheme { get; set; }
+
+        public int ResetCount { get; private set; }
+
+        public AppTheme? GetCurrentTheme() => CurrentTheme;
+
+        public void SetCurrentTheme(AppTheme appTheme) => CurrentTheme = appTheme;
+
+        public void ResetCurrentTheme()
+        {
+            CurrentTheme = null;
+            ResetCount++;
+        }
+    }
+}

--- a/tests/CaptureTool.Presentation.Tests/Features/SettingsPageViewModelAiConsentTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/SettingsPageViewModelAiConsentTests.cs
@@ -36,6 +36,7 @@ using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.Store;
 using CaptureTool.Application.Abstractions.Telemetry;
 using CaptureTool.Application.Abstractions.Themes;
+using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Domain.Ai;
 using CaptureTool.Presentation.Factories;
 using CaptureTool.Presentation.Features.Settings;
@@ -126,6 +127,22 @@ public sealed class SettingsPageViewModelAiConsentTests
 
         viewModel.IsAiConsentSettingsVisible.Should().BeFalse();
         viewModel.AiFeatureConsents.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task RestoreDefaultSettingsCommand_WhenRestoreFails_ShouldKeepDisplayedTheme()
+    {
+        var restoreDefaults = new Mock<IRestoreDefaultsUseCase>();
+        restoreDefaults
+            .Setup(service => service.ExecuteAsync(It.IsAny<RestoreDefaultsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<RestoreDefaultsResponse>.Failure());
+        SettingsPageViewModel viewModel = CreateViewModel(restoreDefaultsUseCase: restoreDefaults.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+        int selectedThemeIndex = viewModel.SelectedAppThemeIndex;
+
+        await viewModel.RestoreDefaultSettingsCommand.ExecuteAsync(null);
+
+        viewModel.SelectedAppThemeIndex.Should().Be(selectedThemeIndex);
     }
 
     [TestMethod]
@@ -228,7 +245,8 @@ public sealed class SettingsPageViewModelAiConsentTests
         bool isImageObjectExtractionEnabled = false,
         bool isVideoSuperResolutionEnabled = false,
         string telemetryConsentValue = TelemetryConsentSettingValues.Unknown,
-        ITelemetryConsentService? telemetryConsentService = null)
+        ITelemetryConsentService? telemetryConsentService = null,
+        IRestoreDefaultsUseCase? restoreDefaultsUseCase = null)
     {
         var localization = new Mock<ILocalizationService>();
         localization
@@ -318,7 +336,7 @@ public sealed class SettingsPageViewModelAiConsentTests
             Mock.Of<IOpenVideosFolderUseCase>(),
             Mock.Of<IOpenTempFolderUseCase>(),
             Mock.Of<IClearTempFilesUseCase>(),
-            Mock.Of<IRestoreDefaultsUseCase>(),
+            restoreDefaultsUseCase ?? Mock.Of<IRestoreDefaultsUseCase>(),
             aiFeatureConsentService.Object,
             Mock.Of<IAiConsentSettingsFeatureAvailability>(service =>
                 service.IsAiConsentSettingsEnabled == isAiConsentSettingsEnabled),


### PR DESCRIPTION
## Summary

- add the ARCH-16 PRD for restoring the separately persisted application theme
- add an explicit `IThemeService.ResetCurrentTheme` operation and invoke it from Restore Defaults
- remove the Windows `themeSetting` override while immediately applying System Default and notifying active theme consumers
- isolate Windows theme persistence behind a testable internal store
- prevent the Settings page from displaying defaults when the restore use case fails
- add a Windows infrastructure test project covering immediate application, telemetry, persistence removal, and next-launch initialization

## Why

The application theme is loaded before the main settings repository initializes, so it is persisted separately in Windows local settings. Restore Defaults cleared `ISettingsService`, telemetry consent, and the language override, but never cleared `themeSetting`. The Settings page then selected System Default locally, which made the reset appear successful until the previous light or dark override returned after restart.

The restore use case now resets the theme through its application abstraction. The Windows implementation removes the persisted override, switches the current theme to System Default, raises the existing theme-change event, and retains the existing settings telemetry behavior.

Fixes #421.

## User impact

Restore Defaults now changes the active application theme immediately and the reset remains in effect after restarting the application. If the restore action fails, the Settings page no longer presents values as though the reset succeeded.

## Validation

- all seven non-UI test projects, Release/x64: 708 passed, 0 failed
- `dotnet build src\CaptureTool.Presentation.Windows.WinUI\CaptureTool.Presentation.Windows.WinUI.csproj --configuration Debug -p:Platform=x64 -m:1 -p:BuildInParallel=false --no-restore`: succeeded with 0 warnings and 0 errors
