### PR TITLE
Make settings persistence transactional

### DIFF
--- a/docs/prd-420-transactional-settings-persistence.md
+++ b/docs/prd-420-transactional-settings-persistence.md
@@ -1,0 +1,96 @@
+# PRD: Transactional Settings Persistence
+
+- Issue: [#420](https://github.com/shanebweaver/CaptureTool/issues/420)
+- Architecture finding: `ARCH-15`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `PLT-01`, `PLT-05`, `PLT-06`, `PLT-07`
+
+## Summary
+
+Settings mutations that require persistence must be serialized with their storage write and return a typed result. The in-memory settings dictionary, subscribers, and dependent runtime services must change only after persistence succeeds. Bulk reset must use the same lock and notification discipline as individual settings.
+
+## Problem
+
+Callers currently invoke synchronous `Set`, `Unset`, or `ClearAllSettings` and then separately call `TrySaveAsync`. Most callers discard the Boolean save result and return successful typed responses. A failed write therefore leaves an unpersisted value in memory and the settings UI continues to show the requested state until restart.
+
+The split mutation/save sequence also allows settings operations to interleave. `ClearAllSettings` bypasses the dictionary access lock entirely and does not raise `SettingsChanged`, so concurrent readers can race with reset and subscribers do not refresh after defaults are restored.
+
+## Goals
+
+1. Serialize each persisted mutation and its storage write.
+2. Keep the last committed in-memory settings visible until the write succeeds.
+3. Return an explicit saved, persistence-failed, or service-unavailable result.
+4. Publish settings notifications and telemetry only for committed mutations.
+5. Make bulk reset lock-safe and notify subscribers of every removed setting.
+6. Propagate persistence failures through settings use-case responses and restore optimistic UI fields.
+7. Apply dependent runtime state, including language, logging, AI consent, and telemetry consent, only after persistence succeeds.
+
+## Non-goals
+
+- Changing the JSON settings schema or file location.
+- Retrying failed storage writes automatically.
+- Adding a settings database or cross-process synchronization.
+- Changing theme persistence, which uses the Windows application-data store rather than `ISettingsService`.
+- Changing settings defaults.
+
+## Functional requirements
+
+### Transaction API
+
+1. Add typed async operations for setting, unsetting, and clearing persisted settings.
+2. Each operation builds a candidate dictionary from the committed state under the access lock.
+3. Candidate writes are serialized with initialization and other saves.
+4. A successful write commits the candidate in memory, raises `SettingsChanged`, and records safe telemetry.
+5. A failed write leaves the committed dictionary and subscribers unchanged and returns `PersistenceFailed`.
+6. A disposed service returns `ServiceUnavailable` without accessing storage.
+
+### Bulk reset
+
+1. Transactional reset writes an empty candidate before publishing defaults in memory.
+2. Successful reset notifies subscribers with all removed definitions.
+3. The legacy synchronous clear operation uses the normal access lock and notification path.
+4. Readers continue seeing the prior committed values while a reset write is pending.
+
+### Caller behavior
+
+1. Settings, folder, language, restore-defaults, and logging use cases set their response success from the mutation result.
+2. Language and logging runtime state changes only after the settings write succeeds.
+3. AI and telemetry consent gates change only after their setting is saved.
+4. Optimistic settings-page fields revert to the committed service value when a use case reports failure.
+5. Restore-defaults refreshes the page only after reset persistence succeeds.
+
+## Reliability requirements
+
+- Cancellation continues to propagate to callers.
+- Storage exceptions remain logged and are represented by `PersistenceFailed`.
+- Missing initialization continues to fail explicitly.
+- Concurrent readers never enumerate or query a dictionary while it is being cleared without the access lock.
+- A later synchronous mutation is not overwritten when an earlier transactional write completes.
+
+## Test plan
+
+Add tests for:
+
+- failed transactional set retaining the committed value and suppressing notifications;
+- pending transactional reset keeping prior values readable until the write completes;
+- successful reset notifying subscribers with all removed settings;
+- disposed transactional mutation returning service unavailable;
+- update and restore use cases returning failure when persistence fails;
+- dependent language, logging, AI consent, and telemetry state not changing after failed persistence;
+- settings-page optimistic values reverting after a failed response.
+
+Run all non-UI test projects and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] Persisted settings mutations are serialized and return a typed result.
+- [x] Failed writes do not alter committed in-memory settings or notify subscribers.
+- [x] Bulk reset is lock-safe, atomic from readers' perspective, and notifies on success.
+- [x] Use cases and runtime consent or behavior services do not report or apply failed changes.
+- [x] Settings-page optimistic fields revert after persistence failure.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+
+## Rollout
+
+No migration or feature flag is required. Existing settings files remain compatible; the change only affects how mutations are committed and reported.

--- a/src/CaptureTool.Application.Abstractions/Ai/IAiFeatureConsentService.cs
+++ b/src/CaptureTool.Application.Abstractions/Ai/IAiFeatureConsentService.cs
@@ -8,6 +8,6 @@ public interface IAiFeatureConsentService
 
     AiFeatureConsentState GetConsentState(AiFeatureId featureId);
 
-    Task SetConsentAsync(AiFeatureId featureId, bool isGranted, CancellationToken cancellationToken = default);
+    Task<bool> SetConsentAsync(AiFeatureId featureId, bool isGranted, CancellationToken cancellationToken = default);
 }
 

--- a/src/CaptureTool.Application.Abstractions/Settings/ISettingsService.cs
+++ b/src/CaptureTool.Application.Abstractions/Settings/ISettingsService.cs
@@ -13,6 +13,27 @@ public interface ISettingsService
     void Unset(ISettingDefinition settingDefinition);
     void Unset(ISettingDefinition[] settingDefinitions);
 
+    Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IBoolSettingDefinition settingDefinition,
+        bool value,
+        CancellationToken cancellationToken);
+    Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IDoubleSettingDefinition settingDefinition,
+        double value,
+        CancellationToken cancellationToken);
+    Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IIntSettingDefinition settingDefinition,
+        int value,
+        CancellationToken cancellationToken);
+    Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IStringSettingDefinition settingDefinition,
+        string value,
+        CancellationToken cancellationToken);
+    Task<SettingsMutationResult> TryUnsetAndSaveAsync(
+        ISettingDefinition settingDefinition,
+        CancellationToken cancellationToken);
+    Task<SettingsMutationResult> TryClearAllAndSaveAsync(CancellationToken cancellationToken);
+
     Task InitializeAsync(string filePath, CancellationToken cancellationToken);
     Task<bool> TrySaveAsync(CancellationToken cancellationToken);
 

--- a/src/CaptureTool.Application.Abstractions/Settings/SettingsMutationResult.cs
+++ b/src/CaptureTool.Application.Abstractions/Settings/SettingsMutationResult.cs
@@ -1,0 +1,18 @@
+namespace CaptureTool.Application.Abstractions.Settings;
+
+public enum SettingsMutationStatus
+{
+    Unknown,
+    Saved,
+    PersistenceFailed,
+    ServiceUnavailable,
+}
+
+public readonly record struct SettingsMutationResult(SettingsMutationStatus Status)
+{
+    public bool Succeeded => Status == SettingsMutationStatus.Saved;
+
+    public static SettingsMutationResult Saved { get; } = new(SettingsMutationStatus.Saved);
+    public static SettingsMutationResult PersistenceFailed { get; } = new(SettingsMutationStatus.PersistenceFailed);
+    public static SettingsMutationResult ServiceUnavailable { get; } = new(SettingsMutationStatus.ServiceUnavailable);
+}

--- a/src/CaptureTool.Application/Ai/AiFeatureConsentService.cs
+++ b/src/CaptureTool.Application/Ai/AiFeatureConsentService.cs
@@ -39,13 +39,16 @@ internal sealed class AiFeatureConsentService : IAiFeatureConsentService
             : AiFeatureConsentState.Denied;
     }
 
-    public async Task SetConsentAsync(
+    public async Task<bool> SetConsentAsync(
         AiFeatureId featureId,
         bool isGranted,
         CancellationToken cancellationToken = default)
     {
-        _settingsService.Set(GetSettingDefinition(featureId), isGranted);
-        await _settingsService.TrySaveAsync(cancellationToken);
+        SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+            GetSettingDefinition(featureId),
+            isGranted,
+            cancellationToken);
+        return result.Succeeded;
     }
 
     private AiFeatureConsent CreateConsent(AiFeatureId featureId, string displayName)

--- a/src/CaptureTool.Application/Diagnostics/UpdateLoggingState/UpdateLoggingStateUseCase.cs
+++ b/src/CaptureTool.Application/Diagnostics/UpdateLoggingState/UpdateLoggingStateUseCase.cs
@@ -29,6 +29,15 @@ internal sealed class UpdateLoggingStateUseCase : IUpdateLoggingStateUseCase
             activityId: ActivityId,
             useCase: async _ =>
             {
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.VerboseLogging,
+                    request.IsEnabled,
+                    cancellationToken);
+                if (!result.Succeeded)
+                {
+                    return new UpdateLoggingStateResponse(false);
+                }
+
                 if (request.IsEnabled)
                 {
                     _logService.Enable();
@@ -38,8 +47,6 @@ internal sealed class UpdateLoggingStateUseCase : IUpdateLoggingStateUseCase
                     _logService.Disable();
                 }
 
-                _settingsService.Set(CaptureToolSettings.VerboseLogging, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
                 return new UpdateLoggingStateResponse();
             },
             cancellationToken: cancellationToken);

--- a/src/CaptureTool.Application/Settings/ChangeAudioFolder/ChangeAudioFolderUseCase.cs
+++ b/src/CaptureTool.Application/Settings/ChangeAudioFolder/ChangeAudioFolderUseCase.cs
@@ -38,9 +38,11 @@ internal sealed class ChangeAudioFolderUseCase : IChangeAudioFolderUseCase
                     return new ChangeAudioFolderResponse(false);
                 }
 
-                _settings.Set(CaptureToolSettings.Settings_AudioCapture_AutoSaveFolder, folder.FolderPath);
-                await _settings.TrySaveAsync(cancellationToken);
-                return new ChangeAudioFolderResponse();
+                SettingsMutationResult result = await _settings.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_AudioCapture_AutoSaveFolder,
+                    folder.FolderPath,
+                    cancellationToken);
+                return new ChangeAudioFolderResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/ChangeScreenshotsFolder/ChangeScreenshotsFolderUseCase.cs
+++ b/src/CaptureTool.Application/Settings/ChangeScreenshotsFolder/ChangeScreenshotsFolderUseCase.cs
@@ -37,9 +37,11 @@ internal sealed class ChangeScreenshotsFolderUseCase : IChangeScreenshotsFolderU
                     return new ChangeScreenshotsFolderResponse(false);
                 }
 
-                _settings.Set(CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder, folder.FolderPath);
-                await _settings.TrySaveAsync(cancellationToken);
-                return new ChangeScreenshotsFolderResponse();
+                SettingsMutationResult result = await _settings.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder,
+                    folder.FolderPath,
+                    cancellationToken);
+                return new ChangeScreenshotsFolderResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/ChangeVideosFolder/ChangeVideosFolderUseCase.cs
+++ b/src/CaptureTool.Application/Settings/ChangeVideosFolder/ChangeVideosFolderUseCase.cs
@@ -36,9 +36,11 @@ internal sealed class ChangeVideosFolderUseCase : IChangeVideosFolderUseCase
                     return new ChangeVideosFolderResponse(false);
                 }
 
-                _settings.Set(CaptureToolSettings.Settings_VideoCapture_AutoSaveFolder, folder.FolderPath);
-                await _settings.TrySaveAsync(cancellationToken);
-                return new ChangeVideosFolderResponse();
+                SettingsMutationResult result = await _settings.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_VideoCapture_AutoSaveFolder,
+                    folder.FolderPath,
+                    cancellationToken);
+                return new ChangeVideosFolderResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/RestoreDefaults/RestoreDefaultsUseCase.cs
+++ b/src/CaptureTool.Application/Settings/RestoreDefaults/RestoreDefaultsUseCase.cs
@@ -36,10 +36,14 @@ internal sealed class RestoreDefaultsUseCase : IRestoreDefaultsUseCase
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.ClearAllSettings();
+                SettingsMutationResult result = await _settingsService.TryClearAllAndSaveAsync(cancellationToken);
+                if (!result.Succeeded)
+                {
+                    return new RestoreDefaultsResponse(false);
+                }
+
                 _telemetryConsentService.SetState(TelemetryConsentState.Unknown);
                 _localizationService.OverrideLanguage(null);
-                await _settingsService.TrySaveAsync(cancellationToken);
                 return new RestoreDefaultsResponse();
             },
             cancellationToken: cancellationToken);

--- a/src/CaptureTool.Application/Settings/UpdateAppLanguage/UpdateAppLanguageUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateAppLanguage/UpdateAppLanguageUseCase.cs
@@ -41,19 +41,27 @@ internal sealed class UpdateAppLanguageUseCase : IUpdateAppLanguageUseCase
                 }
 
                 var language = request.LanguageIndex == languages.Length ? null : languages[request.LanguageIndex];
-                _localization.OverrideLanguage(language);
-
+                SettingsMutationResult result;
                 if (language?.Value is string value)
                 {
-                    _settings.Set(CaptureToolSettings.Settings_LanguageOverride, value);
+                    result = await _settings.TrySetAndSaveAsync(
+                        CaptureToolSettings.Settings_LanguageOverride,
+                        value,
+                        cancellationToken);
                 }
                 else
                 {
-                    _settings.Unset(CaptureToolSettings.Settings_LanguageOverride);
+                    result = await _settings.TryUnsetAndSaveAsync(
+                        CaptureToolSettings.Settings_LanguageOverride,
+                        cancellationToken);
                 }
 
-                await _settings.TrySaveAsync(cancellationToken);
-                return new UpdateAppLanguageResponse();
+                if (result.Succeeded)
+                {
+                    _localization.OverrideLanguage(language);
+                }
+
+                return new UpdateAppLanguageResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateAudioCaptureAutoCopy/UpdateAudioCaptureAutoCopyUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateAudioCaptureAutoCopy/UpdateAudioCaptureAutoCopyUseCase.cs
@@ -28,9 +28,11 @@ internal sealed class UpdateAudioCaptureAutoCopyUseCase : IUpdateAudioCaptureAut
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_AudioCapture_AutoCopy, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateAudioCaptureAutoCopyResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_AudioCapture_AutoCopy,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateAudioCaptureAutoCopyResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateAudioCaptureAutoSave/UpdateAudioCaptureAutoSaveUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateAudioCaptureAutoSave/UpdateAudioCaptureAutoSaveUseCase.cs
@@ -28,9 +28,11 @@ internal sealed class UpdateAudioCaptureAutoSaveUseCase : IUpdateAudioCaptureAut
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_AudioCapture_AutoSave, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateAudioCaptureAutoSaveResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_AudioCapture_AutoSave,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateAudioCaptureAutoSaveResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateAudioCaptureDefaultLocalAudio/UpdateAudioCaptureDefaultLocalAudioUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateAudioCaptureDefaultLocalAudio/UpdateAudioCaptureDefaultLocalAudioUseCase.cs
@@ -28,9 +28,11 @@ internal sealed class UpdateAudioCaptureDefaultLocalAudioUseCase : IUpdateAudioC
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_AudioCapture_DefaultLocalAudioEnabled, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateAudioCaptureDefaultLocalAudioResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_AudioCapture_DefaultLocalAudioEnabled,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateAudioCaptureDefaultLocalAudioResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateCaptureWarnBeforeDiscard/UpdateCaptureWarnBeforeDiscardUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateCaptureWarnBeforeDiscard/UpdateCaptureWarnBeforeDiscardUseCase.cs
@@ -26,9 +26,11 @@ internal sealed class UpdateCaptureWarnBeforeDiscardUseCase : IUpdateCaptureWarn
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_Capture_WarnBeforeDiscard, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateCaptureWarnBeforeDiscardResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_Capture_WarnBeforeDiscard,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateCaptureWarnBeforeDiscardResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateEditWarnBeforeDiscard/UpdateEditWarnBeforeDiscardUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateEditWarnBeforeDiscard/UpdateEditWarnBeforeDiscardUseCase.cs
@@ -26,9 +26,11 @@ internal sealed class UpdateEditWarnBeforeDiscardUseCase : IUpdateEditWarnBefore
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_Edit_WarnBeforeDiscard, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateEditWarnBeforeDiscardResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_Edit_WarnBeforeDiscard,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateEditWarnBeforeDiscardResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateImageAutoCopy/UpdateImageAutoCopyUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateImageAutoCopy/UpdateImageAutoCopyUseCase.cs
@@ -27,9 +27,11 @@ internal sealed class UpdateImageAutoCopyUseCase : IUpdateImageAutoCopyUseCase
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_ImageCapture_AutoCopy, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateImageAutoCopyResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_ImageCapture_AutoCopy,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateImageAutoCopyResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateImageAutoSave/UpdateImageAutoSaveUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateImageAutoSave/UpdateImageAutoSaveUseCase.cs
@@ -27,9 +27,11 @@ internal sealed class UpdateImageAutoSaveUseCase : IUpdateImageAutoSaveUseCase
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_ImageCapture_AutoSave, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateImageAutoSaveResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_ImageCapture_AutoSave,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateImageAutoSaveResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateVideoCaptureAutoCopy/UpdateVideoCaptureAutoCopyUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateVideoCaptureAutoCopy/UpdateVideoCaptureAutoCopyUseCase.cs
@@ -27,9 +27,11 @@ internal sealed class UpdateVideoCaptureAutoCopyUseCase : IUpdateVideoCaptureAut
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_VideoCapture_AutoCopy, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateVideoCaptureAutoCopyResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_VideoCapture_AutoCopy,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateVideoCaptureAutoCopyResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateVideoCaptureAutoSave/UpdateVideoCaptureAutoSaveUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateVideoCaptureAutoSave/UpdateVideoCaptureAutoSaveUseCase.cs
@@ -27,9 +27,11 @@ internal sealed class UpdateVideoCaptureAutoSaveUseCase : IUpdateVideoCaptureAut
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_VideoCapture_AutoSave, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateVideoCaptureAutoSaveResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_VideoCapture_AutoSave,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateVideoCaptureAutoSaveResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Application/Settings/UpdateVideoCaptureDefaultLocalAudio/UpdateVideoCaptureDefaultLocalAudioUseCase.cs
+++ b/src/CaptureTool.Application/Settings/UpdateVideoCaptureDefaultLocalAudio/UpdateVideoCaptureDefaultLocalAudioUseCase.cs
@@ -27,9 +27,11 @@ internal sealed class UpdateVideoCaptureDefaultLocalAudioUseCase : IUpdateVideoC
             activityId: ActivityId,
             useCase: async _ =>
             {
-                _settingsService.Set(CaptureToolSettings.Settings_VideoCapture_DefaultLocalAudioEnabled, request.IsEnabled);
-                await _settingsService.TrySaveAsync(cancellationToken);
-                return new UpdateVideoCaptureDefaultLocalAudioResponse();
+                SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+                    CaptureToolSettings.Settings_VideoCapture_DefaultLocalAudioEnabled,
+                    request.IsEnabled,
+                    cancellationToken);
+                return new UpdateVideoCaptureDefaultLocalAudioResponse(result.Succeeded);
             },
             cancellationToken: cancellationToken);
     }

--- a/src/CaptureTool.Infrastructure/Settings/LocalSettingsService.cs
+++ b/src/CaptureTool.Infrastructure/Settings/LocalSettingsService.cs
@@ -96,6 +96,48 @@ public partial class LocalSettingsService : ISettingsService, IDisposable
     public void Set(IStringSettingDefinition settingDefinition, string value)
         => LockAndSet(new StringSettingDefinition(settingDefinition.Key, value));
 
+    public Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IBoolSettingDefinition settingDefinition,
+        bool value,
+        CancellationToken cancellationToken) =>
+        TryMutateAndSaveAsync(
+            settings => SetCandidate(settings, new BoolSettingDefinition(settingDefinition.Key, value)),
+            cancellationToken);
+
+    public Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IDoubleSettingDefinition settingDefinition,
+        double value,
+        CancellationToken cancellationToken) =>
+        TryMutateAndSaveAsync(
+            settings => SetCandidate(settings, new DoubleSettingDefinition(settingDefinition.Key, value)),
+            cancellationToken);
+
+    public Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IIntSettingDefinition settingDefinition,
+        int value,
+        CancellationToken cancellationToken) =>
+        TryMutateAndSaveAsync(
+            settings => SetCandidate(settings, new IntSettingDefinition(settingDefinition.Key, value)),
+            cancellationToken);
+
+    public Task<SettingsMutationResult> TrySetAndSaveAsync(
+        IStringSettingDefinition settingDefinition,
+        string value,
+        CancellationToken cancellationToken) =>
+        TryMutateAndSaveAsync(
+            settings => SetCandidate(settings, new StringSettingDefinition(settingDefinition.Key, value)),
+            cancellationToken);
+
+    public Task<SettingsMutationResult> TryUnsetAndSaveAsync(
+        ISettingDefinition settingDefinition,
+        CancellationToken cancellationToken) =>
+        TryMutateAndSaveAsync(
+            settings => UnsetCandidate(settings, settingDefinition),
+            cancellationToken);
+
+    public Task<SettingsMutationResult> TryClearAllAndSaveAsync(CancellationToken cancellationToken) =>
+        TryMutateAndSaveAsync(ClearCandidate, cancellationToken);
+
     public async Task InitializeAsync(string filePath, CancellationToken cancellationToken)
     {
         if (_disposed)
@@ -213,7 +255,12 @@ public partial class LocalSettingsService : ISettingsService, IDisposable
 
             try
             {
-                List<SettingDefinition> settingsList = [.. _settings.Values];
+                List<SettingDefinition> settingsList;
+                lock (_accessLock)
+                {
+                    settingsList = [.. _settings.Values];
+                }
+
                 await _jsonStorageService.WriteAsync(GetSettingsFile(), settingsList, SettingDefinitionContext.Default.ListSettingDefinition);
                 return true;
             }
@@ -250,6 +297,153 @@ public partial class LocalSettingsService : ISettingsService, IDisposable
                 FireSettingsChangedEvent(settingDefinition);
                 TrackSettingChanged(settingDefinition.Key, GetSafeTelemetryValue(settingDefinition));
             }
+        }
+    }
+
+    private async Task<SettingsMutationResult> TryMutateAndSaveAsync(
+        Func<Dictionary<string, SettingDefinition>, ISettingDefinition[]> mutate,
+        CancellationToken cancellationToken)
+    {
+        if (_disposed)
+        {
+            return SettingsMutationResult.ServiceUnavailable;
+        }
+
+        await _semaphore.WaitAsync(cancellationToken);
+
+        try
+        {
+            Dictionary<string, SettingDefinition> originalSettings;
+            Dictionary<string, SettingDefinition> candidateSettings;
+            ISettingDefinition[] changedSettings;
+            lock (_accessLock)
+            {
+                ThrowIfNotInitialized();
+                originalSettings = new Dictionary<string, SettingDefinition>(_settings, StringComparer.Ordinal);
+                candidateSettings = new Dictionary<string, SettingDefinition>(_settings, StringComparer.Ordinal);
+                changedSettings = mutate(candidateSettings);
+            }
+
+            try
+            {
+                await _jsonStorageService.WriteAsync(
+                    GetSettingsFile(),
+                    candidateSettings.Values.ToList(),
+                    SettingDefinitionContext.Default.ListSettingDefinition);
+            }
+            catch (Exception e)
+            {
+                LogException(e, "Unable to perform settings mutation save operation.");
+                return SettingsMutationResult.PersistenceFailed;
+            }
+
+            ISettingDefinition[] committedSettings;
+            lock (_accessLock)
+            {
+                committedSettings = CommitCandidateChanges(
+                    originalSettings,
+                    candidateSettings,
+                    changedSettings);
+                if (committedSettings.Length > 0)
+                {
+                    FireSettingsChangedEvent(committedSettings);
+                    TrackCommittedSettings(candidateSettings, committedSettings);
+                }
+            }
+
+            return SettingsMutationResult.Saved;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private static ISettingDefinition[] SetCandidate<T>(
+        Dictionary<string, SettingDefinition> settings,
+        SettingDefinition<T> settingDefinition)
+    {
+        if (settings.TryGetValue(settingDefinition.Key, out SettingDefinition? existingSetting) &&
+            existingSetting is ISettingDefinitionWithValue<T> existingSettingT &&
+            EqualityComparer<T>.Default.Equals(existingSettingT.Value, settingDefinition.Value))
+        {
+            return [];
+        }
+
+        settings[settingDefinition.Key] = settingDefinition;
+        return [settingDefinition];
+    }
+
+    private static ISettingDefinition[] UnsetCandidate(
+        Dictionary<string, SettingDefinition> settings,
+        ISettingDefinition settingDefinition)
+    {
+        return settingDefinition.Key != null && settings.Remove(settingDefinition.Key)
+            ? [settingDefinition]
+            : [];
+    }
+
+    private static ISettingDefinition[] ClearCandidate(Dictionary<string, SettingDefinition> settings)
+    {
+        ISettingDefinition[] removedSettings = [.. settings.Values];
+        settings.Clear();
+        return removedSettings;
+    }
+
+    private ISettingDefinition[] CommitCandidateChanges(
+        Dictionary<string, SettingDefinition> originalSettings,
+        Dictionary<string, SettingDefinition> candidateSettings,
+        ISettingDefinition[] changedSettings)
+    {
+        List<ISettingDefinition> committedSettings = [];
+        foreach (ISettingDefinition changedSetting in changedSettings)
+        {
+            if (changedSetting.Key == null)
+            {
+                continue;
+            }
+
+            bool originallySet = originalSettings.TryGetValue(
+                changedSetting.Key,
+                out SettingDefinition? originalSetting);
+            bool currentlySet = _settings.TryGetValue(
+                changedSetting.Key,
+                out SettingDefinition? currentSetting);
+            bool currentMatchesOriginal = originallySet
+                ? currentlySet && ReferenceEquals(currentSetting, originalSetting)
+                : !currentlySet;
+            if (!currentMatchesOriginal)
+            {
+                continue;
+            }
+
+            if (candidateSettings.TryGetValue(changedSetting.Key, out SettingDefinition? candidateSetting))
+            {
+                _settings[changedSetting.Key] = candidateSetting;
+            }
+            else
+            {
+                _settings.Remove(changedSetting.Key);
+            }
+
+            committedSettings.Add(changedSetting);
+        }
+
+        return [.. committedSettings];
+    }
+
+    private void TrackCommittedSettings(
+        Dictionary<string, SettingDefinition> candidateSettings,
+        ISettingDefinition[] changedSettings)
+    {
+        foreach (ISettingDefinition changedSetting in changedSettings)
+        {
+            object? value = candidateSettings.TryGetValue(
+                changedSetting.Key,
+                out SettingDefinition? candidateSetting)
+                ? GetSafeTelemetryValue(candidateSetting)
+                : "default";
+            TrackSettingChanged(changedSetting.Key, value);
         }
     }
 
@@ -294,16 +488,17 @@ public partial class LocalSettingsService : ISettingsService, IDisposable
             });
     }
 
-    private static object? GetSafeTelemetryValue<T>(SettingDefinition<T> settingDefinition)
+    private static object? GetSafeTelemetryValue(ISettingDefinition settingDefinition)
     {
-        if (settingDefinition.Value is bool value)
+        if (settingDefinition is ISettingDefinitionWithValue<bool> boolSetting)
         {
-            return value;
+            return boolSetting.Value;
         }
 
         if (settingDefinition.Key == CaptureToolSettings.Settings_LanguageOverride.Key)
         {
-            return settingDefinition.Value is not string languageOverride ||
+            return settingDefinition is not ISettingDefinitionWithValue<string> stringSetting ||
+                stringSetting.Value is not string languageOverride ||
                 string.IsNullOrWhiteSpace(languageOverride)
                 ? "system_default"
                 : "override";
@@ -334,6 +529,19 @@ public partial class LocalSettingsService : ISettingsService, IDisposable
 
     public void ClearAllSettings()
     {
-        _settings.Clear();
+        lock (_accessLock)
+        {
+            ThrowIfNotInitialized();
+            ISettingDefinition[] removedSettings = [.. _settings.Values];
+            _settings.Clear();
+            if (removedSettings.Length > 0)
+            {
+                FireSettingsChangedEvent(removedSettings);
+                foreach (ISettingDefinition removedSetting in removedSettings)
+                {
+                    TrackSettingChanged(removedSetting.Key, "default");
+                }
+            }
+        }
     }
 }

--- a/src/CaptureTool.Presentation.Windows.WinUI/Telemetry/TelemetryConsentDialogService.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Telemetry/TelemetryConsentDialogService.cs
@@ -94,11 +94,14 @@ internal sealed class TelemetryConsentDialogService
             TelemetryConsentState state = result == ContentDialogResult.Primary
                 ? TelemetryConsentState.Granted
                 : TelemetryConsentState.Denied;
-            _settingsService.Set(
+            SettingsMutationResult saveResult = await _settingsService.TrySetAndSaveAsync(
                 CaptureToolSettings.Settings_TelemetryConsent,
-                TelemetryConsentSettingValues.Serialize(state));
-            await _settingsService.TrySaveAsync(cancellationToken);
-            _consentService.SetState(state);
+                TelemetryConsentSettingValues.Serialize(state),
+                cancellationToken);
+            if (saveResult.Succeeded)
+            {
+                _consentService.SetState(state);
+            }
         }
         finally
         {

--- a/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
@@ -2198,14 +2198,14 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         }
 
         bool consented = await _aiFeatureConsentDialogService.RequestConsentAsync(featureId, cancellationToken);
-        await _aiFeatureConsentService.SetConsentAsync(featureId, consented, cancellationToken);
+        bool saved = await _aiFeatureConsentService.SetConsentAsync(featureId, consented, cancellationToken);
         UpdateCanToggleSuperResolution();
         UpdateCanToggleTextExtraction();
         UpdateCanToggleImageDescription();
         UpdateCanToggleForegroundExtraction();
         UpdateCanToggleObjectErase();
         UpdateCanToggleObjectExtraction();
-        return consented;
+        return consented && saved;
     }
 
     private async Task EnsureTextExtractionCurrentAsync()
@@ -3215,9 +3215,9 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
             return AiFeatureConsentState.Granted;
         }
 
-        public Task SetConsentAsync(AiFeatureId featureId, bool isGranted, CancellationToken cancellationToken = default)
+        public Task<bool> SetConsentAsync(AiFeatureId featureId, bool isGranted, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
     }
 

--- a/src/CaptureTool.Presentation/Features/Settings/SettingsPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/Settings/SettingsPageViewModel.cs
@@ -490,7 +490,14 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
 
     public async Task UpdateAiFeatureConsentAsync(AiFeatureId featureId, bool isConsented)
     {
-        await _aiFeatureConsentService.SetConsentAsync(featureId, isConsented, CancellationToken.None);
+        bool saved = await _aiFeatureConsentService.SetConsentAsync(
+            featureId,
+            isConsented,
+            CancellationToken.None);
+        if (!saved)
+        {
+            return;
+        }
 
         AiFeatureConsentViewModel? featureConsent = AiFeatureConsents.FirstOrDefault(consent => consent.FeatureId == featureId);
         featureConsent?.ApplyConsent(isConsented);
@@ -510,8 +517,29 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
             return;
         }
 
-        await _updateAppLanguageAction.ExecuteAsync(new UpdateAppLanguageRequest(index), CancellationToken.None);
+        var response = await _updateAppLanguageAction.ExecuteAsync(
+            new UpdateAppLanguageRequest(index),
+            CancellationToken.None);
+        if (response.Value?.Succeeded != true)
+        {
+            SelectedAppLanguageIndex = GetCommittedAppLanguageIndex();
+        }
+
         UpdateShowAppLanguageRestartMessage();
+    }
+
+    private int GetCommittedAppLanguageIndex()
+    {
+        string? languageOverride = _localizationService.LanguageOverride?.Value;
+        for (var index = 0; index < AppLanguages.Count - 1; index++)
+        {
+            if (AppLanguages[index].Language?.Value == languageOverride)
+            {
+                return index;
+            }
+        }
+
+        return AppLanguages.Count - 1;
     }
 
     private void UpdateShowAppLanguageRestartMessage()
@@ -556,62 +584,102 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
 
     private async Task UpdateImageCaptureAutoSaveAsync(bool value)
     {
-        ImageCaptureAutoSave = value;
-        await _updateImageAutoSaveAction.ExecuteAsync(new UpdateImageAutoSaveRequest(value), CancellationToken.None);
+        var response = await _updateImageAutoSaveAction.ExecuteAsync(
+            new UpdateImageAutoSaveRequest(value),
+            CancellationToken.None);
+        ImageCaptureAutoSave = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_ImageCapture_AutoSave);
     }
 
     private async Task UpdateImageCaptureAutoCopyAsync(bool value)
     {
-        ImageCaptureAutoCopy = value;
-        await _updateImageAutoCopyAction.ExecuteAsync(new UpdateImageAutoCopyRequest(value), CancellationToken.None);
+        var response = await _updateImageAutoCopyAction.ExecuteAsync(
+            new UpdateImageAutoCopyRequest(value),
+            CancellationToken.None);
+        ImageCaptureAutoCopy = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_ImageCapture_AutoCopy);
     }
 
     private async Task UpdateVideoCaptureAutoSaveAsync(bool value)
     {
-        VideoCaptureAutoSave = value;
-        await _updateVideoCaptureAutoSaveAction.ExecuteAsync(new UpdateVideoCaptureAutoSaveRequest(value), CancellationToken.None);
+        var response = await _updateVideoCaptureAutoSaveAction.ExecuteAsync(
+            new UpdateVideoCaptureAutoSaveRequest(value),
+            CancellationToken.None);
+        VideoCaptureAutoSave = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_VideoCapture_AutoSave);
     }
 
     private async Task UpdateVideoCaptureAutoCopyAsync(bool value)
     {
-        VideoCaptureAutoCopy = value;
-        await _updateVideoCaptureAutoCopyAction.ExecuteAsync(new UpdateVideoCaptureAutoCopyRequest(value), CancellationToken.None);
+        var response = await _updateVideoCaptureAutoCopyAction.ExecuteAsync(
+            new UpdateVideoCaptureAutoCopyRequest(value),
+            CancellationToken.None);
+        VideoCaptureAutoCopy = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_VideoCapture_AutoCopy);
     }
 
     private async Task UpdateAudioCaptureAutoSaveAsync(bool value)
     {
-        AudioCaptureAutoSave = value;
-        await _updateAudioCaptureAutoSaveAction.ExecuteAsync(new UpdateAudioCaptureAutoSaveRequest(value), CancellationToken.None);
+        var response = await _updateAudioCaptureAutoSaveAction.ExecuteAsync(
+            new UpdateAudioCaptureAutoSaveRequest(value),
+            CancellationToken.None);
+        AudioCaptureAutoSave = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_AudioCapture_AutoSave);
     }
 
     private async Task UpdateAudioCaptureAutoCopyAsync(bool value)
     {
-        AudioCaptureAutoCopy = value;
-        await _updateAudioCaptureAutoCopyAction.ExecuteAsync(new UpdateAudioCaptureAutoCopyRequest(value), CancellationToken.None);
+        var response = await _updateAudioCaptureAutoCopyAction.ExecuteAsync(
+            new UpdateAudioCaptureAutoCopyRequest(value),
+            CancellationToken.None);
+        AudioCaptureAutoCopy = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_AudioCapture_AutoCopy);
     }
 
     private async Task UpdateVideoCaptureDefaultLocalAudioAsync(bool value)
     {
-        VideoCaptureDefaultLocalAudio = value;
-        await _updateVideoCaptureDefaultLocalAudioAction.ExecuteAsync(new UpdateVideoCaptureDefaultLocalAudioRequest(value), CancellationToken.None);
+        var response = await _updateVideoCaptureDefaultLocalAudioAction.ExecuteAsync(
+            new UpdateVideoCaptureDefaultLocalAudioRequest(value),
+            CancellationToken.None);
+        VideoCaptureDefaultLocalAudio = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_VideoCapture_DefaultLocalAudioEnabled);
     }
 
     private async Task UpdateAudioCaptureDefaultLocalAudioAsync(bool value)
     {
-        AudioCaptureDefaultLocalAudio = value;
-        await _updateAudioCaptureDefaultLocalAudioAction.ExecuteAsync(new UpdateAudioCaptureDefaultLocalAudioRequest(value), CancellationToken.None);
+        var response = await _updateAudioCaptureDefaultLocalAudioAction.ExecuteAsync(
+            new UpdateAudioCaptureDefaultLocalAudioRequest(value),
+            CancellationToken.None);
+        AudioCaptureDefaultLocalAudio = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_AudioCapture_DefaultLocalAudioEnabled);
     }
 
     private async Task UpdateEditWarnBeforeDiscardAsync(bool value)
     {
-        EditWarnBeforeDiscard = value;
-        await _updateEditWarnBeforeDiscardAction.ExecuteAsync(new UpdateEditWarnBeforeDiscardRequest(value), CancellationToken.None);
+        var response = await _updateEditWarnBeforeDiscardAction.ExecuteAsync(
+            new UpdateEditWarnBeforeDiscardRequest(value),
+            CancellationToken.None);
+        EditWarnBeforeDiscard = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_Edit_WarnBeforeDiscard);
     }
 
     private async Task UpdateCaptureWarnBeforeDiscardAsync(bool value)
     {
-        CaptureWarnBeforeDiscard = value;
-        await _updateCaptureWarnBeforeDiscardAction.ExecuteAsync(new UpdateCaptureWarnBeforeDiscardRequest(value), CancellationToken.None);
+        var response = await _updateCaptureWarnBeforeDiscardAction.ExecuteAsync(
+            new UpdateCaptureWarnBeforeDiscardRequest(value),
+            CancellationToken.None);
+        CaptureWarnBeforeDiscard = response.Value?.Succeeded == true
+            ? value
+            : _settingsService.Get(CaptureToolSettings.Settings_Capture_WarnBeforeDiscard);
     }
 
     private async Task UpdateStoreReviewRemindersEnabledAsync(bool value)
@@ -622,23 +690,24 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
 
     private async Task UpdateOptionalUsageDataEnabledAsync(bool value)
     {
-        OptionalUsageDataEnabled = value;
         TelemetryConsentState state = value
             ? TelemetryConsentState.Granted
             : TelemetryConsentState.Denied;
-        if (state == TelemetryConsentState.Denied)
+        SettingsMutationResult result = await _settingsService.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_TelemetryConsent,
+            TelemetryConsentSettingValues.Serialize(state),
+            CancellationToken.None);
+        if (!result.Succeeded)
         {
-            _telemetryConsentService?.SetState(state);
+            OptionalUsageDataEnabled =
+                TelemetryConsentSettingValues.Parse(
+                    _settingsService.Get(CaptureToolSettings.Settings_TelemetryConsent)) ==
+                TelemetryConsentState.Granted;
+            return;
         }
 
-        _settingsService.Set(
-            CaptureToolSettings.Settings_TelemetryConsent,
-            TelemetryConsentSettingValues.Serialize(state));
-        await _settingsService.TrySaveAsync(CancellationToken.None);
-        if (state == TelemetryConsentState.Granted)
-        {
-            _telemetryConsentService?.SetState(state);
-        }
+        OptionalUsageDataEnabled = value;
+        _telemetryConsentService?.SetState(state);
     }
 
     private async Task OpenStoreReviewAsync()
@@ -731,7 +800,13 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
 
     private async Task RestoreDefaultSettingsAsync()
     {
-        await _restoreDefaultsAction.ExecuteAsync(new RestoreDefaultsRequest(), CancellationToken.None);
+        var response = await _restoreDefaultsAction.ExecuteAsync(
+            new RestoreDefaultsRequest(),
+            CancellationToken.None);
+        if (response.Value?.Succeeded != true)
+        {
+            return;
+        }
 
         ImageCaptureAutoCopy = _settingsService.Get(CaptureToolSettings.Settings_ImageCapture_AutoCopy);
         ImageCaptureAutoSave = _settingsService.Get(CaptureToolSettings.Settings_ImageCapture_AutoSave);

--- a/src/CaptureTool.Presentation/Features/VideoEdit/VideoEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/VideoEdit/VideoEditPageViewModel.cs
@@ -571,12 +571,12 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         bool consented = await _aiFeatureConsentDialogService.RequestConsentAsync(
             featureId,
             cancellationToken);
-        await _aiFeatureConsentService.SetConsentAsync(
+        bool saved = await _aiFeatureConsentService.SetConsentAsync(
             featureId,
             consented,
             cancellationToken);
         UpdateVideoSuperResolutionAvailability();
-        return consented;
+        return consented && saved;
     }
 
     private void ShowOriginalVideo()
@@ -819,12 +819,12 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
             return AiFeatureConsentState.Granted;
         }
 
-        public Task SetConsentAsync(
+        public Task<bool> SetConsentAsync(
             AiFeatureId featureId,
             bool isGranted,
             CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
     }
 

--- a/tests/CaptureTool.Application.Tests/Ai/AiFeatureConsentServiceTests.cs
+++ b/tests/CaptureTool.Application.Tests/Ai/AiFeatureConsentServiceTests.cs
@@ -40,13 +40,19 @@ public sealed class AiFeatureConsentServiceTests
     [TestMethod]
     public async Task SetConsentAsync_PersistsFeatureConsent()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var service = new AiFeatureConsentService(settings.Object);
 
-        await service.SetConsentAsync(AiFeatureId.TextExtraction, true, TestContext.CancellationToken);
+        bool saved = await service.SetConsentAsync(
+            AiFeatureId.TextExtraction,
+            true,
+            TestContext.CancellationToken);
 
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AiConsent_TextExtraction, true), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+        saved.Should().BeTrue();
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_AiConsent_TextExtraction,
+            true,
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -63,12 +69,15 @@ public sealed class AiFeatureConsentServiceTests
     [TestMethod]
     public async Task SetConsentAsync_PersistsImageDescriptionConsent()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var service = new AiFeatureConsentService(settings.Object);
 
         await service.SetConsentAsync(AiFeatureId.ImageDescription, true, TestContext.CancellationToken);
 
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AiConsent_ImageDescription, true), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_AiConsent_ImageDescription,
+            true,
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -85,12 +94,15 @@ public sealed class AiFeatureConsentServiceTests
     [TestMethod]
     public async Task SetConsentAsync_PersistsBackgroundRemovalConsent()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var service = new AiFeatureConsentService(settings.Object);
 
         await service.SetConsentAsync(AiFeatureId.ImageForegroundExtraction, true, TestContext.CancellationToken);
 
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AiConsent_ImageForegroundExtraction, true), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_AiConsent_ImageForegroundExtraction,
+            true,
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -107,12 +119,15 @@ public sealed class AiFeatureConsentServiceTests
     [TestMethod]
     public async Task SetConsentAsync_PersistsObjectEraseConsent()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var service = new AiFeatureConsentService(settings.Object);
 
         await service.SetConsentAsync(AiFeatureId.ImageObjectErase, true, TestContext.CancellationToken);
 
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AiConsent_ImageObjectErase, true), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_AiConsent_ImageObjectErase,
+            true,
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -129,12 +144,15 @@ public sealed class AiFeatureConsentServiceTests
     [TestMethod]
     public async Task SetConsentAsync_PersistsObjectExtractionConsent()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var service = new AiFeatureConsentService(settings.Object);
 
         await service.SetConsentAsync(AiFeatureId.ImageObjectExtraction, true, TestContext.CancellationToken);
 
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AiConsent_ImageObjectExtraction, true), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_AiConsent_ImageObjectExtraction,
+            true,
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -151,7 +169,7 @@ public sealed class AiFeatureConsentServiceTests
     [TestMethod]
     public async Task SetConsentAsync_PersistsVideoSuperResolutionConsent()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var service = new AiFeatureConsentService(settings.Object);
 
         await service.SetConsentAsync(
@@ -160,10 +178,43 @@ public sealed class AiFeatureConsentServiceTests
             TestContext.CancellationToken);
 
         settings.Verify(
-            service => service.Set(
+            service => service.TrySetAndSaveAsync(
                 CaptureToolSettings.Settings_AiConsent_VideoSuperResolution,
-                true),
+                true,
+                TestContext.CancellationToken),
             Times.Once);
+    }
+
+    [TestMethod]
+    public async Task SetConsentAsync_WhenPersistenceFails_ReturnsFalse()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                CaptureToolSettings.Settings_AiConsent_TextExtraction,
+                true,
+                TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.PersistenceFailed);
+        var service = new AiFeatureConsentService(settings.Object);
+
+        bool saved = await service.SetConsentAsync(
+            AiFeatureId.TextExtraction,
+            true,
+            TestContext.CancellationToken);
+
+        saved.Should().BeFalse();
+    }
+
+    private static Mock<ISettingsService> CreatePersistingSettings()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                It.IsAny<IBoolSettingDefinition>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SettingsMutationResult.Saved);
+        return settings;
     }
 
     public TestContext TestContext { get; set; } = null!;

--- a/tests/CaptureTool.Application.Tests/Diagnostics/DiagnosticsUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Diagnostics/DiagnosticsUseCaseTests.cs
@@ -57,6 +57,12 @@ public sealed class DiagnosticsUseCaseTests
     {
         var logService = new Mock<ILogService>();
         var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                CaptureToolSettings.VerboseLogging,
+                true,
+                TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.Saved);
         var useCase = new UpdateLoggingStateUseCase(logService.Object, settings.Object, TestUseCaseExecutor.Instance);
 
         UpdateLoggingStateResponse response = (await useCase.ExecuteAsync(new UpdateLoggingStateRequest(true), TestContext.CancellationToken)).Value!;
@@ -64,8 +70,10 @@ public sealed class DiagnosticsUseCaseTests
         Assert.IsTrue(response.Succeeded);
         logService.Verify(service => service.Enable(), Times.Once);
         logService.Verify(service => service.Disable(), Times.Never);
-        settings.Verify(service => service.Set(CaptureToolSettings.VerboseLogging, true), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.VerboseLogging,
+            true,
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -73,6 +81,12 @@ public sealed class DiagnosticsUseCaseTests
     {
         var logService = new Mock<ILogService>();
         var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                CaptureToolSettings.VerboseLogging,
+                false,
+                TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.Saved);
         var useCase = new UpdateLoggingStateUseCase(logService.Object, settings.Object, TestUseCaseExecutor.Instance);
 
         UpdateLoggingStateResponse response = (await useCase.ExecuteAsync(new UpdateLoggingStateRequest(false), TestContext.CancellationToken)).Value!;
@@ -80,8 +94,35 @@ public sealed class DiagnosticsUseCaseTests
         Assert.IsTrue(response.Succeeded);
         logService.Verify(service => service.Disable(), Times.Once);
         logService.Verify(service => service.Enable(), Times.Never);
-        settings.Verify(service => service.Set(CaptureToolSettings.VerboseLogging, false), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.VerboseLogging,
+            false,
+            TestContext.CancellationToken), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UpdateLoggingStateUseCase_WhenPersistenceFails_DoesNotChangeLoggingState()
+    {
+        var logService = new Mock<ILogService>();
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                CaptureToolSettings.VerboseLogging,
+                true,
+                TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.PersistenceFailed);
+        var useCase = new UpdateLoggingStateUseCase(
+            logService.Object,
+            settings.Object,
+            TestUseCaseExecutor.Instance);
+
+        UpdateLoggingStateResponse response = (await useCase.ExecuteAsync(
+            new UpdateLoggingStateRequest(true),
+            TestContext.CancellationToken)).Value!;
+
+        Assert.IsFalse(response.Succeeded);
+        logService.Verify(service => service.Enable(), Times.Never);
+        logService.Verify(service => service.Disable(), Times.Never);
     }
 
     public TestContext TestContext { get; set; } = null!;

--- a/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
@@ -61,7 +61,7 @@ public sealed class SettingsPageUseCaseTests
     public async Task ChangeScreenshotsFolderUseCase_WhenFolderSelected_SavesFolderSetting()
     {
         var picker = new Mock<IFilePickerService>();
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         picker
             .Setup(service => service.PickFolderAsync(UserFolder.Pictures))
             .ReturnsAsync(Mock.Of<IFolder>(folder => folder.FolderPath == @"C:\Screenshots"));
@@ -70,15 +70,17 @@ public sealed class SettingsPageUseCaseTests
         ChangeScreenshotsFolderResponse response = (await useCase.ExecuteAsync(new ChangeScreenshotsFolderRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsTrue(response.Changed);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder, @"C:\Screenshots"), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder,
+            @"C:\Screenshots",
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
     public async Task ChangeVideosFolderUseCase_WhenPickerCanceled_DoesNotSaveSetting()
     {
         var picker = new Mock<IFilePickerService>();
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         picker
             .Setup(service => service.PickFolderAsync(UserFolder.Videos))
             .ReturnsAsync((IFolder?)null);
@@ -87,15 +89,17 @@ public sealed class SettingsPageUseCaseTests
         ChangeVideosFolderResponse response = (await useCase.ExecuteAsync(new ChangeVideosFolderRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsFalse(response.Changed);
-        settings.Verify(service => service.Set(It.IsAny<IStringSettingDefinition>(), It.IsAny<string>()), Times.Never);
-        settings.Verify(service => service.TrySaveAsync(It.IsAny<CancellationToken>()), Times.Never);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            It.IsAny<IStringSettingDefinition>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [TestMethod]
     public async Task ChangeAudioFolderUseCase_WhenFolderSelected_SavesFolderSetting()
     {
         var picker = new Mock<IFilePickerService>();
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         picker
             .Setup(service => service.PickFolderAsync(UserFolder.Music))
             .ReturnsAsync(Mock.Of<IFolder>(folder => folder.FolderPath == @"C:\Audio"));
@@ -104,8 +108,10 @@ public sealed class SettingsPageUseCaseTests
         ChangeAudioFolderResponse response = (await useCase.ExecuteAsync(new ChangeAudioFolderRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsTrue(response.Changed);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AudioCapture_AutoSaveFolder, @"C:\Audio"), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_AudioCapture_AutoSaveFolder,
+            @"C:\Audio",
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
@@ -159,7 +165,7 @@ public sealed class SettingsPageUseCaseTests
     public async Task OpenFolderUseCases_WhenFoldersAreMissing_ReturnNotOpened()
     {
         string missingFolder = Path.Combine(Path.GetTempPath(), "CaptureToolTests", Guid.NewGuid().ToString());
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var storage = new Mock<IStorageService>();
         var folderLauncher = new Mock<IFolderLauncher>();
         settings.Setup(service => service.Get(CaptureToolSettings.Settings_ImageCapture_AutoSaveFolder)).Returns("");
@@ -206,7 +212,7 @@ public sealed class SettingsPageUseCaseTests
     [TestMethod]
     public async Task RestoreDefaultsUseCase_ClearsSettingsLanguageOverrideAndSaves()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         var localization = new Mock<ILocalizationService>();
         var telemetryConsent = new Mock<ITelemetryConsentService>();
         var useCase = new RestoreDefaultsUseCase(
@@ -218,12 +224,37 @@ public sealed class SettingsPageUseCaseTests
         RestoreDefaultsResponse response = (await useCase.ExecuteAsync(new RestoreDefaultsRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsTrue(response.Succeeded);
-        settings.Verify(service => service.ClearAllSettings(), Times.Once);
+        settings.Verify(service => service.TryClearAllAndSaveAsync(TestContext.CancellationToken), Times.Once);
         localization.Verify(service => service.OverrideLanguage(null), Times.Once);
         telemetryConsent.Verify(
             service => service.SetState(TelemetryConsentState.Unknown),
             Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RestoreDefaultsUseCase_WhenPersistenceFails_DoesNotApplyRuntimeDefaults()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TryClearAllAndSaveAsync(TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.PersistenceFailed);
+        var localization = new Mock<ILocalizationService>();
+        var telemetryConsent = new Mock<ITelemetryConsentService>();
+        var useCase = new RestoreDefaultsUseCase(
+            settings.Object,
+            localization.Object,
+            telemetryConsent.Object,
+            TestUseCaseExecutor.Instance);
+
+        RestoreDefaultsResponse response = (await useCase.ExecuteAsync(
+            new RestoreDefaultsRequest(),
+            TestContext.CancellationToken)).Value!;
+
+        Assert.IsFalse(response.Succeeded);
+        localization.Verify(service => service.OverrideLanguage(It.IsAny<IAppLanguage?>()), Times.Never);
+        telemetryConsent.Verify(
+            service => service.SetState(It.IsAny<TelemetryConsentState>()),
+            Times.Never);
     }
 
     [TestMethod]
@@ -231,7 +262,7 @@ public sealed class SettingsPageUseCaseTests
     {
         var language = Mock.Of<IAppLanguage>(appLanguage => appLanguage.Value == "fr-FR");
         var localization = new Mock<ILocalizationService>();
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         localization.Setup(service => service.SupportedLanguages).Returns([language]);
         var useCase = new UpdateAppLanguageUseCase(localization.Object, settings.Object, TestUseCaseExecutor.Instance);
 
@@ -240,15 +271,17 @@ public sealed class SettingsPageUseCaseTests
 
         Assert.IsTrue(response.Succeeded);
         localization.Verify(service => service.OverrideLanguage(language), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_LanguageOverride, "fr-FR"), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Once);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            CaptureToolSettings.Settings_LanguageOverride,
+            "fr-FR",
+            TestContext.CancellationToken), Times.Once);
     }
 
     [TestMethod]
     public async Task UpdateAppLanguageUseCase_WithDefaultLanguage_ClearsLanguageOverride()
     {
         var localization = new Mock<ILocalizationService>();
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         localization.Setup(service => service.SupportedLanguages).Returns([Mock.Of<IAppLanguage>()]);
         var useCase = new UpdateAppLanguageUseCase(localization.Object, settings.Object, TestUseCaseExecutor.Instance);
 
@@ -256,14 +289,42 @@ public sealed class SettingsPageUseCaseTests
 
         Assert.IsTrue(response.Succeeded);
         localization.Verify(service => service.OverrideLanguage(null), Times.Once);
-        settings.Verify(service => service.Unset(CaptureToolSettings.Settings_LanguageOverride), Times.Once);
+        settings.Verify(service => service.TryUnsetAndSaveAsync(
+            CaptureToolSettings.Settings_LanguageOverride,
+            TestContext.CancellationToken), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UpdateAppLanguageUseCase_WhenPersistenceFails_DoesNotOverrideLanguage()
+    {
+        var language = Mock.Of<IAppLanguage>(appLanguage => appLanguage.Value == "fr-FR");
+        var localization = new Mock<ILocalizationService>();
+        localization.Setup(service => service.SupportedLanguages).Returns([language]);
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                CaptureToolSettings.Settings_LanguageOverride,
+                "fr-FR",
+                TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.PersistenceFailed);
+        var useCase = new UpdateAppLanguageUseCase(
+            localization.Object,
+            settings.Object,
+            TestUseCaseExecutor.Instance);
+
+        UpdateAppLanguageResponse response = (await useCase.ExecuteAsync(
+            new UpdateAppLanguageRequest(0),
+            TestContext.CancellationToken)).Value!;
+
+        Assert.IsFalse(response.Succeeded);
+        localization.Verify(service => service.OverrideLanguage(It.IsAny<IAppLanguage?>()), Times.Never);
     }
 
     [TestMethod]
     public async Task UpdateAppLanguageUseCase_WithInvalidIndex_ReturnsFailureWithoutSaving()
     {
         var localization = new Mock<ILocalizationService>();
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
         localization.Setup(service => service.SupportedLanguages).Returns([]);
         var useCase = new UpdateAppLanguageUseCase(localization.Object, settings.Object, TestUseCaseExecutor.Instance);
 
@@ -271,13 +332,19 @@ public sealed class SettingsPageUseCaseTests
         UpdateAppLanguageResponse response = (await useCase.ExecuteAsync(new UpdateAppLanguageRequest(-1), TestContext.CancellationToken)).Value!;
 
         Assert.IsFalse(response.Succeeded);
-        settings.Verify(service => service.TrySaveAsync(It.IsAny<CancellationToken>()), Times.Never);
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            It.IsAny<IStringSettingDefinition>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        settings.Verify(service => service.TryUnsetAndSaveAsync(
+            It.IsAny<ISettingDefinition>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [TestMethod]
     public async Task UpdateBooleanSettingsUseCases_SetExpectedSettingAndSave()
     {
-        var settings = new Mock<ISettingsService>();
+        Mock<ISettingsService> settings = CreatePersistingSettings();
 
         await new UpdateImageAutoCopyUseCase(settings.Object, TestUseCaseExecutor.Instance)
             .ExecuteAsync(new UpdateImageAutoCopyRequest(false), TestContext.CancellationToken);
@@ -304,17 +371,31 @@ public sealed class SettingsPageUseCaseTests
             new UpdateEditWarnBeforeDiscardRequest(true),
             TestContext.CancellationToken);
 
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_ImageCapture_AutoCopy, false), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_ImageCapture_AutoSave, true), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_VideoCapture_AutoCopy, false), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_VideoCapture_AutoSave, true), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_VideoCapture_DefaultLocalAudioEnabled, false), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AudioCapture_AutoCopy, false), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AudioCapture_AutoSave, true), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_AudioCapture_DefaultLocalAudioEnabled, false), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_Capture_WarnBeforeDiscard, false), Times.Once);
-        settings.Verify(service => service.Set(CaptureToolSettings.Settings_Edit_WarnBeforeDiscard, true), Times.Once);
-        settings.Verify(service => service.TrySaveAsync(TestContext.CancellationToken), Times.Exactly(10));
+        settings.Verify(service => service.TrySetAndSaveAsync(
+            It.IsAny<IBoolSettingDefinition>(),
+            It.IsAny<bool>(),
+            TestContext.CancellationToken), Times.Exactly(10));
+    }
+
+    [TestMethod]
+    public async Task UpdateImageAutoSaveUseCase_WhenPersistenceFails_ReturnsFailure()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                CaptureToolSettings.Settings_ImageCapture_AutoSave,
+                true,
+                TestContext.CancellationToken))
+            .ReturnsAsync(SettingsMutationResult.PersistenceFailed);
+        var useCase = new UpdateImageAutoSaveUseCase(
+            settings.Object,
+            TestUseCaseExecutor.Instance);
+
+        UpdateImageAutoSaveResponse response = (await useCase.ExecuteAsync(
+            new UpdateImageAutoSaveRequest(true),
+            TestContext.CancellationToken)).Value!;
+
+        Assert.IsFalse(response.Succeeded);
     }
 
     private static string CreateTestFolder()
@@ -322,6 +403,32 @@ public sealed class SettingsPageUseCaseTests
         string path = Path.Combine(Path.GetTempPath(), "CaptureToolTests", Guid.NewGuid().ToString());
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static Mock<ISettingsService> CreatePersistingSettings()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                It.IsAny<IBoolSettingDefinition>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SettingsMutationResult.Saved);
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                It.IsAny<IStringSettingDefinition>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SettingsMutationResult.Saved);
+        settings
+            .Setup(service => service.TryUnsetAndSaveAsync(
+                It.IsAny<ISettingDefinition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SettingsMutationResult.Saved);
+        settings
+            .Setup(service => service.TryClearAllAndSaveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SettingsMutationResult.Saved);
+        return settings;
     }
 
     public TestContext TestContext { get; set; } = null!;

--- a/tests/CaptureTool.Infrastructure.Tests/Settings/LocalSettingsServiceTests.cs
+++ b/tests/CaptureTool.Infrastructure.Tests/Settings/LocalSettingsServiceTests.cs
@@ -143,6 +143,148 @@ public sealed class LocalSettingsServiceTests
     }
 
     [TestMethod]
+    public async Task TrySetAndSaveAsync_WhenStorageThrows_KeepsCommittedValueAndSuppressesNotification()
+    {
+        var logService = new TestLogService();
+        var jsonStorage = new TestJsonStorageService { WriteException = new IOException("nope") };
+        var telemetry = new RecordingTelemetryService();
+        using var service = new LocalSettingsService(logService, jsonStorage, telemetry);
+        IBoolSettingDefinition definition = CaptureToolSettings.Settings_ImageCapture_AutoCopy;
+        await service.InitializeAsync("settings.json", TestContext.CancellationToken);
+        int changedCount = 0;
+        service.SettingsChanged += _ => changedCount++;
+
+        SettingsMutationResult result = await service.TrySetAndSaveAsync(
+            definition,
+            false,
+            TestContext.CancellationToken);
+
+        Assert.AreEqual(SettingsMutationStatus.PersistenceFailed, result.Status);
+        Assert.IsTrue(service.Get(definition));
+        Assert.IsFalse(service.IsSet(definition));
+        Assert.AreEqual(0, changedCount);
+        Assert.IsEmpty(telemetry.Events);
+        StringAssert.Contains(logService.LastMessage!, "settings mutation save operation");
+    }
+
+    [TestMethod]
+    public async Task TrySetAndSaveAsync_WhenWriteSucceeds_CommitsThenNotifies()
+    {
+        var jsonStorage = new TestJsonStorageService();
+        var telemetry = new RecordingTelemetryService();
+        using var service = new LocalSettingsService(
+            new TestLogService(),
+            jsonStorage,
+            telemetry);
+        IBoolSettingDefinition definition = CaptureToolSettings.Settings_ImageCapture_AutoCopy;
+        await service.InitializeAsync("settings.json", TestContext.CancellationToken);
+        ISettingDefinition[]? changed = null;
+        service.SettingsChanged += settings => changed = settings;
+
+        SettingsMutationResult result = await service.TrySetAndSaveAsync(
+            definition,
+            false,
+            TestContext.CancellationToken);
+
+        Assert.AreEqual(SettingsMutationStatus.Saved, result.Status);
+        Assert.IsFalse(service.Get(definition));
+        Assert.IsTrue(service.IsSet(definition));
+        Assert.IsNotNull(changed);
+        Assert.AreEqual(definition.Key, changed.Single().Key);
+        Assert.AreEqual(definition.Key, jsonStorage.WrittenSettings!.Single().Key);
+        Assert.HasCount(1, telemetry.Events);
+    }
+
+    [TestMethod]
+    public async Task TryClearAllAndSaveAsync_WhileWriteIsPending_KeepsCommittedValuesReadableThenNotifies()
+    {
+        var writeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var jsonStorage = new TestJsonStorageService
+        {
+            WriteStarted = writeStarted,
+            ContinueWrite = continueWrite,
+        };
+        using var service = new LocalSettingsService(new TestLogService(), jsonStorage);
+        var first = new BoolSettingDefinition("first", false);
+        var second = new StringSettingDefinition("second", "default");
+        await service.InitializeAsync("settings.json", TestContext.CancellationToken);
+        service.Set(first, true);
+        service.Set(second, "saved");
+        ISettingDefinition[]? changed = null;
+        service.SettingsChanged += settings => changed = settings;
+
+        Task<SettingsMutationResult> clearTask = service.TryClearAllAndSaveAsync(
+            TestContext.CancellationToken);
+        await writeStarted.Task;
+        bool[] concurrentReads = await Task.WhenAll(
+            Enumerable.Range(0, 16).Select(_ => Task.Run(() => service.Get(first))));
+
+        Assert.IsTrue(concurrentReads.All(value => value));
+        Assert.IsNull(changed);
+
+        continueWrite.SetResult(true);
+        SettingsMutationResult result = await clearTask;
+
+        Assert.AreEqual(SettingsMutationStatus.Saved, result.Status);
+        Assert.IsFalse(service.Get(first));
+        Assert.AreEqual("default", service.Get(second));
+        Assert.IsNotNull(changed);
+        CollectionAssert.AreEquivalent(
+            new[] { "first", "second" },
+            changed.Select(setting => setting.Key).ToArray());
+        Assert.IsEmpty(jsonStorage.WrittenSettings!);
+    }
+
+    [TestMethod]
+    public async Task TrySetAndSaveAsync_WhenLaterMutationOccurs_DoesNotOverwriteLaterValue()
+    {
+        var writeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var jsonStorage = new TestJsonStorageService
+        {
+            WriteStarted = writeStarted,
+            ContinueWrite = continueWrite,
+        };
+        using var service = new LocalSettingsService(new TestLogService(), jsonStorage);
+        var definition = new BoolSettingDefinition("enabled", false);
+        await service.InitializeAsync("settings.json", TestContext.CancellationToken);
+
+        Task<SettingsMutationResult> saveTask = service.TrySetAndSaveAsync(
+            definition,
+            true,
+            TestContext.CancellationToken);
+        await writeStarted.Task;
+
+        service.Set(definition, false);
+        continueWrite.SetResult(true);
+        SettingsMutationResult result = await saveTask;
+
+        Assert.AreEqual(SettingsMutationStatus.Saved, result.Status);
+        Assert.IsFalse(service.Get(definition));
+    }
+
+    [TestMethod]
+    public async Task ClearAllSettings_UsesNotificationPathForRemovedSettings()
+    {
+        using var service = new LocalSettingsService(new TestLogService(), new TestJsonStorageService());
+        var first = new BoolSettingDefinition("first", false);
+        var second = new IntSettingDefinition("second", 0);
+        await service.InitializeAsync("settings.json", TestContext.CancellationToken);
+        service.Set(first, true);
+        service.Set(second, 2);
+        ISettingDefinition[]? changed = null;
+        service.SettingsChanged += settings => changed = settings;
+
+        service.ClearAllSettings();
+
+        Assert.IsNotNull(changed);
+        CollectionAssert.AreEquivalent(
+            new[] { "first", "second" },
+            changed.Select(setting => setting.Key).ToArray());
+    }
+
+    [TestMethod]
     public async Task AfterDispose_InitializeAndSaveReturnWithoutStorageAccess()
     {
         var jsonStorage = new TestJsonStorageService();
@@ -158,13 +300,32 @@ public sealed class LocalSettingsServiceTests
         Assert.AreEqual(0, jsonStorage.WriteCount);
     }
 
+    [TestMethod]
+    public async Task TrySetAndSaveAsync_AfterDispose_ReturnsServiceUnavailable()
+    {
+        var jsonStorage = new TestJsonStorageService();
+        var service = new LocalSettingsService(new TestLogService(), jsonStorage);
+        await service.InitializeAsync("settings.json", TestContext.CancellationToken);
+        service.Dispose();
+
+        SettingsMutationResult result = await service.TrySetAndSaveAsync(
+            new BoolSettingDefinition("enabled", false),
+            true,
+            TestContext.CancellationToken);
+
+        Assert.AreEqual(SettingsMutationStatus.ServiceUnavailable, result.Status);
+        Assert.AreEqual(0, jsonStorage.WriteCount);
+    }
+
     public TestContext TestContext { get; set; } = null!;
 
     private sealed class TestJsonStorageService : IJsonStorageService
     {
         public List<SettingDefinition>? ReadResult { get; init; }
         public List<SettingDefinition>? WrittenSettings { get; private set; }
-        public Exception? WriteException { get; init; }
+        public Exception? WriteException { get; set; }
+        public TaskCompletionSource<bool>? WriteStarted { get; init; }
+        public TaskCompletionSource<bool>? ContinueWrite { get; init; }
         public int ReadCount { get; private set; }
         public int WriteCount { get; private set; }
 
@@ -174,7 +335,7 @@ public sealed class LocalSettingsServiceTests
             return Task.FromResult((T?)(object?)ReadResult);
         }
 
-        public Task WriteAsync<T>(FileReference file, T value, JsonTypeInfo<T> jsonTypeInfo)
+        public async Task WriteAsync<T>(FileReference file, T value, JsonTypeInfo<T> jsonTypeInfo)
         {
             WriteCount++;
             if (WriteException is not null)
@@ -182,8 +343,13 @@ public sealed class LocalSettingsServiceTests
                 throw WriteException;
             }
 
+            WriteStarted?.TrySetResult(true);
+            if (ContinueWrite is not null)
+            {
+                await ContinueWrite.Task;
+            }
+
             WrittenSettings = (List<SettingDefinition>)(object)value!;
-            return Task.CompletedTask;
         }
     }
 

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelForegroundExtractionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelForegroundExtractionTests.cs
@@ -38,7 +38,7 @@ public sealed class ImageEditPageViewModelForegroundExtractionTests
             .Returns(AiFeatureConsentState.Denied);
         consent
             .Setup(x => x.SetConsentAsync(AiFeatureId.ImageForegroundExtraction, false, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         dialog
             .Setup(x => x.RequestConsentAsync(AiFeatureId.ImageForegroundExtraction, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelImageDescriptionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelImageDescriptionTests.cs
@@ -56,7 +56,7 @@ public sealed class ImageEditPageViewModelImageDescriptionTests
             .Returns(AiFeatureConsentState.Denied);
         consent
             .Setup(x => x.SetConsentAsync(AiFeatureId.ImageDescription, false, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         dialog
             .Setup(x => x.RequestConsentAsync(AiFeatureId.ImageDescription, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
@@ -95,7 +95,7 @@ public sealed class ImageEditPageViewModelImageDescriptionTests
             .Returns(AiFeatureConsentState.Unknown);
         consent
             .Setup(x => x.SetConsentAsync(AiFeatureId.ImageDescription, true, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         dialog
             .Setup(x => x.RequestConsentAsync(AiFeatureId.ImageDescription, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelObjectEraseTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelObjectEraseTests.cs
@@ -38,7 +38,7 @@ public sealed class ImageEditPageViewModelObjectEraseTests
             .Returns(AiFeatureConsentState.Denied);
         consent
             .Setup(x => x.SetConsentAsync(AiFeatureId.ImageObjectErase, false, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         dialog
             .Setup(x => x.RequestConsentAsync(AiFeatureId.ImageObjectErase, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelObjectExtractionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelObjectExtractionTests.cs
@@ -39,7 +39,7 @@ public sealed class ImageEditPageViewModelObjectExtractionTests
             .Returns(AiFeatureConsentState.Denied);
         consent
             .Setup(x => x.SetConsentAsync(AiFeatureId.ImageObjectExtraction, false, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         dialog
             .Setup(x => x.RequestConsentAsync(AiFeatureId.ImageObjectExtraction, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelTextExtractionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelTextExtractionTests.cs
@@ -58,7 +58,7 @@ public sealed class ImageEditPageViewModelTextExtractionTests
         consent
             .Setup(service => service.SetConsentAsync(AiFeatureId.TextExtraction, false, It.IsAny<CancellationToken>()))
             .Callback(() => consentState = AiFeatureConsentState.Denied)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         consent
             .Setup(service => service.GetConsentState(AiFeatureId.ImageSuperResolution))
             .Returns(AiFeatureConsentState.Granted);
@@ -103,7 +103,7 @@ public sealed class ImageEditPageViewModelTextExtractionTests
         consent
             .Setup(service => service.SetConsentAsync(AiFeatureId.TextExtraction, true, It.IsAny<CancellationToken>()))
             .Callback(() => consentState = AiFeatureConsentState.Granted)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         consent
             .Setup(service => service.GetConsentState(AiFeatureId.ImageSuperResolution))
             .Returns(AiFeatureConsentState.Granted);

--- a/tests/CaptureTool.Presentation.Tests/Features/SettingsPageViewModelAiConsentTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/SettingsPageViewModelAiConsentTests.cs
@@ -36,6 +36,7 @@ using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.Store;
 using CaptureTool.Application.Abstractions.Telemetry;
 using CaptureTool.Application.Abstractions.Themes;
+using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Domain.Ai;
 using CaptureTool.Presentation.Factories;
 using CaptureTool.Presentation.Features.Settings;
@@ -72,6 +73,42 @@ public sealed class SettingsPageViewModelAiConsentTests
         telemetryConsent.Verify(
             service => service.SetState(TelemetryConsentState.Granted),
             Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UpdateOptionalUsageDataEnabledCommand_WhenPersistenceFails_RevertsConsentGate()
+    {
+        var telemetryConsent = new Mock<ITelemetryConsentService>();
+        SettingsPageViewModel viewModel = CreateViewModel(
+            telemetryConsentService: telemetryConsent.Object,
+            settingsMutationStatus: SettingsMutationStatus.PersistenceFailed);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        await viewModel.UpdateOptionalUsageDataEnabledCommand.ExecuteAsync(true);
+
+        viewModel.OptionalUsageDataEnabled.Should().BeFalse();
+        telemetryConsent.Verify(
+            service => service.SetState(It.IsAny<TelemetryConsentState>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateImageCaptureAutoSaveCommand_WhenPersistenceFails_RevertsOptimisticValue()
+    {
+        var updateAction = new Mock<IUpdateImageAutoSaveUseCase>();
+        updateAction
+            .Setup(action => action.ExecuteAsync(
+                new UpdateImageAutoSaveRequest(false),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<UpdateImageAutoSaveResponse>.Success(
+                new UpdateImageAutoSaveResponse(false)));
+        SettingsPageViewModel viewModel = CreateViewModel(
+            updateImageAutoSaveAction: updateAction.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        await viewModel.UpdateImageCaptureAutoSaveCommand.ExecuteAsync(false);
+
+        viewModel.ImageCaptureAutoSave.Should().BeTrue();
     }
 
     [TestMethod]
@@ -113,6 +150,20 @@ public sealed class SettingsPageViewModelAiConsentTests
         viewModel.AiFeatureConsents.Should().ContainSingle(consent =>
             consent.FeatureId == AiFeatureId.TextExtraction &&
             consent.DisplayName == "Localized text extraction");
+    }
+
+    [TestMethod]
+    public async Task UpdateAiFeatureConsentAsync_WhenPersistenceFails_KeepsCommittedConsent()
+    {
+        SettingsPageViewModel viewModel = CreateViewModel(
+            isImageSuperResolutionEnabled: false,
+            isTextExtractionEnabled: true,
+            aiConsentSaveSucceeded: false);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        await viewModel.UpdateAiFeatureConsentAsync(AiFeatureId.TextExtraction, false);
+
+        viewModel.AiFeatureConsents.Single().IsConsented.Should().BeTrue();
     }
 
     [TestMethod]
@@ -228,7 +279,10 @@ public sealed class SettingsPageViewModelAiConsentTests
         bool isImageObjectExtractionEnabled = false,
         bool isVideoSuperResolutionEnabled = false,
         string telemetryConsentValue = TelemetryConsentSettingValues.Unknown,
-        ITelemetryConsentService? telemetryConsentService = null)
+        ITelemetryConsentService? telemetryConsentService = null,
+        SettingsMutationStatus settingsMutationStatus = SettingsMutationStatus.Saved,
+        IUpdateImageAutoSaveUseCase? updateImageAutoSaveAction = null,
+        bool aiConsentSaveSucceeded = true)
     {
         var localization = new Mock<ILocalizationService>();
         localization
@@ -257,6 +311,12 @@ public sealed class SettingsPageViewModelAiConsentTests
         settings
             .Setup(service => service.Get(CaptureToolSettings.Settings_TelemetryConsent))
             .Returns(telemetryConsentValue);
+        settings
+            .Setup(service => service.TrySetAndSaveAsync(
+                It.IsAny<IStringSettingDefinition>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SettingsMutationResult(settingsMutationStatus));
 
         var aiFeatureConsentService = new Mock<IAiFeatureConsentService>();
         aiFeatureConsentService
@@ -270,6 +330,12 @@ public sealed class SettingsPageViewModelAiConsentTests
                 new(AiFeatureId.ImageObjectExtraction, "Object extraction", AiFeatureConsentState.Granted),
                 new(AiFeatureId.VideoSuperResolution, "Video super resolution", AiFeatureConsentState.Granted)
             ]);
+        aiFeatureConsentService
+            .Setup(service => service.SetConsentAsync(
+                It.IsAny<AiFeatureId>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aiConsentSaveSucceeded);
 
         var appLanguageViewModelFactory = new Mock<IFactoryServiceWithArgs<AppLanguageViewModel, IAppLanguage?>>();
         appLanguageViewModelFactory
@@ -299,7 +365,7 @@ public sealed class SettingsPageViewModelAiConsentTests
             Mock.Of<ILeaveSettingsPageUseCase>(),
             Mock.Of<IRestartSettingsApplicationUseCase>(),
             Mock.Of<IUpdateImageAutoCopyUseCase>(),
-            Mock.Of<IUpdateImageAutoSaveUseCase>(),
+            updateImageAutoSaveAction ?? Mock.Of<IUpdateImageAutoSaveUseCase>(),
             Mock.Of<IUpdateAudioCaptureAutoCopyUseCase>(),
             Mock.Of<IUpdateAudioCaptureAutoSaveUseCase>(),
             Mock.Of<IUpdateAudioCaptureDefaultLocalAudioUseCase>(),

--- a/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelSuperResolutionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelSuperResolutionTests.cs
@@ -62,6 +62,12 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
         consent
             .Setup(service => service.GetConsentState(AiFeatureId.VideoSuperResolution))
             .Returns(AiFeatureConsentState.Unknown);
+        consent
+            .Setup(service => service.SetConsentAsync(
+                AiFeatureId.VideoSuperResolution,
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         var dialog = new Mock<IAiFeatureConsentDialogService>();
         dialog
             .Setup(service => service.RequestConsentAsync(
@@ -94,6 +100,12 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
         consent
             .Setup(service => service.GetConsentState(AiFeatureId.VideoSuperResolution))
             .Returns(AiFeatureConsentState.Unknown);
+        consent
+            .Setup(service => service.SetConsentAsync(
+                AiFeatureId.VideoSuperResolution,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         var dialog = new Mock<IAiFeatureConsentDialogService>();
         dialog
             .Setup(service => service.RequestConsentAsync(


### PR DESCRIPTION
## Summary
- add serialized, typed settings mutation-and-save operations
- commit in-memory state, change notifications, and telemetry only after storage succeeds
- make bulk reset lock-safe and propagate persistence failures through settings, logging, language, AI consent, and telemetry consent callers
- document the behavior in an implementation PRD and cover failure/concurrency paths with tests

## Why
Settings callers mutated memory first and discarded the boolean result from `TrySaveAsync`. A failed disk write therefore appeared successful until restart, while bulk reset was neither locked nor observable through change notifications.

## Impact
Failed writes now preserve the last committed state and are surfaced to callers. Concurrent readers continue to see committed values until persistence completes, and successful resets notify subscribers consistently.

## Validation
- 724 non-UI tests passed
- x64 Debug WinUI build succeeded with 0 warnings and 0 errors
- rebased onto the latest `main`

Closes #420
