### PR TITLE
Separate retained captures from scratch artifacts

### DIFF
--- a/docs/prd-423-separate-retained-captures-and-scratch.md
+++ b/docs/prd-423-separate-retained-captures-and-scratch.md
@@ -3,7 +3,7 @@
 - Issue: [#423](https://github.com/shanebweaver/CaptureTool/issues/423)
 - Architecture finding: `ARCH-18`
 - Severity: Medium
-- Status: Planned
+- Status: Implemented
 - Affected features: `APP-05`, `APP-06`, `CAP-08`, `IMG-15`, `VID-02`, `VID-03`, `VID-04`, `PLT-02`
 
 ## Summary
@@ -106,14 +106,14 @@ Run all non-UI test projects and build the WinUI x64 Debug project.
 
 ## Acceptance criteria
 
-- [ ] Catalog-backed captures without auto-save survive the temporary-files clear command.
-- [ ] Captures and scratch artifacts use different application storage roots.
-- [ ] Active scratch artifacts cannot be removed by manual cleanup or startup scavenging.
-- [ ] Session-owned scratch artifacts are deleted deterministically on owner disposal.
-- [ ] Abandoned scratch directories older than seven days are removed at startup.
-- [ ] Clipboard file artifacts remain available after copy and are eligible for later cleanup.
-- [ ] Cleanup failures remain isolated, logged, and recoverable.
-- [ ] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+- [x] Catalog-backed captures without auto-save survive the temporary-files clear command.
+- [x] Captures and scratch artifacts use different application storage roots.
+- [x] Active scratch artifacts cannot be removed by manual cleanup or startup scavenging.
+- [x] Session-owned scratch artifacts are deleted deterministically on owner disposal.
+- [x] Abandoned scratch directories older than seven days are removed at startup.
+- [x] Clipboard file artifacts remain available after copy and are eligible for later cleanup.
+- [x] Cleanup failures remain isolated, logged, and recoverable.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.
 
 ## Rollout
 

--- a/docs/prd-423-separate-retained-captures-and-scratch.md
+++ b/docs/prd-423-separate-retained-captures-and-scratch.md
@@ -1,0 +1,120 @@
+# PRD: Separate Retained Captures from Leased Scratch Artifacts
+
+- Issue: [#423](https://github.com/shanebweaver/CaptureTool/issues/423)
+- Architecture finding: `ARCH-18`
+- Severity: Medium
+- Status: Planned
+- Affected features: `APP-05`, `APP-06`, `CAP-08`, `IMG-15`, `VID-02`, `VID-03`, `VID-04`, `PLT-02`
+
+## Summary
+
+CaptureTool must store catalog-backed captures separately from disposable edit and export artifacts. Captures that are not auto-saved remain retained application data and survive cache cleanup. Scratch work receives an explicit owner lease, is protected while in use, is deleted when the owning session releases it, and is scavenged after an age threshold when a prior process could not release it cleanly.
+
+## Problem
+
+The application currently writes retained captures, imported working copies, rendered trim previews, clipboard trims, Paint exports, and AI-derived media into the same application temporary folder. The settings command clears every entry in that folder without distinguishing the user's only catalog-backed capture from disposable work or checking whether an operation is still using it.
+
+This creates three failure modes:
+
+1. clearing temporary files can delete a recent capture that has no other saved copy;
+2. cleanup can race with an editor, renderer, or AI operation that is actively reading or writing a file;
+3. abandoned scratch files accumulate indefinitely unless the user clears the entire shared folder.
+
+## Goals
+
+1. Give retained captures and scratch artifacts distinct, explicit storage locations.
+2. Keep non-auto-saved captures available through the recent-capture catalog after cache cleanup.
+3. Give each scratch artifact an isolated owner directory and an active lease.
+4. Prevent manual cleanup and startup scavenging from deleting active leases.
+5. Delete session-owned working copies, previews, Paint exports, and AI derivatives when their owner is disposed.
+6. Scavenge abandoned scratch directories after seven days at application startup.
+7. Preserve clipboard-backed file artifacts long enough to be pasted, while making them eligible for later cleanup.
+
+## Non-goals
+
+- Changing the recent-capture catalog format or retention policy.
+- Moving or deleting the user's configured auto-save destination files.
+- Deduplicating retained captures after auto-save.
+- Adding a settings control for deleting retained captures.
+- Recovering a scratch operation after the process terminates unexpectedly.
+- Coordinating leases across multiple CaptureTool processes; the existing single-instance application model remains authoritative.
+
+## Functional requirements
+
+### Storage classification
+
+1. Add an application-local retained-capture folder below the durable application data root.
+2. Add an application scratch folder below the platform temporary root.
+3. Image, video, and audio capture workflows allocate their initial output in the retained-capture folder.
+4. Imported working copies, recent-capture working copies, AI derivatives, rendered trim previews, Paint exports, and trimmed clipboard files allocate in scratch.
+5. Settings that display or open the temporary-files folder refer to scratch only.
+
+### Scratch ownership
+
+1. Every scratch allocation receives a unique owner directory so cleanup cannot partially delete another operation's files.
+2. A central scratch-artifact store tracks active owner directories for the lifetime of the process.
+3. Manual cleanup deletes only unleased scratch directories and files.
+4. Releasing a session-owned artifact removes its lease and recursively deletes its owner directory.
+5. Relinquishing a clipboard-owned artifact removes its active lease without deleting the file so the flushed clipboard can continue to resolve it.
+6. Release operations are idempotent and never delete paths outside the configured scratch root.
+
+### Owner lifecycle
+
+1. Editor working copies are released when the corresponding editor view model is disposed.
+2. Image and video AI derivatives are released when replaced, cancelled after allocation, or when the editor is disposed.
+3. Rendered video trim previews are released when superseded or when the page is unloaded.
+4. Paint exports are released when the image editor is disposed.
+5. Scratch allocations are released immediately when navigation or generation fails before ownership transfers to a session.
+
+### Startup scavenging
+
+1. Application startup scans the scratch root once after core services initialize.
+2. Unleased owner directories older than seven days are deleted.
+3. Fresh and active owner directories are preserved.
+4. A failure to inspect or delete one entry is logged and does not prevent startup or cleanup of other entries.
+
+## Reliability requirements
+
+- Capture allocation remains collision-safe.
+- Scratch cleanup is best-effort and cannot make application startup fail.
+- Manual clear remains best-effort and reports success after attempting every eligible entry.
+- A malformed or external path passed to release is ignored safely.
+- Cancellation and generation failures do not leave an in-process active lease.
+- Retained captures are never enumerated by the scratch clear or scavenging operations.
+
+## User experience
+
+- Clearing temporary files no longer removes unsaved recent captures.
+- Active editors and render operations continue working if temporary cleanup runs concurrently.
+- Leaving an editor cleans up its disposable working files and derived previews.
+- The existing temporary-files folder and clear-cache controls continue to operate, but now expose and clear scratch data only.
+
+## Test plan
+
+Add focused regression coverage for:
+
+- image, video, and audio workflows allocating under retained storage;
+- manual cleanup preserving retained captures and active scratch leases;
+- released scratch artifacts being deleted without affecting another lease;
+- stale startup scratch entries being scavenged while fresh and active entries survive;
+- imported and recent-capture working copies transferring ownership to an editor and cleaning up on failure;
+- editor disposal releasing working copies and generated derivatives;
+- clipboard trim artifacts becoming unleased without immediate deletion;
+- explicit storage paths in the Windows and UI-test implementations.
+
+Run all non-UI test projects and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [ ] Catalog-backed captures without auto-save survive the temporary-files clear command.
+- [ ] Captures and scratch artifacts use different application storage roots.
+- [ ] Active scratch artifacts cannot be removed by manual cleanup or startup scavenging.
+- [ ] Session-owned scratch artifacts are deleted deterministically on owner disposal.
+- [ ] Abandoned scratch directories older than seven days are removed at startup.
+- [ ] Clipboard file artifacts remain available after copy and are eligible for later cleanup.
+- [ ] Cleanup failures remain isolated, logged, and recoverable.
+- [ ] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+
+## Rollout
+
+No data migration is required. Existing files already placed directly in the platform temporary folder are left untouched because their ownership cannot be inferred safely. New captures use retained storage and new scratch artifacts use the leased scratch root immediately after upgrade.

--- a/src/CaptureTool.Application.Abstractions/Storage/IScratchArtifactStore.cs
+++ b/src/CaptureTool.Application.Abstractions/Storage/IScratchArtifactStore.cs
@@ -1,0 +1,10 @@
+namespace CaptureTool.Application.Abstractions.Storage;
+
+public interface IScratchArtifactStore
+{
+    string CreateLeasedArtifactPath(string owner, string extension);
+    void DeleteArtifact(string artifactPath);
+    void RelinquishArtifact(string artifactPath);
+    void ClearUnleasedArtifacts();
+    void ScavengeStaleArtifacts(TimeSpan maximumAge);
+}

--- a/src/CaptureTool.Application.Abstractions/Storage/IStorageService.cs
+++ b/src/CaptureTool.Application.Abstractions/Storage/IStorageService.cs
@@ -3,8 +3,9 @@ namespace CaptureTool.Application.Abstractions.Storage;
 public partial interface IStorageService
 {
     string GetApplicationDataFolderPath();
+    string GetApplicationRetainedCaptureFolderPath();
+    string GetApplicationScratchFolderPath();
     string GetSystemDefaultScreenshotsFolderPath();
-    string GetApplicationTemporaryFolderPath();
     string GetTemporaryFileName();
     string GetSystemDefaultVideosFolderPath();
     string GetSystemDefaultMusicFolderPath();

--- a/src/CaptureTool.Application/Activation/ApplicationStartupInitializer.cs
+++ b/src/CaptureTool.Application/Activation/ApplicationStartupInitializer.cs
@@ -11,6 +11,8 @@ namespace CaptureTool.Application.Activation;
 
 internal sealed class ApplicationStartupInitializer : IApplicationStartupInitializer
 {
+    private static readonly TimeSpan ScratchArtifactMaximumAge = TimeSpan.FromDays(7);
+
     private readonly ICancellationService _cancellationService;
     private readonly ISettingsService _settingsService;
     private readonly ILogService _logService;
@@ -19,6 +21,7 @@ internal sealed class ApplicationStartupInitializer : IApplicationStartupInitial
     private readonly INavigationHandler _navigationHandler;
     private readonly INavigationService _navigationService;
     private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
     private readonly ITelemetryService? _telemetryService;
     private readonly ITelemetryConsentService? _telemetryConsentService;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
@@ -34,6 +37,7 @@ internal sealed class ApplicationStartupInitializer : IApplicationStartupInitial
         INavigationHandler navigationHandler,
         INavigationService navigationService,
         IStorageService storageService,
+        IScratchArtifactStore scratchArtifactStore,
         ITelemetryService? telemetryService = null,
         ITelemetryConsentService? telemetryConsentService = null)
     {
@@ -45,6 +49,7 @@ internal sealed class ApplicationStartupInitializer : IApplicationStartupInitial
         _navigationHandler = navigationHandler;
         _navigationService = navigationService;
         _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
         _telemetryService = telemetryService;
         _telemetryConsentService = telemetryConsentService;
     }
@@ -72,6 +77,8 @@ internal sealed class ApplicationStartupInitializer : IApplicationStartupInitial
                 _logService.Enable();
             }
 
+            ScavengeScratchArtifacts();
+
             string languageOverride = _settingsService.Get(CaptureToolSettings.Settings_LanguageOverride);
             _localizationService.Initialize(languageOverride);
 
@@ -83,6 +90,18 @@ internal sealed class ApplicationStartupInitializer : IApplicationStartupInitial
         finally
         {
             _semaphore.Release();
+        }
+    }
+
+    private void ScavengeScratchArtifacts()
+    {
+        try
+        {
+            _scratchArtifactStore.ScavengeStaleArtifacts(ScratchArtifactMaximumAge);
+        }
+        catch (Exception ex)
+        {
+            _logService.LogException(ex, "Failed to scavenge stale scratch artifacts.");
         }
     }
 

--- a/src/CaptureTool.Application/Capture/Audio/AudioCaptureWorkflow.cs
+++ b/src/CaptureTool.Application/Capture/Audio/AudioCaptureWorkflow.cs
@@ -71,7 +71,7 @@ internal sealed class AudioCaptureWorkflow : IAudioCaptureWorkflow
         TrackCapture(TelemetryEvents.CaptureRequested);
 
         string tempAudioPath = _fileAllocator.ReserveUniqueFile(
-            _storageService.GetApplicationTemporaryFolderPath(),
+            _storageService.GetApplicationRetainedCaptureFolderPath(),
             _fileNameGenerator.GetNewCaptureFileName);
 
         AudioCaptureSession? session = null;

--- a/src/CaptureTool.Application/Capture/CaptureFileAllocator.cs
+++ b/src/CaptureTool.Application/Capture/CaptureFileAllocator.cs
@@ -56,6 +56,7 @@ internal sealed class CaptureFileAllocator
         Func<string> createFileName,
         Action<string> createFile)
     {
+        _fileSystem.CreateDirectory(folderPath);
         IOException? lastCollision = null;
 
         for (int attempt = 0; attempt < MaxAttempts; attempt++)

--- a/src/CaptureTool.Application/Capture/Image/ImageCaptureWorkflow.cs
+++ b/src/CaptureTool.Application/Capture/Image/ImageCaptureWorkflow.cs
@@ -50,7 +50,7 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
         {
             TrackCapture(TelemetryEvents.CaptureStarted, "all_screens");
             tempPath = _fileAllocator.ReserveUniqueFile(
-                _storageService.GetApplicationTemporaryFolderPath(),
+                _storageService.GetApplicationRetainedCaptureFolderPath(),
                 _fileNameGenerator.GetNewCaptureFileName);
 
             using System.Drawing.Image combined = _screenCapture.CombineMonitors([.. monitors]);
@@ -84,7 +84,7 @@ internal sealed class ImageCaptureWorkflow : IImageCaptureWorkflow, IImageCaptur
         {
             TrackCapture(TelemetryEvents.CaptureStarted, captureType);
             tempPath = _fileAllocator.ReserveUniqueFile(
-                _storageService.GetApplicationTemporaryFolderPath(),
+                _storageService.GetApplicationRetainedCaptureFolderPath(),
                 _fileNameGenerator.GetNewCaptureFileName);
 
             MonitorCaptureResult monitor = args.Monitor;

--- a/src/CaptureTool.Application/Capture/Video/VideoCaptureWorkflow.cs
+++ b/src/CaptureTool.Application/Capture/Video/VideoCaptureWorkflow.cs
@@ -104,7 +104,7 @@ internal sealed class VideoCaptureWorkflow : IVideoCaptureWorkflow
         }
 
         string tempVideoPath = _fileAllocator.ReserveUniqueFile(
-            _storageService.GetApplicationTemporaryFolderPath(),
+            _storageService.GetApplicationRetainedCaptureFolderPath(),
             _fileNameGenerator.GetNewCaptureFileName);
 
         CaptureRecordingTarget target = CreateRecordingTarget(args);

--- a/src/CaptureTool.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/src/CaptureTool.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -2,11 +2,13 @@ using CaptureTool.Application.Abstractions.Ai;
 using CaptureTool.Application.Abstractions.Edit.External;
 using CaptureTool.Application.Abstractions.EditSessions;
 using CaptureTool.Application.Abstractions.Navigation;
+using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Ai;
 using CaptureTool.Application.Capture;
 using CaptureTool.Application.Edit.External;
 using CaptureTool.Application.EditSessions;
 using CaptureTool.Application.Navigation;
+using CaptureTool.Application.Storage;
 using CaptureTool.Application.UseCases;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -46,6 +48,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IEditSessionGuard, EditSessionGuard>();
         services.AddSingleton<INavigationCoordinator, NavigationCoordinator>();
         services.AddSingleton<CaptureFileAllocator>();
+        services.AddSingleton<IScratchArtifactStore, ScratchArtifactStore>();
 
         return services;
     }

--- a/src/CaptureTool.Application/Edit/Video/CopyVideoFile/CopyVideoFileUseCase.cs
+++ b/src/CaptureTool.Application/Edit/Video/CopyVideoFile/CopyVideoFileUseCase.cs
@@ -14,19 +14,19 @@ internal sealed class CopyVideoFileUseCase : ICopyVideoFileUseCase
 
     private readonly IUseCaseExecutor _useCaseExecutor;
     private readonly IClipboardService _clipboardService;
-    private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
     private readonly IVideoFileTrimmer _videoFileTrimmer;
     private readonly IFileSystem _fileSystem;
 
     public CopyVideoFileUseCase(IClipboardService clipboardService,
-        IStorageService storageService,
+        IScratchArtifactStore scratchArtifactStore,
         IVideoFileTrimmer videoFileTrimmer,
         IFileSystem fileSystem,
         IUseCaseExecutor useCaseExecutor)
     {
         _useCaseExecutor = useCaseExecutor;
         _clipboardService = clipboardService;
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
         _videoFileTrimmer = videoFileTrimmer;
         _fileSystem = fileSystem;
     }
@@ -50,21 +50,46 @@ internal sealed class CopyVideoFileUseCase : ICopyVideoFileUseCase
                 string clipboardVideoPath = request.VideoPath;
                 if (TryGetTrim(request, out TimeSpan trimStart, out TimeSpan trimEnd))
                 {
-                    clipboardVideoPath = Path.Combine(
-                    _storageService.GetApplicationTemporaryFolderPath(),
-                    $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}.mp4");
+                    clipboardVideoPath = _scratchArtifactStore.CreateLeasedArtifactPath("clipboard-video-trim", ".mp4");
 
-                    await _videoFileTrimmer.TrimAsync(
-                    request.VideoPath,
-                    clipboardVideoPath,
-                    trimStart,
-                    trimEnd,
-                    cancellationToken);
+                    try
+                    {
+                        await _videoFileTrimmer.TrimAsync(
+                            request.VideoPath,
+                            clipboardVideoPath,
+                            trimStart,
+                            trimEnd,
+                            cancellationToken);
+                    }
+                    catch
+                    {
+                        _scratchArtifactStore.DeleteArtifact(clipboardVideoPath);
+                        throw;
+                    }
                 }
 
-                ClipboardFile clipboardVideo = new(clipboardVideoPath);
-                Task task = _clipboardService.CopyFileAsync(clipboardVideo);
-                await task.WaitAsync(cancellationToken);
+                bool ownsScratchArtifact = !string.Equals(
+                    clipboardVideoPath,
+                    request.VideoPath,
+                    StringComparison.OrdinalIgnoreCase);
+                try
+                {
+                    ClipboardFile clipboardVideo = new(clipboardVideoPath);
+                    Task task = _clipboardService.CopyFileAsync(clipboardVideo);
+                    await task.WaitAsync(cancellationToken);
+                    if (ownsScratchArtifact)
+                    {
+                        _scratchArtifactStore.RelinquishArtifact(clipboardVideoPath);
+                    }
+                }
+                catch
+                {
+                    if (ownsScratchArtifact)
+                    {
+                        _scratchArtifactStore.DeleteArtifact(clipboardVideoPath);
+                    }
+                    throw;
+                }
                 return new CopyVideoFileResponse();
             },
             cancellationToken: cancellationToken);

--- a/src/CaptureTool.Application/Library/RecentCaptures/OpenRecentCapture/OpenRecentCaptureUseCase.cs
+++ b/src/CaptureTool.Application/Library/RecentCaptures/OpenRecentCapture/OpenRecentCaptureUseCase.cs
@@ -19,7 +19,7 @@ internal sealed class OpenRecentCaptureUseCase : IOpenRecentCaptureUseCase
 
     private readonly IUseCaseExecutor _useCaseExecutor;
     private readonly IFileSystem _fileSystem;
-    private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
     private readonly IRecentCaptureCatalog _recentCaptureCatalog;
     private readonly IOpenAudioEditPageUseCase _goToAudioEdit;
     private readonly IOpenImageEditPageUseCase _goToImageEdit;
@@ -28,7 +28,7 @@ internal sealed class OpenRecentCaptureUseCase : IOpenRecentCaptureUseCase
 
     public OpenRecentCaptureUseCase(
         IFileSystem fileSystem,
-        IStorageService storageService,
+        IScratchArtifactStore scratchArtifactStore,
         IRecentCaptureCatalog recentCaptureCatalog,
         IOpenAudioEditPageUseCase goToAudioEdit,
         IOpenImageEditPageUseCase goToImageEdit,
@@ -38,7 +38,7 @@ internal sealed class OpenRecentCaptureUseCase : IOpenRecentCaptureUseCase
     {
         _useCaseExecutor = useCaseExecutor;
         _fileSystem = fileSystem;
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
         _recentCaptureCatalog = recentCaptureCatalog;
         _goToAudioEdit = goToAudioEdit;
         _goToImageEdit = goToImageEdit;
@@ -72,23 +72,33 @@ internal sealed class OpenRecentCaptureUseCase : IOpenRecentCaptureUseCase
                     async token =>
                     {
                         string workingFilePath = PrepareWorkingFile(request.FilePath);
-                        bool navigated = fileType switch
+                        bool navigated;
+                        try
                         {
-                            CaptureFileType.Audio => (await _goToAudioEdit.ExecuteAsync(
-                                new OpenAudioEditPageRequest(new AudioFile(workingFilePath)),
-                                token)).Value?.Succeeded == true,
-                            CaptureFileType.Image => (await _goToImageEdit.ExecuteAsync(
-                                new OpenImageEditPageRequest(new ImageFile(
-                                    workingFilePath,
-                                    string.Equals(workingFilePath, request.FilePath, StringComparison.OrdinalIgnoreCase)
-                                        ? null
-                                        : request.FilePath)),
-                                token)).Value?.Succeeded == true,
-                            CaptureFileType.Video => (await _goToVideoEdit.ExecuteAsync(
-                                new OpenVideoEditPageRequest(new VideoFile(workingFilePath)),
-                                token)).Value?.Succeeded == true,
-                            _ => false
-                        };
+                            navigated = fileType switch
+                            {
+                                CaptureFileType.Audio => (await _goToAudioEdit.ExecuteAsync(
+                                    new OpenAudioEditPageRequest(new AudioFile(workingFilePath)),
+                                    token)).Value?.Succeeded == true,
+                                CaptureFileType.Image => (await _goToImageEdit.ExecuteAsync(
+                                    new OpenImageEditPageRequest(new ImageFile(workingFilePath, request.FilePath)),
+                                    token)).Value?.Succeeded == true,
+                                CaptureFileType.Video => (await _goToVideoEdit.ExecuteAsync(
+                                    new OpenVideoEditPageRequest(new VideoFile(workingFilePath)),
+                                    token)).Value?.Succeeded == true,
+                                _ => false
+                            };
+                        }
+                        catch
+                        {
+                            _scratchArtifactStore.DeleteArtifact(workingFilePath);
+                            throw;
+                        }
+
+                        if (!navigated)
+                        {
+                            _scratchArtifactStore.DeleteArtifact(workingFilePath);
+                        }
 
                         if (navigated)
                         {
@@ -106,26 +116,16 @@ internal sealed class OpenRecentCaptureUseCase : IOpenRecentCaptureUseCase
 
     private string PrepareWorkingFile(string sourcePath)
     {
-        string temporaryFolderPath = _storageService.GetApplicationTemporaryFolderPath();
-        if (IsFileInFolder(sourcePath, temporaryFolderPath))
+        string workingFilePath = _scratchArtifactStore.CreateLeasedArtifactPath("recent-capture-working-copy", Path.GetExtension(sourcePath));
+        try
         {
-            return sourcePath;
+            _fileSystem.CopyFile(sourcePath, workingFilePath, true);
+            return workingFilePath;
         }
-
-        _fileSystem.CreateDirectory(temporaryFolderPath);
-        string workingFilePath = Path.Combine(
-            temporaryFolderPath,
-            $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}{Path.GetExtension(sourcePath)}");
-        _fileSystem.CopyFile(sourcePath, workingFilePath, true);
-        return workingFilePath;
-    }
-
-    private static bool IsFileInFolder(string sourcePath, string folderPath)
-    {
-        string fullFolderPath = Path.GetFullPath(folderPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        string fullSourcePath = Path.GetFullPath(sourcePath);
-
-        return fullSourcePath.StartsWith(fullFolderPath, StringComparison.OrdinalIgnoreCase);
+        catch
+        {
+            _scratchArtifactStore.DeleteArtifact(workingFilePath);
+            throw;
+        }
     }
 }

--- a/src/CaptureTool.Application/Settings/ClearTempFiles/ClearTempFilesUseCase.cs
+++ b/src/CaptureTool.Application/Settings/ClearTempFiles/ClearTempFilesUseCase.cs
@@ -1,6 +1,4 @@
-using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Library.RecentCaptures;
-using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Settings.ClearTempFiles;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.UseCases;
@@ -13,20 +11,16 @@ internal sealed class ClearTempFilesUseCase : IClearTempFilesUseCase
     private const string ActivityId = "ClearTempFiles";
 
     private readonly IUseCaseExecutor _useCaseExecutor;
-    private readonly ILogService _logService;
-    private readonly IStorageService _storageService;
-    private readonly IFileSystem _fileSystem;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
     private readonly IRecentCapturesChangeNotifier _recentCapturesChangeNotifier;
 
-    public ClearTempFilesUseCase(ILogService logService, IStorageService storageService,
-        IFileSystem fileSystem,
+    public ClearTempFilesUseCase(
+        IScratchArtifactStore scratchArtifactStore,
         IUseCaseExecutor useCaseExecutor,
         IRecentCapturesChangeNotifier recentCapturesChangeNotifier)
     {
         _useCaseExecutor = useCaseExecutor;
-        _logService = logService;
-        _storageService = storageService;
-        _fileSystem = fileSystem;
+        _scratchArtifactStore = scratchArtifactStore;
         _recentCapturesChangeNotifier = recentCapturesChangeNotifier;
     }
 
@@ -38,26 +32,7 @@ internal sealed class ClearTempFilesUseCase : IClearTempFilesUseCase
             activityId: ActivityId,
             useCase: () =>
             {
-                string tempFolderPath = _storageService.GetApplicationTemporaryFolderPath();
-                foreach (var entry in _fileSystem.EnumerateFileSystemEntries(tempFolderPath))
-                {
-                    try
-                    {
-                        if (_fileSystem.DirectoryExists(entry))
-                        {
-                            _fileSystem.DeleteDirectory(entry, true);
-                        }
-                        else
-                        {
-                            _fileSystem.DeleteFile(entry);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logService.LogException(ex, $"Failed to delete temporary file or folder: {entry}");
-                    }
-                }
-
+                _scratchArtifactStore.ClearUnleasedArtifacts();
                 _recentCapturesChangeNotifier.NotifyRecentCapturesChanged();
                 return new ClearTempFilesResponse();
             },

--- a/src/CaptureTool.Application/Settings/OpenTempFolder/OpenTempFolderUseCase.cs
+++ b/src/CaptureTool.Application/Settings/OpenTempFolder/OpenTempFolderUseCase.cs
@@ -1,4 +1,5 @@
 using CaptureTool.Application.Abstractions.Settings.OpenTempFolder;
+using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Application.UseCases;
@@ -12,14 +13,17 @@ internal sealed class OpenTempFolderUseCase : IOpenTempFolderUseCase
     private readonly IUseCaseExecutor _useCaseExecutor;
     private readonly IStorageService _storageService;
     private readonly IFolderLauncher _folderLauncher;
+    private readonly IFileSystem _fileSystem;
 
     public OpenTempFolderUseCase(IStorageService storageService,
         IFolderLauncher folderLauncher,
+        IFileSystem fileSystem,
         IUseCaseExecutor useCaseExecutor)
     {
         _useCaseExecutor = useCaseExecutor;
         _storageService = storageService;
         _folderLauncher = folderLauncher;
+        _fileSystem = fileSystem;
     }
 
     public bool CanExecute(OpenTempFolderRequest request) => true;
@@ -30,7 +34,8 @@ internal sealed class OpenTempFolderUseCase : IOpenTempFolderUseCase
             activityId: ActivityId,
             useCase: () =>
             {
-                var tempFolderPath = _storageService.GetApplicationTemporaryFolderPath();
+                var tempFolderPath = _storageService.GetApplicationScratchFolderPath();
+                _fileSystem.CreateDirectory(tempFolderPath);
                 if (!_folderLauncher.TryOpenFolder(tempFolderPath))
                 {
                     return new OpenTempFolderResponse(false);

--- a/src/CaptureTool.Application/Shell/AppMenu/OpenFile/OpenFileUseCase.cs
+++ b/src/CaptureTool.Application/Shell/AppMenu/OpenFile/OpenFileUseCase.cs
@@ -17,14 +17,14 @@ internal sealed class OpenFileUseCase : IOpenFileUseCase
     private readonly IUseCaseExecutor _useCaseExecutor;
     private readonly IFilePickerService _filePickerService;
     private readonly INavigationCoordinator _navigationCoordinator;
-    private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
     private readonly IFileSystem _fileSystem;
     private readonly IRecentCaptureCatalog _recentCaptureCatalog;
 
     public OpenFileUseCase(
         IFilePickerService filePickerService,
         INavigationCoordinator navigationCoordinator,
-        IStorageService storageService,
+        IScratchArtifactStore scratchArtifactStore,
         IFileSystem fileSystem,
         IRecentCaptureCatalog recentCaptureCatalog,
         IUseCaseExecutor useCaseExecutor)
@@ -32,7 +32,7 @@ internal sealed class OpenFileUseCase : IOpenFileUseCase
         _useCaseExecutor = useCaseExecutor;
         _filePickerService = filePickerService;
         _navigationCoordinator = navigationCoordinator;
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
         _fileSystem = fileSystem;
         _recentCaptureCatalog = recentCaptureCatalog;
     }
@@ -60,27 +60,37 @@ internal sealed class OpenFileUseCase : IOpenFileUseCase
                             return false;
                         }
 
-                        string temporaryFolderPath = _storageService.GetApplicationTemporaryFolderPath();
-                        bool isTemporaryFile = IsFileInFolder(file.FilePath, temporaryFolderPath);
-                        string filePath = isTemporaryFile
-                            ? file.FilePath
-                            : CopyFileToFolder(file.FilePath, temporaryFolderPath);
-                        bool navigated = fileType switch
+                        string workingFilePath = CopyFileToScratch(file.FilePath);
+                        bool navigated;
+                        try
                         {
-                            CaptureFileType.Audio => await _navigationCoordinator.NavigateAsync(
-                                NavigationRoute.AudioEdit,
-                                new AudioFile(filePath),
-                                cancellationToken: token),
-                            CaptureFileType.Image => await _navigationCoordinator.NavigateAsync(
-                                NavigationRoute.ImageEdit,
-                                new ImageFile(filePath, isTemporaryFile ? null : file.FilePath),
-                                cancellationToken: token),
-                            CaptureFileType.Video => await _navigationCoordinator.NavigateAsync(
-                                NavigationRoute.VideoEdit,
-                                new VideoFile(filePath),
-                                cancellationToken: token),
-                            _ => false
-                        };
+                            navigated = fileType switch
+                            {
+                                CaptureFileType.Audio => await _navigationCoordinator.NavigateAsync(
+                                    NavigationRoute.AudioEdit,
+                                    new AudioFile(workingFilePath),
+                                    cancellationToken: token),
+                                CaptureFileType.Image => await _navigationCoordinator.NavigateAsync(
+                                    NavigationRoute.ImageEdit,
+                                    new ImageFile(workingFilePath, file.FilePath),
+                                    cancellationToken: token),
+                                CaptureFileType.Video => await _navigationCoordinator.NavigateAsync(
+                                    NavigationRoute.VideoEdit,
+                                    new VideoFile(workingFilePath),
+                                    cancellationToken: token),
+                                _ => false
+                            };
+                        }
+                        catch
+                        {
+                            _scratchArtifactStore.DeleteArtifact(workingFilePath);
+                            throw;
+                        }
+
+                        if (!navigated)
+                        {
+                            _scratchArtifactStore.DeleteArtifact(workingFilePath);
+                        }
 
                         if (navigated)
                         {
@@ -96,24 +106,18 @@ internal sealed class OpenFileUseCase : IOpenFileUseCase
             cancellationToken: cancellationToken);
     }
 
-    private static bool IsFileInFolder(string sourcePath, string folderPath)
+    private string CopyFileToScratch(string sourcePath)
     {
-        string fullFolderPath = Path.GetFullPath(folderPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        string fullSourcePath = Path.GetFullPath(sourcePath);
-
-        return fullSourcePath.StartsWith(fullFolderPath, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private string CopyFileToFolder(string sourcePath, string folderPath)
-    {
-        _fileSystem.CreateDirectory(folderPath);
-
-        string destinationPath = Path.Combine(
-            folderPath,
-            $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}{Path.GetExtension(sourcePath)}");
-
-        _fileSystem.CopyFile(sourcePath, destinationPath, true);
-        return destinationPath;
+        string artifactPath = _scratchArtifactStore.CreateLeasedArtifactPath("imported-working-copy", Path.GetExtension(sourcePath));
+        try
+        {
+            _fileSystem.CopyFile(sourcePath, artifactPath, true);
+            return artifactPath;
+        }
+        catch
+        {
+            _scratchArtifactStore.DeleteArtifact(artifactPath);
+            throw;
+        }
     }
 }

--- a/src/CaptureTool.Application/Storage/ScratchArtifactStore.cs
+++ b/src/CaptureTool.Application/Storage/ScratchArtifactStore.cs
@@ -1,0 +1,218 @@
+using CaptureTool.Application.Abstractions.Files;
+using CaptureTool.Application.Abstractions.Logging;
+using CaptureTool.Application.Abstractions.Storage;
+using CaptureTool.Application.Abstractions.Time;
+
+namespace CaptureTool.Application.Storage;
+
+internal sealed class ScratchArtifactStore : IScratchArtifactStore
+{
+    private readonly Lock _lock = new();
+    private readonly HashSet<string> _activeOwnerDirectories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IStorageService _storageService;
+    private readonly IFileSystem _fileSystem;
+    private readonly IClock _clock;
+    private readonly ILogService _logService;
+
+    public ScratchArtifactStore(
+        IStorageService storageService,
+        IFileSystem fileSystem,
+        IClock clock,
+        ILogService logService)
+    {
+        _storageService = storageService;
+        _fileSystem = fileSystem;
+        _clock = clock;
+        _logService = logService;
+    }
+
+    public string CreateLeasedArtifactPath(string owner, string extension)
+    {
+        string rootPath = GetNormalizedRootPath();
+        _fileSystem.CreateDirectory(rootPath);
+
+        string ownerName = NormalizeOwnerName(owner);
+        string ownerDirectory = Path.Combine(rootPath, $"{ownerName}-{Guid.NewGuid():N}");
+        lock (_lock)
+        {
+            _activeOwnerDirectories.Add(ownerDirectory);
+        }
+
+        try
+        {
+            _fileSystem.CreateDirectory(ownerDirectory);
+
+            string normalizedExtension = string.IsNullOrWhiteSpace(extension)
+                ? string.Empty
+                : extension.StartsWith('.') ? extension : $".{extension}";
+            string fileName = $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}{normalizedExtension}";
+            return Path.Combine(ownerDirectory, fileName);
+        }
+        catch
+        {
+            lock (_lock)
+            {
+                _activeOwnerDirectories.Remove(ownerDirectory);
+            }
+            TryDeleteEntry(ownerDirectory);
+            throw;
+        }
+    }
+
+    public void DeleteArtifact(string artifactPath)
+    {
+        string? ownerDirectory = TryGetOwnerDirectory(artifactPath);
+        if (ownerDirectory is null)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            _activeOwnerDirectories.Remove(ownerDirectory);
+        }
+
+        TryDeleteEntry(ownerDirectory);
+    }
+
+    public void RelinquishArtifact(string artifactPath)
+    {
+        string? ownerDirectory = TryGetOwnerDirectory(artifactPath);
+        if (ownerDirectory is null)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            _activeOwnerDirectories.Remove(ownerDirectory);
+        }
+    }
+
+    public void ClearUnleasedArtifacts()
+    {
+        string rootPath = GetNormalizedRootPath();
+        if (!_fileSystem.DirectoryExists(rootPath))
+        {
+            return;
+        }
+
+        foreach (string entry in _fileSystem.EnumerateFileSystemEntries(rootPath))
+        {
+            if (!IsActive(entry))
+            {
+                TryDeleteEntry(entry);
+            }
+        }
+    }
+
+    public void ScavengeStaleArtifacts(TimeSpan maximumAge)
+    {
+        string rootPath = GetNormalizedRootPath();
+        if (!_fileSystem.DirectoryExists(rootPath))
+        {
+            return;
+        }
+
+        DateTime cutoffUtc = _clock.UtcNow - maximumAge;
+        foreach (string entry in _fileSystem.EnumerateFileSystemEntries(rootPath))
+        {
+            if (IsActive(entry))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (_fileSystem.GetLastWriteTimeUtc(entry) < cutoffUtc)
+                {
+                    TryDeleteEntry(entry);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logService.LogException(ex, $"Failed to inspect scratch artifact: {entry}");
+            }
+        }
+    }
+
+    private bool IsActive(string entry)
+    {
+        string normalizedEntry = Path.GetFullPath(entry)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        lock (_lock)
+        {
+            return _activeOwnerDirectories.Contains(normalizedEntry);
+        }
+    }
+
+    private string? TryGetOwnerDirectory(string artifactPath)
+    {
+        if (string.IsNullOrWhiteSpace(artifactPath))
+        {
+            return null;
+        }
+
+        string rootPath = GetNormalizedRootPath();
+        string rootPrefix = rootPath + Path.DirectorySeparatorChar;
+        string fullArtifactPath;
+        try
+        {
+            fullArtifactPath = Path.GetFullPath(artifactPath);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (!fullArtifactPath.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        string relativePath = fullArtifactPath[rootPrefix.Length..];
+        int separatorIndex = relativePath.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]);
+        if (separatorIndex <= 0)
+        {
+            return null;
+        }
+
+        return Path.Combine(rootPath, relativePath[..separatorIndex]);
+    }
+
+    private string GetNormalizedRootPath()
+    {
+        return Path.GetFullPath(_storageService.GetApplicationScratchFolderPath())
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private void TryDeleteEntry(string entry)
+    {
+        try
+        {
+            if (_fileSystem.DirectoryExists(entry))
+            {
+                _fileSystem.DeleteDirectory(entry, true);
+            }
+            else if (_fileSystem.FileExists(entry))
+            {
+                _fileSystem.DeleteFile(entry);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logService.LogException(ex, $"Failed to delete scratch artifact: {entry}");
+        }
+    }
+
+    private static string NormalizeOwnerName(string owner)
+    {
+        string value = string.IsNullOrWhiteSpace(owner) ? "artifact" : owner.Trim();
+        foreach (char invalidCharacter in Path.GetInvalidFileNameChars())
+        {
+            value = value.Replace(invalidCharacter, '-');
+        }
+
+        return value;
+    }
+}

--- a/src/CaptureTool.Infrastructure.Edit.Windows/WindowsImageForegroundExtractionService.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/WindowsImageForegroundExtractionService.cs
@@ -13,13 +13,11 @@ namespace CaptureTool.Infrastructure.Edit.Windows;
 
 public sealed class WindowsImageForegroundExtractionService : IImageForegroundExtractionService
 {
-    private const string EditCacheFolderName = "ImageEdit";
+    private readonly IScratchArtifactStore _scratchArtifactStore;
 
-    private readonly IStorageService _storageService;
-
-    public WindowsImageForegroundExtractionService(IStorageService storageService)
+    public WindowsImageForegroundExtractionService(IScratchArtifactStore scratchArtifactStore)
     {
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
     }
 
     public ForegroundExtractionReadyState GetReadyState()
@@ -81,6 +79,7 @@ public sealed class WindowsImageForegroundExtractionService : IImageForegroundEx
             return ForegroundExtractionResult.NotReady;
         }
 
+        string? outputPath = null;
         try
         {
             StorageFile sourceFile = await StorageFile.GetFileFromPathAsync(request.SourceImage.FilePath);
@@ -115,14 +114,11 @@ public sealed class WindowsImageForegroundExtractionService : IImageForegroundEx
             byte[] maskPixels = CopyPixels(mask, mask.PixelWidth * mask.PixelHeight);
             ApplyMaskToAlpha(sourcePixels, maskPixels);
 
-            StorageFolder temporaryFolder = await StorageFolder.GetFolderFromPathAsync(
-                _storageService.GetApplicationTemporaryFolderPath());
-            StorageFolder outputFolder = await temporaryFolder.CreateFolderAsync(
-                EditCacheFolderName,
-                CreationCollisionOption.OpenIfExists);
+            outputPath = _scratchArtifactStore.CreateLeasedArtifactPath("image-foreground-extraction", ".png");
+            StorageFolder outputFolder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(outputPath));
             StorageFile outputFile = await outputFolder.CreateFileAsync(
-                GetOutputFileName(request.SourceImage.FilePath),
-                CreationCollisionOption.GenerateUniqueName);
+                Path.GetFileName(outputPath),
+                CreationCollisionOption.ReplaceExisting);
             await SavePixelsAsync(
                 sourcePixels,
                 sourceBitmap.PixelWidth,
@@ -135,10 +131,12 @@ public sealed class WindowsImageForegroundExtractionService : IImageForegroundEx
         }
         catch (OperationCanceledException)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return ForegroundExtractionResult.Cancelled;
         }
         catch (Exception ex)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return ForegroundExtractionResult.Failed(ex.Message);
         }
     }

--- a/src/CaptureTool.Infrastructure.Edit.Windows/WindowsImageObjectEraseService.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/WindowsImageObjectEraseService.cs
@@ -13,13 +13,11 @@ namespace CaptureTool.Infrastructure.Edit.Windows;
 
 public sealed class WindowsImageObjectEraseService : IImageObjectEraseService
 {
-    private const string EditCacheFolderName = "ImageEdit";
+    private readonly IScratchArtifactStore _scratchArtifactStore;
 
-    private readonly IStorageService _storageService;
-
-    public WindowsImageObjectEraseService(IStorageService storageService)
+    public WindowsImageObjectEraseService(IScratchArtifactStore scratchArtifactStore)
     {
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
     }
 
     public ObjectEraseReadyState GetReadyState()
@@ -101,6 +99,7 @@ public sealed class WindowsImageObjectEraseService : IImageObjectEraseService
             return ObjectEraseResult.NotReady;
         }
 
+        string? outputPath = null;
         try
         {
             StorageFile sourceFile = await StorageFile.GetFileFromPathAsync(request.SourceImage.FilePath);
@@ -139,14 +138,11 @@ public sealed class WindowsImageObjectEraseService : IImageObjectEraseService
                 CancellationToken.None);
             cancellationToken.ThrowIfCancellationRequested();
 
-            StorageFolder temporaryFolder = await StorageFolder.GetFolderFromPathAsync(
-                _storageService.GetApplicationTemporaryFolderPath());
-            StorageFolder outputFolder = await temporaryFolder.CreateFolderAsync(
-                EditCacheFolderName,
-                CreationCollisionOption.OpenIfExists);
+            outputPath = _scratchArtifactStore.CreateLeasedArtifactPath("image-object-erase", ".png");
+            StorageFolder outputFolder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(outputPath));
             StorageFile outputFile = await outputFolder.CreateFileAsync(
-                GetOutputFileName(request.SourceImage.FilePath),
-                CreationCollisionOption.GenerateUniqueName);
+                Path.GetFileName(outputPath),
+                CreationCollisionOption.ReplaceExisting);
             await SaveBitmapAsync(resultBitmap, outputFile, cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -154,10 +150,12 @@ public sealed class WindowsImageObjectEraseService : IImageObjectEraseService
         }
         catch (OperationCanceledException)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return ObjectEraseResult.Cancelled;
         }
         catch (Exception ex)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return ObjectEraseResult.Failed(ex.Message);
         }
     }

--- a/src/CaptureTool.Infrastructure.Edit.Windows/WindowsImageSuperResolutionService.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/WindowsImageSuperResolutionService.cs
@@ -15,11 +15,11 @@ public sealed class WindowsImageSuperResolutionService : IImageSuperResolutionSe
     private const int DocumentedMaxScaleFactor = 8;
     private const long MaxOutputPixels = 64L * 1024L * 1024L;
 
-    private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
 
-    public WindowsImageSuperResolutionService(IStorageService storageService)
+    public WindowsImageSuperResolutionService(IScratchArtifactStore scratchArtifactStore)
     {
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
     }
 
     public ImageSuperResolutionReadyState GetReadyState()
@@ -82,6 +82,7 @@ public sealed class WindowsImageSuperResolutionService : IImageSuperResolutionSe
             return ImageSuperResolutionResult.NotReady;
         }
 
+        string? outputPath = null;
         try
         {
             using ImageScaler imageScaler = await ImageScaler.CreateAsync();
@@ -105,9 +106,9 @@ public sealed class WindowsImageSuperResolutionService : IImageSuperResolutionSe
                 targetSize.Width,
                 targetSize.Height);
 
-            StorageFolder outputFolder = await StorageFolder.GetFolderFromPathAsync(_storageService.GetApplicationTemporaryFolderPath());
-            string outputFileName = GetOutputFileName(request.SourceImage.FilePath);
-            StorageFile outputFile = await outputFolder.CreateFileAsync(outputFileName, CreationCollisionOption.ReplaceExisting);
+            outputPath = _scratchArtifactStore.CreateLeasedArtifactPath("image-super-resolution", ".png");
+            StorageFolder outputFolder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(outputPath));
+            StorageFile outputFile = await outputFolder.CreateFileAsync(Path.GetFileName(outputPath), CreationCollisionOption.ReplaceExisting);
 
             await SaveSoftwareBitmapAsync(scaledBitmap, outputFile);
 
@@ -115,10 +116,12 @@ public sealed class WindowsImageSuperResolutionService : IImageSuperResolutionSe
         }
         catch (OperationCanceledException)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return ImageSuperResolutionResult.Cancelled;
         }
         catch (Exception ex)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return ImageSuperResolutionResult.Failed(ex.Message);
         }
     }

--- a/src/CaptureTool.Infrastructure.Edit.Windows/WindowsVideoSuperResolutionService.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/WindowsVideoSuperResolutionService.cs
@@ -24,11 +24,11 @@ public sealed class WindowsVideoSuperResolutionService : IVideoSuperResolutionSe
     private const double MinSupportedFrameRate = 15;
     private const double MaxSupportedFrameRate = 60;
 
-    private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
 
-    public WindowsVideoSuperResolutionService(IStorageService storageService)
+    public WindowsVideoSuperResolutionService(IScratchArtifactStore scratchArtifactStore)
     {
-        _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
     }
 
     public VideoSuperResolutionReadyState GetReadyState()
@@ -92,6 +92,7 @@ public sealed class WindowsVideoSuperResolutionService : IVideoSuperResolutionSe
             return VideoSuperResolutionResult.NotReady;
         }
 
+        string? outputPath = null;
         string? videoOnlyPath = null;
         try
         {
@@ -117,9 +118,9 @@ public sealed class WindowsVideoSuperResolutionService : IVideoSuperResolutionSe
                 return VideoSuperResolutionResult.UnsupportedVideo();
             }
 
-            StorageFolder outputFolder = await StorageFolder.GetFolderFromPathAsync(
-                _storageService.GetApplicationTemporaryFolderPath());
-            string outputFileName = GetOutputFileName(request.SourceVideo.FilePath);
+            outputPath = _scratchArtifactStore.CreateLeasedArtifactPath("video-super-resolution", ".mp4");
+            StorageFolder outputFolder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(outputPath));
+            string outputFileName = Path.GetFileName(outputPath);
             string videoOnlyFileName = $"{Path.GetFileNameWithoutExtension(outputFileName)}.video.mp4";
             StorageFile videoOnlyFile = await outputFolder.CreateFileAsync(
                 videoOnlyFileName,
@@ -167,10 +168,12 @@ public sealed class WindowsVideoSuperResolutionService : IVideoSuperResolutionSe
         }
         catch (OperationCanceledException)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return VideoSuperResolutionResult.Cancelled;
         }
         catch (Exception ex)
         {
+            _scratchArtifactStore.DeleteArtifact(outputPath ?? string.Empty);
             return VideoSuperResolutionResult.Failed(ex.Message);
         }
         finally

--- a/src/CaptureTool.Infrastructure.Windows/Storage/WindowsStorageService.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Storage/WindowsStorageService.cs
@@ -10,9 +10,14 @@ public sealed partial class WindowsStorageService : IStorageService
         return ApplicationData.GetDefault().LocalPath;
     }
 
-    public string GetApplicationTemporaryFolderPath()
+    public string GetApplicationRetainedCaptureFolderPath()
     {
-        return ApplicationData.GetDefault().TemporaryPath;
+        return Path.Combine(ApplicationData.GetDefault().LocalPath, "Captures");
+    }
+
+    public string GetApplicationScratchFolderPath()
+    {
+        return Path.Combine(ApplicationData.GetDefault().TemporaryPath, "Scratch");
     }
 
     public string GetSystemDefaultScreenshotsFolderPath()

--- a/src/CaptureTool.Presentation.Windows.WinUI/UiTests/UiTestStorageService.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/UiTests/UiTestStorageService.cs
@@ -27,9 +27,14 @@ internal sealed class UiTestStorageService : IStorageService
         return Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
     }
 
-    public string GetApplicationTemporaryFolderPath()
+    public string GetApplicationRetainedCaptureFolderPath()
     {
-        return _temporaryFolderPath;
+        return Path.Combine(_dataFolderPath, "Captures");
+    }
+
+    public string GetApplicationScratchFolderPath()
+    {
+        return Path.Combine(_temporaryFolderPath, "Scratch");
     }
 
     public string GetTemporaryFileName()

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/VideoEditPage.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/VideoEditPage.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class VideoEditPage : VideoEditPageBase
 {
     private readonly DispatcherTimer _boundedPlaybackTimer;
     private readonly ILogService _logService;
-    private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore _scratchArtifactStore;
     private readonly IVideoFileTrimmer _videoFileTrimmer;
     private MediaPlayer? _originalMediaPlayer;
     private MediaPlayer? _renderedTrimMediaPlayer;
@@ -34,7 +34,7 @@ public sealed partial class VideoEditPage : VideoEditPageBase
     {
         InitializeComponent();
         _logService = App.Current.ServiceProvider.GetService<ILogService>();
-        _storageService = App.Current.ServiceProvider.GetService<IStorageService>();
+        _scratchArtifactStore = App.Current.ServiceProvider.GetService<IScratchArtifactStore>();
         _videoFileTrimmer = App.Current.ServiceProvider.GetService<IVideoFileTrimmer>();
 
         _originalMediaPlayer = CreateMediaPlayer();
@@ -472,15 +472,16 @@ public sealed partial class VideoEditPage : VideoEditPageBase
         }
 
         int renderVersion = ++_renderedTrimPreviewVersion;
+        string? renderedTrimPreviewPath = null;
         try
         {
             PauseTrimPreview();
             SetTrimPreviewLoading(true);
 
-            _renderedTrimPreviewPath ??= GetRenderedTrimPreviewPath();
+            renderedTrimPreviewPath = GetRenderedTrimPreviewPath();
             await _videoFileTrimmer.TrimAsync(
                 _originalVideoPath,
-                _renderedTrimPreviewPath,
+                renderedTrimPreviewPath,
                 TimeSpan.FromSeconds(ViewModel.TrimStartSeconds),
                 TimeSpan.FromSeconds(ViewModel.TrimEndSeconds));
 
@@ -489,7 +490,10 @@ public sealed partial class VideoEditPage : VideoEditPageBase
                 return;
             }
 
-            await LoadMediaSourceAsync(_renderedTrimMediaPlayer, _renderedTrimPreviewPath);
+            await LoadMediaSourceAsync(_renderedTrimMediaPlayer, renderedTrimPreviewPath);
+            DeleteRenderedTrimPreview();
+            _renderedTrimPreviewPath = renderedTrimPreviewPath;
+            renderedTrimPreviewPath = null;
             _renderedTrimPreviewStartSeconds = ViewModel.TrimStartSeconds;
             _renderedTrimPreviewEndSeconds = ViewModel.TrimEndSeconds;
             ViewModel.UpdatePlayhead(ViewModel.TrimStartSeconds);
@@ -502,6 +506,11 @@ public sealed partial class VideoEditPage : VideoEditPageBase
         }
         finally
         {
+            if (!string.IsNullOrWhiteSpace(renderedTrimPreviewPath))
+            {
+                _scratchArtifactStore.DeleteArtifact(renderedTrimPreviewPath);
+            }
+
             if (renderVersion == _renderedTrimPreviewVersion)
             {
                 SetTrimPreviewLoading(false);
@@ -545,9 +554,7 @@ public sealed partial class VideoEditPage : VideoEditPageBase
 
     private string GetRenderedTrimPreviewPath()
     {
-        return Path.Combine(
-            _storageService.GetApplicationTemporaryFolderPath(),
-            $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}.mp4");
+        return _scratchArtifactStore.CreateLeasedArtifactPath("video-trim-preview", ".mp4");
     }
 
     private bool IsRenderedTrimPreviewCurrent()
@@ -565,23 +572,10 @@ public sealed partial class VideoEditPage : VideoEditPageBase
             return;
         }
 
-        try
-        {
-            if (File.Exists(_renderedTrimPreviewPath))
-            {
-                File.Delete(_renderedTrimPreviewPath);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logService.LogException(ex, "Failed to delete rendered trim preview.");
-        }
-        finally
-        {
-            _renderedTrimPreviewPath = null;
-            _renderedTrimPreviewStartSeconds = null;
-            _renderedTrimPreviewEndSeconds = null;
-        }
+        _scratchArtifactStore.DeleteArtifact(_renderedTrimPreviewPath);
+        _renderedTrimPreviewPath = null;
+        _renderedTrimPreviewStartSeconds = null;
+        _renderedTrimPreviewEndSeconds = null;
     }
 
     private MediaPlayer? ActiveMediaPlayer => _isRenderedTrimPlayerActive ? _renderedTrimMediaPlayer : _originalMediaPlayer;

--- a/src/CaptureTool.Presentation/Features/AudioEdit/AudioEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/AudioEdit/AudioEditPageViewModel.cs
@@ -2,6 +2,7 @@ using CaptureTool.Application.Abstractions.Edit.Audio.CopyAudioFile;
 using CaptureTool.Application.Abstractions.Edit.Audio.SaveAudioFile;
 using CaptureTool.Application.Abstractions.Edit.External;
 using CaptureTool.Application.Abstractions.Settings.OpenAudioFolder;
+using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.Telemetry;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Domain.FileSystem;
@@ -40,6 +41,7 @@ public sealed partial class AudioEditPageViewModel : LoadableViewModelBase<Audio
     private readonly IOpenAudioFolderUseCase _openAudioFolderAction;
     private readonly IAudioWaveformHistory _waveformHistory;
     private readonly ITelemetryService? _telemetryService;
+    private readonly IScratchArtifactStore? _scratchArtifactStore;
 
     public ObservableCollection<AudioWaveformBarViewModel> WaveformBars
     {
@@ -53,7 +55,8 @@ public sealed partial class AudioEditPageViewModel : LoadableViewModelBase<Audio
         IOpenExternalEditorUseCase openExternalEditorAction,
         IOpenAudioFolderUseCase openAudioFolderAction,
         IAudioWaveformHistory waveformHistory,
-        ITelemetryService? telemetryService = null)
+        ITelemetryService? telemetryService = null,
+        IScratchArtifactStore? scratchArtifactStore = null)
     {
         _saveAction = saveAction;
         _copyAction = copyAction;
@@ -61,6 +64,7 @@ public sealed partial class AudioEditPageViewModel : LoadableViewModelBase<Audio
         _openAudioFolderAction = openAudioFolderAction;
         _waveformHistory = waveformHistory;
         _telemetryService = telemetryService;
+        _scratchArtifactStore = scratchArtifactStore;
 
         SaveCommand = new AsyncRelayCommand(SaveAsync, AsyncRelayCommandOptions.FlowExceptionsToTaskScheduler);
         CopyCommand = new AsyncRelayCommand(CopyAsync, AsyncRelayCommandOptions.FlowExceptionsToTaskScheduler);
@@ -70,6 +74,17 @@ public sealed partial class AudioEditPageViewModel : LoadableViewModelBase<Audio
         IsAudioReady = false;
         WaveformBars = [];
         ResetWaveform();
+    }
+
+    public override void Dispose()
+    {
+        if (!string.IsNullOrWhiteSpace(AudioPath))
+        {
+            _scratchArtifactStore?.DeleteArtifact(AudioPath);
+        }
+
+        AudioPath = null;
+        base.Dispose();
     }
 
     public override void Load(AudioFile audio)

--- a/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
@@ -67,6 +67,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
     private readonly IShareService _shareService;
     private readonly IOpenExternalEditorUseCase _openExternalEditorAction;
     private readonly IStorageService _storageService;
+    private readonly IScratchArtifactStore? _scratchArtifactStore;
+    private readonly HashSet<string> _scratchArtifactPaths = new(StringComparer.OrdinalIgnoreCase);
     private readonly ISettingsService _settingsService;
     private readonly IOpenScreenshotsFolderUseCase _openScreenshotsFolderAction;
     private readonly ILogService _logService;
@@ -739,7 +741,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         IImageObjectEraseService? imageObjectEraseService = null,
         IImageObjectEraseFeatureAvailability? imageObjectEraseFeatureAvailability = null,
         IImageObjectExtractionFeatureAvailability? imageObjectExtractionFeatureAvailability = null,
-        ITelemetryService? telemetryService = null)
+        ITelemetryService? telemetryService = null,
+        IScratchArtifactStore? scratchArtifactStore = null)
     {
         _localizationService = localizationService;
         _cancellationService = cancellationService;
@@ -763,6 +766,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         _shareService = shareService;
         _openExternalEditorAction = openExternalEditorAction;
         _storageService = storageService;
+        _scratchArtifactStore = scratchArtifactStore;
         _imageCanvasExporter = imageCanvasExporter;
         _settingsService = settingsService;
         _openScreenshotsFolderAction = openScreenshotsFolderAction;
@@ -897,6 +901,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         {
             Vector2 topLeft = Vector2.Zero;
             ImageFile = imageFile;
+            TrackScratchArtifact(imageFile.FilePath);
             _editSession = new ImageEditSession(_imageMetadataService.GetImageFileSize(imageFile));
             SyncImageGeometryFromSession();
             _originalImageFile = imageFile;
@@ -945,6 +950,11 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         _settingsService.SettingsChanged -= SettingsService_SettingsChanged;
         ChromaKeyTool.SettingsChanged -= ChromaKeyTool_SettingsChanged;
         ChromaKeyTool.InteractionCommitted -= ChromaKeyTool_InteractionCommitted;
+        foreach (string artifactPath in _scratchArtifactPaths)
+        {
+            _scratchArtifactStore?.DeleteArtifact(artifactPath);
+        }
+        _scratchArtifactPaths.Clear();
         _imageDrawable = null;
         _originalImageFile = null;
         _originalImageSize = Size.Empty;
@@ -1625,9 +1635,29 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
 
     private string GetTemporaryPaintImagePath()
     {
-        return Path.Combine(
-            _storageService.GetApplicationTemporaryFolderPath(),
-            $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}.png");
+        string artifactPath = _scratchArtifactStore?.CreateLeasedArtifactPath("paint-export", ".png") ??
+            Path.Combine(
+                _storageService.GetApplicationScratchFolderPath(),
+                $"{Path.GetFileNameWithoutExtension(_storageService.GetTemporaryFileName())}.png");
+        TrackScratchArtifact(artifactPath);
+        return artifactPath;
+    }
+
+    private void TrackScratchArtifact(string artifactPath)
+    {
+        if (string.IsNullOrWhiteSpace(artifactPath))
+        {
+            return;
+        }
+
+        if (LoadState == CaptureTool.Presentation.Loading.LoadState.Disposed)
+        {
+            _scratchArtifactStore?.DeleteArtifact(artifactPath);
+        }
+        else
+        {
+            _scratchArtifactPaths.Add(artifactPath);
+        }
     }
 
     public void OnCropInteractionComplete(Rectangle oldCropRect)
@@ -1910,6 +1940,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
                 return;
             }
 
+            TrackScratchArtifact(result.ImageFile.FilePath);
+
             if (cancellationToken.IsCancellationRequested ||
                 !ReferenceEquals(_foregroundExtractionCancellationTokenSource, cancellationTokenSource) ||
                 !IsForegroundExtractionModeActive ||
@@ -2023,6 +2055,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
                 return;
             }
 
+            TrackScratchArtifact(result.ImageFile.FilePath);
+
             if (cancellationToken.IsCancellationRequested ||
                 !ReferenceEquals(_objectEraseCancellationTokenSource, cancellationTokenSource) ||
                 !IsObjectEraseModeActive ||
@@ -2135,6 +2169,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
                 ShowObjectExtractionFailure(GetObjectExtractionFailureMessage(result));
                 return;
             }
+
+            TrackScratchArtifact(result.ImageFile.FilePath);
 
             if (cancellationToken.IsCancellationRequested ||
                 !ReferenceEquals(_objectExtractionCancellationTokenSource, cancellationTokenSource) ||
@@ -2498,6 +2534,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
                 return;
             }
 
+            TrackScratchArtifact(result.ImageFile.FilePath);
             _superResolutionImageFile = result.ImageFile;
             _superResolutionImageSize = result.ImageSize;
             ApplySuperResolutionImageVariant();

--- a/src/CaptureTool.Presentation/Features/Settings/SettingsPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/Settings/SettingsPageViewModel.cs
@@ -483,7 +483,7 @@ public sealed partial class SettingsPageViewModel : AsyncLoadableViewModelBase
         }
 
         AudioFolderPath = audioFolder;
-        TemporaryFilesFolderPath = _storageService.GetApplicationTemporaryFolderPath();
+        TemporaryFilesFolderPath = _storageService.GetApplicationScratchFolderPath();
 
         await base.LoadAsync(cancellationToken);
     }

--- a/src/CaptureTool.Presentation/Features/VideoEdit/VideoEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/VideoEdit/VideoEditPageViewModel.cs
@@ -7,6 +7,7 @@ using CaptureTool.Application.Abstractions.EditSessions;
 using CaptureTool.Application.Abstractions.Localization;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Settings.OpenVideosFolder;
+using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.Telemetry;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Domain.Ai;
@@ -160,6 +161,8 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
     private readonly ILocalizationService _localizationService;
     private readonly IAppNotificationService _notificationService;
     private readonly ITelemetryService? _telemetryService;
+    private readonly IScratchArtifactStore? _scratchArtifactStore;
+    private readonly HashSet<string> _scratchArtifactPaths = new(StringComparer.OrdinalIgnoreCase);
     private string? _originalVideoPath;
     private string? _superResolutionVideoPath;
     private VideoEditSnapshot? _savedEditSnapshot;
@@ -184,7 +187,8 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         IAiFeatureConsentDialogService? aiFeatureConsentDialogService = null,
         ILocalizationService? localizationService = null,
         IAppNotificationService? notificationService = null,
-        ITelemetryService? telemetryService = null)
+        ITelemetryService? telemetryService = null,
+        IScratchArtifactStore? scratchArtifactStore = null)
     {
         _saveAction = saveAction;
         _copyAction = copyAction;
@@ -199,6 +203,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         _localizationService = localizationService ?? new ResourceKeyLocalizationService();
         _notificationService = notificationService ?? new NullAppNotificationService();
         _telemetryService = telemetryService;
+        _scratchArtifactStore = scratchArtifactStore;
 
         SaveCommand = new AsyncRelayCommand(SaveCommandAsync, AsyncRelayCommandOptions.FlowExceptionsToTaskScheduler);
         CopyCommand = new AsyncRelayCommand(CopyAsync, AsyncRelayCommandOptions.FlowExceptionsToTaskScheduler);
@@ -226,6 +231,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         StartLoading();
 
         _originalVideoPath = video.FilePath;
+        TrackScratchArtifact(video.FilePath);
         _superResolutionVideoPath = null;
         _savedEditSnapshot = null;
         VideoPath = _originalVideoPath;
@@ -445,6 +451,7 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
             }
 
             _superResolutionVideoPath = result.VideoFile.FilePath;
+            TrackScratchArtifact(_superResolutionVideoPath);
             ShowSuperResolutionVideo(_superResolutionVideoPath);
         }
         catch (OperationCanceledException)
@@ -506,6 +513,36 @@ public sealed partial class VideoEditPageViewModel : LoadableViewModelBase<Video
         UpdateHasUnsavedChanges();
         UpdateVideoSuperResolutionAvailability();
         TrackEditTool("super_resolution", TelemetryOutcomes.Succeeded);
+    }
+
+    public override void Dispose()
+    {
+        foreach (string artifactPath in _scratchArtifactPaths)
+        {
+            _scratchArtifactStore?.DeleteArtifact(artifactPath);
+        }
+        _scratchArtifactPaths.Clear();
+        _originalVideoPath = null;
+        _superResolutionVideoPath = null;
+        VideoPath = null;
+        base.Dispose();
+    }
+
+    private void TrackScratchArtifact(string artifactPath)
+    {
+        if (string.IsNullOrWhiteSpace(artifactPath))
+        {
+            return;
+        }
+
+        if (LoadState == CaptureTool.Presentation.Loading.LoadState.Disposed)
+        {
+            _scratchArtifactStore?.DeleteArtifact(artifactPath);
+        }
+        else
+        {
+            _scratchArtifactPaths.Add(artifactPath);
+        }
     }
 
     private void UpdateVideoSuperResolutionAvailability()

--- a/tests/CaptureTool.Application.Tests/Activation/ActivationHandlerTests.cs
+++ b/tests/CaptureTool.Application.Tests/Activation/ActivationHandlerTests.cs
@@ -52,6 +52,9 @@ public sealed class ActivationHandlerTests
         fixture.LogService.Verify(service => service.Enable(), Times.Once);
         fixture.Localization.Verify(service => service.Initialize("fr-FR"), Times.Once);
         fixture.NavigationService.Verify(service => service.SetNavigationHandler(fixture.NavigationHandler.Object), Times.Once);
+        fixture.ScratchArtifactStore.Verify(
+            service => service.ScavengeStaleArtifacts(TimeSpan.FromDays(7)),
+            Times.Once);
     }
 
     [TestMethod]
@@ -101,6 +104,25 @@ public sealed class ActivationHandlerTests
 
         fixture.TelemetryConsent.Verify(
             service => service.SetState(TelemetryConsentState.Granted),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ApplicationStartupInitializer_WhenScratchScavengingFails_ShouldContinueInitialization()
+    {
+        StartupInitializerFixture fixture = new();
+        var exception = new IOException("scratch unavailable");
+        fixture.ScratchArtifactStore
+            .Setup(service => service.ScavengeStaleArtifacts(TimeSpan.FromDays(7)))
+            .Throws(exception);
+
+        await fixture.Initializer.InitializeAsync(TestContext.CancellationToken);
+
+        fixture.NavigationService.Verify(
+            service => service.SetNavigationHandler(fixture.NavigationHandler.Object),
+            Times.Once);
+        fixture.LogService.Verify(
+            service => service.LogException(exception, "Failed to scavenge stale scratch artifacts."),
             Times.Once);
     }
 
@@ -443,6 +465,7 @@ public sealed class ActivationHandlerTests
                 NavigationHandler.Object,
                 NavigationService.Object,
                 StorageService.Object,
+                ScratchArtifactStore.Object,
                 telemetryConsentService: TelemetryConsent.Object);
         }
 
@@ -456,6 +479,7 @@ public sealed class ActivationHandlerTests
         public Mock<INavigationHandler> NavigationHandler { get; } = new();
         public Mock<INavigationService> NavigationService { get; } = new();
         public Mock<IStorageService> StorageService { get; } = new();
+        public Mock<IScratchArtifactStore> ScratchArtifactStore { get; } = new();
         public Mock<ITelemetryConsentService> TelemetryConsent { get; } = new();
     }
 }

--- a/tests/CaptureTool.Application.Tests/Capture/AudioCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/AudioCaptureWorkflowTests.cs
@@ -378,7 +378,7 @@ public sealed class AudioCaptureWorkflowTests
         fileSystem ??= new Mock<IFileSystem>();
 
         storage ??= new Mock<IStorageService>();
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(@"C:\Temp");
+        storage.Setup(service => service.GetApplicationRetainedCaptureFolderPath()).Returns(@"C:\Captures");
         storage.Setup(service => service.GetSystemDefaultMusicFolderPath()).Returns(@"C:\Music");
 
         var taskEnvironment = new Mock<ITaskEnvironment>();

--- a/tests/CaptureTool.Application.Tests/Capture/ImageCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/ImageCaptureWorkflowTests.cs
@@ -180,7 +180,7 @@ public sealed class ImageCaptureWorkflowTests
         IFileSystem? fileSystem = null)
     {
         var storage = new Mock<IStorageService>();
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(tempFolder);
+        storage.Setup(service => service.GetApplicationRetainedCaptureFolderPath()).Returns(tempFolder);
         storage.Setup(service => service.GetSystemDefaultScreenshotsFolderPath()).Returns(tempFolder);
 
         var taskEnvironment = new Mock<ITaskEnvironment>();

--- a/tests/CaptureTool.Application.Tests/Capture/VideoCaptureWorkflowTests.cs
+++ b/tests/CaptureTool.Application.Tests/Capture/VideoCaptureWorkflowTests.cs
@@ -576,7 +576,7 @@ public sealed class VideoCaptureWorkflowTests
 
         var storage = new Mock<IStorageService>();
         storage
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
+            .Setup(service => service.GetApplicationRetainedCaptureFolderPath())
             .Returns(@"C:\Temp");
 
         var backgroundTaskRunner = new Mock<IBackgroundTaskRunner>();

--- a/tests/CaptureTool.Application.Tests/DependencyInjection/ApplicationServiceCollectionExtensionsTests.cs
+++ b/tests/CaptureTool.Application.Tests/DependencyInjection/ApplicationServiceCollectionExtensionsTests.cs
@@ -12,6 +12,7 @@ using CaptureTool.Application.Abstractions.Library.RecentCaptures.ClearRecentCap
 using CaptureTool.Application.Abstractions.Library.RecentCaptures.RemoveRecentCapture;
 using CaptureTool.Application.Abstractions.Navigation;
 using CaptureTool.Application.Abstractions.Settings.OpenSettingsPage;
+using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Activation;
 using CaptureTool.Application.Ai;
 using CaptureTool.Application.Capture.Audio;
@@ -29,6 +30,7 @@ using CaptureTool.Application.Library.RecentCaptures.ClearRecentCaptures;
 using CaptureTool.Application.Library.RecentCaptures.RemoveRecentCapture;
 using CaptureTool.Application.Navigation;
 using CaptureTool.Application.Settings.OpenSettingsPage;
+using CaptureTool.Application.Storage;
 using CaptureTool.Application.UseCases;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -52,6 +54,7 @@ public sealed class ApplicationServiceCollectionExtensionsTests
         AssertHasRegistration<IActiveEditSessionService, ActiveEditSessionService>(services, ServiceLifetime.Singleton);
         AssertHasRegistration<IEditSessionGuard, EditSessionGuard>(services, ServiceLifetime.Singleton);
         AssertHasRegistration<INavigationCoordinator, NavigationCoordinator>(services, ServiceLifetime.Singleton);
+        AssertHasRegistration<IScratchArtifactStore, ScratchArtifactStore>(services, ServiceLifetime.Singleton);
         AssertHasRegistration<IRecentCapturesChangeNotifier, RecentCapturesChangeNotifier>(services, ServiceLifetime.Singleton);
         AssertHasRegistration<IClearRecentCapturesUseCase, ClearRecentCapturesUseCase>(services, ServiceLifetime.Transient);
         AssertHasRegistration<IRemoveRecentCaptureUseCase, RemoveRecentCaptureUseCase>(services, ServiceLifetime.Transient);

--- a/tests/CaptureTool.Application.Tests/Edit/MediaEditUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Edit/MediaEditUseCaseTests.cs
@@ -137,7 +137,7 @@ public sealed class MediaEditUseCaseTests
         var clipboard = new Mock<IClipboardService>();
         var useCase = new CopyVideoFileUseCase(
             clipboard.Object,
-            Mock.Of<IStorageService>(),
+            Mock.Of<IScratchArtifactStore>(),
             Mock.Of<IVideoFileTrimmer>(),
             TestFileSystem.Instance,
             TestUseCaseExecutor.Instance);
@@ -154,19 +154,21 @@ public sealed class MediaEditUseCaseTests
         string videoPath = await CreateTempFileAsync("source.mp4", "video");
         string tempFolder = CreateTestFolder();
         var clipboard = new Mock<IClipboardService>();
-        var storage = new Mock<IStorageService>();
+        var scratchArtifactStore = new Mock<IScratchArtifactStore>();
         var trimmer = new Mock<IVideoFileTrimmer>();
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(tempFolder);
-        storage.Setup(service => service.GetTemporaryFileName()).Returns("trim.tmp");
-        var useCase = new CopyVideoFileUseCase(clipboard.Object, storage.Object, trimmer.Object, TestFileSystem.Instance, TestUseCaseExecutor.Instance);
+        string expectedTrimmedPath = Path.Combine(tempFolder, "trim.mp4");
+        scratchArtifactStore
+            .Setup(service => service.CreateLeasedArtifactPath("clipboard-video-trim", ".mp4"))
+            .Returns(expectedTrimmedPath);
+        var useCase = new CopyVideoFileUseCase(clipboard.Object, scratchArtifactStore.Object, trimmer.Object, TestFileSystem.Instance, TestUseCaseExecutor.Instance);
         var request = new CopyVideoFileRequest(videoPath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3));
 
         CopyVideoFileResponse response = (await useCase.ExecuteAsync(request, TestContext.CancellationToken)).Value!;
 
-        string expectedTrimmedPath = Path.Combine(tempFolder, "trim.mp4");
         Assert.IsTrue(response.Copied);
         trimmer.Verify(service => service.TrimAsync(videoPath, expectedTrimmedPath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TestContext.CancellationToken), Times.Once);
         clipboard.Verify(service => service.CopyFileAsync(It.Is<ClipboardFile>(file => file.FilePath == expectedTrimmedPath)), Times.Once);
+        scratchArtifactStore.Verify(service => service.RelinquishArtifact(expectedTrimmedPath), Times.Once);
     }
 
     [TestMethod]

--- a/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Settings/SettingsPageUseCaseTests.cs
@@ -109,28 +109,19 @@ public sealed class SettingsPageUseCaseTests
     }
 
     [TestMethod]
-    public async Task ClearTempFilesUseCase_DeletesFilesAndFoldersInTemporaryFolder()
+    public async Task ClearTempFilesUseCase_ClearsOnlyUnleasedScratchArtifacts()
     {
-        string tempFolder = CreateTestFolder();
-        string filePath = Path.Combine(tempFolder, "capture.tmp");
-        string directoryPath = Path.Combine(tempFolder, "nested");
-        Directory.CreateDirectory(directoryPath);
-        await File.WriteAllTextAsync(filePath, "file", TestContext.CancellationToken);
-        await File.WriteAllTextAsync(Path.Combine(directoryPath, "child.tmp"), "child", TestContext.CancellationToken);
-        var storage = new Mock<IStorageService>();
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(tempFolder);
+        var scratchArtifactStore = new Mock<IScratchArtifactStore>();
         var recentCapturesChangeNotifier = new Mock<IRecentCapturesChangeNotifier>();
         var useCase = new ClearTempFilesUseCase(
-            Mock.Of<ILogService>(),
-            storage.Object,
-            TestFileSystem.Instance,
+            scratchArtifactStore.Object,
             TestUseCaseExecutor.Instance,
             recentCapturesChangeNotifier.Object);
 
         ClearTempFilesResponse response = (await useCase.ExecuteAsync(new ClearTempFilesRequest(), TestContext.CancellationToken)).Value!;
 
         Assert.IsTrue(response.Succeeded);
-        Assert.IsEmpty(Directory.EnumerateFileSystemEntries(tempFolder).ToArray());
+        scratchArtifactStore.Verify(store => store.ClearUnleasedArtifacts(), Times.Once);
         recentCapturesChangeNotifier.Verify(
             notifier => notifier.NotifyRecentCapturesChanged(),
             Times.Once);
@@ -168,13 +159,13 @@ public sealed class SettingsPageUseCaseTests
         storage.Setup(service => service.GetSystemDefaultScreenshotsFolderPath()).Returns(missingFolder);
         storage.Setup(service => service.GetSystemDefaultVideosFolderPath()).Returns(missingFolder);
         storage.Setup(service => service.GetSystemDefaultMusicFolderPath()).Returns(missingFolder);
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(missingFolder);
+        storage.Setup(service => service.GetApplicationScratchFolderPath()).Returns(missingFolder);
         folderLauncher.Setup(service => service.TryOpenFolder(missingFolder)).Returns(false);
 
         var screenshots = new OpenScreenshotsFolderUseCase(settings.Object, storage.Object, folderLauncher.Object, TestUseCaseExecutor.Instance);
         var videos = new OpenVideosFolderUseCase(settings.Object, storage.Object, folderLauncher.Object, TestUseCaseExecutor.Instance);
         var audio = new OpenAudioFolderUseCase(settings.Object, storage.Object, folderLauncher.Object, TestUseCaseExecutor.Instance);
-        var temp = new OpenTempFolderUseCase(storage.Object, folderLauncher.Object, TestUseCaseExecutor.Instance);
+        var temp = new OpenTempFolderUseCase(storage.Object, folderLauncher.Object, TestFileSystem.Instance, TestUseCaseExecutor.Instance);
 
         OpenScreenshotsFolderResponse screenshotsResponse = (await screenshots.ExecuteAsync(new OpenScreenshotsFolderRequest(), TestContext.CancellationToken)).Value!;
         OpenVideosFolderResponse videosResponse = (await videos.ExecuteAsync(new OpenVideosFolderRequest(), TestContext.CancellationToken)).Value!;

--- a/tests/CaptureTool.Application.Tests/Shell/OpenFileUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Shell/OpenFileUseCaseTests.cs
@@ -28,7 +28,7 @@ public class OpenFileUseCaseTests
             TestNavigationCoordinator.Create(
                 navigationService.Object,
                 editSessionGuard.Object),
-            Mock.Of<IStorageService>(),
+            Mock.Of<IScratchArtifactStore>(),
             TestFileSystem.Instance,
             Mock.Of<IRecentCaptureCatalog>(),
             TestUseCaseExecutor.Instance);
@@ -56,7 +56,7 @@ public class OpenFileUseCaseTests
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
         TestNavigationService.AcceptAll(navigationService);
-        Mock<IStorageService> storageService = new();
+        Mock<IScratchArtifactStore> scratchArtifactStore = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
         string sourceFolder = CreateTestFolder();
@@ -69,16 +69,13 @@ public class OpenFileUseCaseTests
         filePickerService
             .Setup(service => service.PickFileAsync(FilePickerType.CaptureMedia, UserFolder.Pictures))
             .ReturnsAsync(new FileReference(sourcePath));
-        storageService
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
-            .Returns(tempFolder);
-        storageService
-            .Setup(service => service.GetTemporaryFileName())
-            .Returns("open-file.tmp");
+        scratchArtifactStore
+            .Setup(service => service.CreateLeasedArtifactPath("imported-working-copy", ".png"))
+            .Returns(copiedPath);
         OpenFileUseCase useCase = new(
             filePickerService.Object,
             TestNavigationCoordinator.Create(navigationService.Object),
-            storageService.Object,
+            scratchArtifactStore.Object,
             TestFileSystem.Instance,
             recentCaptureCatalog.Object,
             TestUseCaseExecutor.Instance);
@@ -95,7 +92,7 @@ public class OpenFileUseCaseTests
                 false,
                 It.IsAny<CancellationToken>()),
             Times.Once);
-        storageService.Verify(service => service.GetTemporaryFileName(), Times.Once);
+        scratchArtifactStore.Verify(service => service.CreateLeasedArtifactPath("imported-working-copy", ".png"), Times.Once);
         recentCaptureCatalog.Verify(
             catalog => catalog.RecordOpened(sourcePath, CaptureFileType.Image),
             Times.Once);
@@ -107,7 +104,7 @@ public class OpenFileUseCaseTests
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
         TestNavigationService.AcceptAll(navigationService);
-        Mock<IStorageService> storageService = new();
+        Mock<IScratchArtifactStore> scratchArtifactStore = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
         string sourceFolder = CreateTestFolder();
@@ -120,16 +117,13 @@ public class OpenFileUseCaseTests
         filePickerService
             .Setup(service => service.PickFileAsync(FilePickerType.CaptureMedia, UserFolder.Pictures))
             .ReturnsAsync(new FileReference(sourcePath));
-        storageService
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
-            .Returns(tempFolder);
-        storageService
-            .Setup(service => service.GetTemporaryFileName())
-            .Returns("open-file.tmp");
+        scratchArtifactStore
+            .Setup(service => service.CreateLeasedArtifactPath("imported-working-copy", ".wav"))
+            .Returns(copiedPath);
         OpenFileUseCase useCase = new(
             filePickerService.Object,
             TestNavigationCoordinator.Create(navigationService.Object),
-            storageService.Object,
+            scratchArtifactStore.Object,
             TestFileSystem.Instance,
             recentCaptureCatalog.Object,
             TestUseCaseExecutor.Instance);
@@ -144,7 +138,7 @@ public class OpenFileUseCaseTests
                 false,
                 It.IsAny<CancellationToken>()),
             Times.Once);
-        storageService.Verify(service => service.GetTemporaryFileName(), Times.Once);
+        scratchArtifactStore.Verify(service => service.CreateLeasedArtifactPath("imported-working-copy", ".wav"), Times.Once);
         recentCaptureCatalog.Verify(
             catalog => catalog.RecordOpened(sourcePath, CaptureFileType.Audio),
             Times.Once);
@@ -156,7 +150,7 @@ public class OpenFileUseCaseTests
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
         TestNavigationService.AcceptAll(navigationService);
-        Mock<IStorageService> storageService = new();
+        Mock<IScratchArtifactStore> scratchArtifactStore = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
         string sourceFolder = CreateTestFolder();
@@ -169,16 +163,13 @@ public class OpenFileUseCaseTests
         filePickerService
             .Setup(service => service.PickFileAsync(FilePickerType.CaptureMedia, UserFolder.Pictures))
             .ReturnsAsync(new FileReference(sourcePath));
-        storageService
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
-            .Returns(tempFolder);
-        storageService
-            .Setup(service => service.GetTemporaryFileName())
-            .Returns("open-file.tmp");
+        scratchArtifactStore
+            .Setup(service => service.CreateLeasedArtifactPath("imported-working-copy", ".mp4"))
+            .Returns(copiedPath);
         OpenFileUseCase useCase = new(
             filePickerService.Object,
             TestNavigationCoordinator.Create(navigationService.Object),
-            storageService.Object,
+            scratchArtifactStore.Object,
             TestFileSystem.Instance,
             recentCaptureCatalog.Object,
             TestUseCaseExecutor.Instance);
@@ -193,22 +184,23 @@ public class OpenFileUseCaseTests
                 false,
                 It.IsAny<CancellationToken>()),
             Times.Once);
-        storageService.Verify(service => service.GetTemporaryFileName(), Times.Once);
+        scratchArtifactStore.Verify(service => service.CreateLeasedArtifactPath("imported-working-copy", ".mp4"), Times.Once);
         recentCaptureCatalog.Verify(
             catalog => catalog.RecordOpened(sourcePath, CaptureFileType.Video),
             Times.Once);
     }
 
     [TestMethod]
-    public async Task ExecuteAsync_WithFileAlreadyInTemporaryFolder_ShouldNavigateToExistingFile()
+    public async Task ExecuteAsync_WithFileAlreadyInScratchFolder_ShouldCreateOwnedWorkingCopy()
     {
         Mock<IFilePickerService> filePickerService = new();
         Mock<INavigationService> navigationService = new();
         TestNavigationService.AcceptAll(navigationService);
-        Mock<IStorageService> storageService = new();
+        Mock<IScratchArtifactStore> scratchArtifactStore = new();
         Mock<IRecentCaptureCatalog> recentCaptureCatalog = new();
         string tempFolder = CreateTestFolder();
         string sourcePath = Path.Combine(tempFolder, "source.png");
+        string copiedPath = Path.Combine(tempFolder, "owned-copy.png");
         await File.WriteAllTextAsync(sourcePath, "image", TestContext.CancellationToken);
         DateTime oldLastWriteTimeUtc = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         File.SetLastWriteTimeUtc(sourcePath, oldLastWriteTimeUtc);
@@ -216,13 +208,13 @@ public class OpenFileUseCaseTests
         filePickerService
             .Setup(service => service.PickFileAsync(FilePickerType.CaptureMedia, UserFolder.Pictures))
             .ReturnsAsync(new FileReference(sourcePath));
-        storageService
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
-            .Returns(tempFolder);
+        scratchArtifactStore
+            .Setup(service => service.CreateLeasedArtifactPath("imported-working-copy", ".png"))
+            .Returns(copiedPath);
         OpenFileUseCase useCase = new(
             filePickerService.Object,
             TestNavigationCoordinator.Create(navigationService.Object),
-            storageService.Object,
+            scratchArtifactStore.Object,
             TestFileSystem.Instance,
             recentCaptureCatalog.Object,
             TestUseCaseExecutor.Instance);
@@ -234,12 +226,12 @@ public class OpenFileUseCaseTests
             service => service.NavigateAsync(
                 NavigationRoute.ImageEdit,
                 It.Is<ImageFile>(file =>
-                    file.FilePath == sourcePath &&
-                    file.PersistentFilePath == null),
+                    file.FilePath == copiedPath &&
+                    file.PersistentFilePath == sourcePath),
                 false,
                 It.IsAny<CancellationToken>()),
             Times.Once);
-        storageService.Verify(service => service.GetTemporaryFileName(), Times.Never);
+        scratchArtifactStore.Verify(service => service.CreateLeasedArtifactPath("imported-working-copy", ".png"), Times.Once);
         recentCaptureCatalog.Verify(
             catalog => catalog.RecordOpened(sourcePath, CaptureFileType.Image),
             Times.Once);

--- a/tests/CaptureTool.Application.Tests/Shell/SimpleApplicationUseCaseTests.cs
+++ b/tests/CaptureTool.Application.Tests/Shell/SimpleApplicationUseCaseTests.cs
@@ -343,7 +343,7 @@ public sealed class SimpleApplicationUseCaseTests
         INavigationCoordinator coordinator = TestNavigationCoordinator.Create(Mock.Of<INavigationService>());
         var useCase = new OpenRecentCaptureUseCase(
             TestFileSystem.Instance,
-            CreateRecentCaptureStorage(),
+            CreateRecentCaptureScratchStore(),
             catalog.Object,
             audioEdit.Object,
             imageEdit.Object,
@@ -384,7 +384,7 @@ public sealed class SimpleApplicationUseCaseTests
         INavigationCoordinator coordinator = TestNavigationCoordinator.Create(Mock.Of<INavigationService>());
         var useCase = new OpenRecentCaptureUseCase(
             TestFileSystem.Instance,
-            CreateRecentCaptureStorage(),
+            CreateRecentCaptureScratchStore(),
             Mock.Of<IRecentCaptureCatalog>(),
             Mock.Of<IOpenAudioEditPageUseCase>(),
             Mock.Of<IOpenImageEditPageUseCase>(),
@@ -408,13 +408,22 @@ public sealed class SimpleApplicationUseCaseTests
         return path;
     }
 
-    private static IStorageService CreateRecentCaptureStorage()
+    private static IScratchArtifactStore CreateRecentCaptureScratchStore()
     {
-        var storage = new Mock<IStorageService>();
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath())
-            .Returns(Path.Combine(Path.GetTempPath(), "CaptureToolTests", "RecentWorkingFiles"));
-        storage.Setup(service => service.GetTemporaryFileName()).Returns(Guid.NewGuid().ToString());
-        return storage.Object;
+        var scratchArtifactStore = new Mock<IScratchArtifactStore>();
+        scratchArtifactStore
+            .Setup(service => service.CreateLeasedArtifactPath("recent-capture-working-copy", It.IsAny<string>()))
+            .Returns((string _, string extension) =>
+            {
+                string ownerFolder = Path.Combine(
+                    Path.GetTempPath(),
+                    "CaptureToolTests",
+                    "RecentWorkingFiles",
+                    Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(ownerFolder);
+                return Path.Combine(ownerFolder, $"working{extension}");
+            });
+        return scratchArtifactStore.Object;
     }
 
     public TestContext TestContext { get; set; } = null!;

--- a/tests/CaptureTool.Application.Tests/Storage/ScratchArtifactStoreTests.cs
+++ b/tests/CaptureTool.Application.Tests/Storage/ScratchArtifactStoreTests.cs
@@ -1,0 +1,115 @@
+using CaptureTool.Application.Abstractions.Logging;
+using CaptureTool.Application.Abstractions.Storage;
+using CaptureTool.Application.Abstractions.Time;
+using CaptureTool.Application.Storage;
+using Moq;
+
+namespace CaptureTool.Application.Tests.Storage;
+
+[TestClass]
+public sealed class ScratchArtifactStoreTests
+{
+    [TestMethod]
+    public async Task ClearUnleasedArtifacts_PreservesActiveLeaseAndRetainedCapture()
+    {
+        using TestFolders folders = new();
+        ScratchArtifactStore store = CreateStore(folders);
+        string activePath = store.CreateLeasedArtifactPath("active-editor", ".png");
+        string unleasedPath = store.CreateLeasedArtifactPath("clipboard", ".mp4");
+        await File.WriteAllTextAsync(activePath, "active", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(unleasedPath, "clipboard", TestContext.CancellationToken);
+        store.RelinquishArtifact(unleasedPath);
+
+        string retainedCapturePath = Path.Combine(folders.RetainedPath, "only-copy.png");
+        Directory.CreateDirectory(folders.RetainedPath);
+        await File.WriteAllTextAsync(retainedCapturePath, "capture", TestContext.CancellationToken);
+
+        store.ClearUnleasedArtifacts();
+
+        Assert.IsTrue(File.Exists(activePath));
+        Assert.IsFalse(Directory.Exists(Path.GetDirectoryName(unleasedPath)));
+        Assert.IsTrue(File.Exists(retainedCapturePath));
+    }
+
+    [TestMethod]
+    public async Task DeleteArtifact_DeletesOnlyItsOwnerDirectoryAndIsIdempotent()
+    {
+        using TestFolders folders = new();
+        ScratchArtifactStore store = CreateStore(folders);
+        string firstPath = store.CreateLeasedArtifactPath("first", ".png");
+        string secondPath = store.CreateLeasedArtifactPath("second", ".png");
+        await File.WriteAllTextAsync(firstPath, "first", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(secondPath, "second", TestContext.CancellationToken);
+
+        store.DeleteArtifact(firstPath);
+        store.DeleteArtifact(firstPath);
+        store.DeleteArtifact(Path.Combine(folders.RetainedPath, "outside.png"));
+
+        Assert.IsFalse(Directory.Exists(Path.GetDirectoryName(firstPath)));
+        Assert.IsTrue(File.Exists(secondPath));
+    }
+
+    [TestMethod]
+    public async Task ScavengeStaleArtifacts_DeletesOnlyStaleUnleasedOwners()
+    {
+        using TestFolders folders = new();
+        DateTime nowUtc = new(2026, 8, 5, 12, 0, 0, DateTimeKind.Utc);
+        ScratchArtifactStore store = CreateStore(folders, nowUtc);
+        string stalePath = store.CreateLeasedArtifactPath("stale", ".tmp");
+        string freshPath = store.CreateLeasedArtifactPath("fresh", ".tmp");
+        string activePath = store.CreateLeasedArtifactPath("active", ".tmp");
+        await File.WriteAllTextAsync(stalePath, "stale", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(freshPath, "fresh", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(activePath, "active", TestContext.CancellationToken);
+        store.RelinquishArtifact(stalePath);
+        store.RelinquishArtifact(freshPath);
+
+        Directory.SetLastWriteTimeUtc(Path.GetDirectoryName(stalePath)!, nowUtc - TimeSpan.FromDays(8));
+        Directory.SetLastWriteTimeUtc(Path.GetDirectoryName(freshPath)!, nowUtc - TimeSpan.FromDays(6));
+        Directory.SetLastWriteTimeUtc(Path.GetDirectoryName(activePath)!, nowUtc - TimeSpan.FromDays(30));
+
+        store.ScavengeStaleArtifacts(TimeSpan.FromDays(7));
+
+        Assert.IsFalse(Directory.Exists(Path.GetDirectoryName(stalePath)));
+        Assert.IsTrue(File.Exists(freshPath));
+        Assert.IsTrue(File.Exists(activePath));
+    }
+
+    private static ScratchArtifactStore CreateStore(TestFolders folders, DateTime? utcNow = null)
+    {
+        var storage = new Mock<IStorageService>();
+        storage.Setup(service => service.GetApplicationScratchFolderPath()).Returns(folders.ScratchPath);
+        storage.Setup(service => service.GetTemporaryFileName()).Returns(() => $"{Guid.NewGuid():N}.tmp");
+        var clock = new Mock<IClock>();
+        clock.SetupGet(service => service.UtcNow).Returns(utcNow ?? DateTime.UtcNow);
+        return new ScratchArtifactStore(
+            storage.Object,
+            TestFileSystem.Instance,
+            clock.Object,
+            Mock.Of<ILogService>());
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+
+    private sealed class TestFolders : IDisposable
+    {
+        public TestFolders()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), "CaptureToolTests", Guid.NewGuid().ToString("N"));
+            ScratchPath = Path.Combine(RootPath, "Scratch");
+            RetainedPath = Path.Combine(RootPath, "Captures");
+        }
+
+        public string RootPath { get; }
+        public string ScratchPath { get; }
+        public string RetainedPath { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, true);
+            }
+        }
+    }
+}

--- a/tests/CaptureTool.Infrastructure.Tests/RecentCaptures/LocalRecentCaptureCatalogTests.cs
+++ b/tests/CaptureTool.Infrastructure.Tests/RecentCaptures/LocalRecentCaptureCatalogTests.cs
@@ -99,7 +99,8 @@ public sealed class LocalRecentCaptureCatalogTests
     private sealed class TestStorageService(string dataFolder) : IStorageService
     {
         public string GetApplicationDataFolderPath() => dataFolder;
-        public string GetApplicationTemporaryFolderPath() => Path.Combine(dataFolder, "Temp");
+        public string GetApplicationRetainedCaptureFolderPath() => Path.Combine(dataFolder, "Captures");
+        public string GetApplicationScratchFolderPath() => Path.Combine(dataFolder, "Temp", "Scratch");
         public string GetSystemDefaultMusicFolderPath() => Path.Combine(dataFolder, "Music");
         public string GetSystemDefaultScreenshotsFolderPath() => Path.Combine(dataFolder, "Pictures");
         public string GetSystemDefaultVideosFolderPath() => Path.Combine(dataFolder, "Videos");

--- a/tests/CaptureTool.Presentation.Tests/Features/AudioEditPageViewModelWaveformTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/AudioEditPageViewModelWaveformTests.cs
@@ -2,6 +2,7 @@ using CaptureTool.Application.Abstractions.Edit.Audio.CopyAudioFile;
 using CaptureTool.Application.Abstractions.Edit.Audio.SaveAudioFile;
 using CaptureTool.Application.Abstractions.Edit.External;
 using CaptureTool.Application.Abstractions.Settings.OpenAudioFolder;
+using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Domain.FileSystem;
 using CaptureTool.Presentation.Features.Audio;
@@ -77,15 +78,31 @@ public sealed class AudioEditPageViewModelWaveformTests
             Times.Once);
     }
 
+    [TestMethod]
+    public void Dispose_ShouldReleaseOwnedWorkingCopy()
+    {
+        var scratchArtifactStore = new Mock<IScratchArtifactStore>();
+        AudioEditPageViewModel viewModel = CreateViewModel(scratchArtifactStore: scratchArtifactStore.Object);
+        viewModel.Load(new AudioFile("scratch\\working.wav"));
+
+        viewModel.Dispose();
+
+        scratchArtifactStore.Verify(
+            store => store.DeleteArtifact("scratch\\working.wav"),
+            Times.Once);
+    }
+
     private static AudioEditPageViewModel CreateViewModel(
         IOpenExternalEditorUseCase? openExternalEditorAction = null,
-        IOpenAudioFolderUseCase? openAudioFolderAction = null)
+        IOpenAudioFolderUseCase? openAudioFolderAction = null,
+        IScratchArtifactStore? scratchArtifactStore = null)
     {
         return new AudioEditPageViewModel(
             Mock.Of<ISaveAudioFileUseCase>(),
             Mock.Of<ICopyAudioFileUseCase>(),
             openExternalEditorAction ?? Mock.Of<IOpenExternalEditorUseCase>(),
             openAudioFolderAction ?? Mock.Of<IOpenAudioFolderUseCase>(),
-            Mock.Of<IAudioWaveformHistory>());
+            Mock.Of<IAudioWaveformHistory>(),
+            scratchArtifactStore: scratchArtifactStore);
     }
 }

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelShareTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelShareTests.cs
@@ -148,7 +148,7 @@ public sealed class ImageEditPageViewModelShareTests
             .Returns(new Size(100, 200));
 
         storage
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
+            .Setup(service => service.GetApplicationScratchFolderPath())
             .Returns(tempFolder);
         storage
             .Setup(service => service.GetTemporaryFileName())

--- a/tests/CaptureTool.Presentation.Tests/Features/SettingsPageViewModelAiConsentTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/SettingsPageViewModelAiConsentTests.cs
@@ -292,7 +292,7 @@ public sealed class SettingsPageViewModelAiConsentTests
             .Setup(service => service.GetSystemDefaultMusicFolderPath())
             .Returns(@"C:\Music");
         storage
-            .Setup(service => service.GetApplicationTemporaryFolderPath())
+            .Setup(service => service.GetApplicationScratchFolderPath())
             .Returns(@"C:\Temp");
 
         return new SettingsPageViewModel(

--- a/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelSuperResolutionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelSuperResolutionTests.cs
@@ -6,6 +6,7 @@ using CaptureTool.Application.Abstractions.Edit.Video.SuperResolution;
 using CaptureTool.Application.Abstractions.Localization;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Settings.OpenVideosFolder;
+using CaptureTool.Application.Abstractions.Storage;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Domain.Ai;
 using CaptureTool.Domain.FileSystem;
@@ -53,6 +54,22 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
         saveAction.Verify(action => action.ExecuteAsync(
             It.Is<SaveVideoFileRequest>(request => request.VideoPath == "enhanced.mp4"),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Dispose_ShouldReleaseWorkingCopyAndGeneratedDerivative()
+    {
+        var scratchArtifactStore = new Mock<IScratchArtifactStore>();
+        VideoEditPageViewModel viewModel = CreateViewModel(
+            service: CreateReadyService("enhanced.mp4"),
+            scratchArtifactStore: scratchArtifactStore.Object);
+        viewModel.Load(new VideoFile("working.mp4"));
+        await viewModel.ToggleVideoSuperResolutionCommand.ExecuteAsync(null);
+
+        viewModel.Dispose();
+
+        scratchArtifactStore.Verify(store => store.DeleteArtifact("working.mp4"), Times.Once);
+        scratchArtifactStore.Verify(store => store.DeleteArtifact("enhanced.mp4"), Times.Once);
     }
 
     [TestMethod]
@@ -274,7 +291,8 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
         Mock<IVideoSuperResolutionService>? service = null,
         ISaveVideoFileUseCase? saveAction = null,
         IAiFeatureConsentService? consentService = null,
-        IAiFeatureConsentDialogService? consentDialogService = null)
+        IAiFeatureConsentDialogService? consentDialogService = null,
+        IScratchArtifactStore? scratchArtifactStore = null)
     {
         service ??= CreateReadyService("enhanced.mp4");
         consentService ??= Mock.Of<IAiFeatureConsentService>(consent =>
@@ -297,7 +315,8 @@ public sealed class VideoEditPageViewModelSuperResolutionTests
             consentService,
             consentDialogService ?? Mock.Of<IAiFeatureConsentDialogService>(),
             localization.Object,
-            Mock.Of<IAppNotificationService>());
+            Mock.Of<IAppNotificationService>(),
+            scratchArtifactStore: scratchArtifactStore);
     }
 
     public TestContext TestContext { get; set; } = null!;

--- a/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelTrimTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/VideoEditPageViewModelTrimTests.cs
@@ -316,7 +316,7 @@ public class VideoEditPageViewModelTrimTests
     private static ICopyVideoFileUseCase CreateCopyUseCase(Mock<IVideoFileTrimmer>? trimmer = null)
     {
         var storage = new Mock<IStorageService>();
-        storage.Setup(service => service.GetApplicationTemporaryFolderPath()).Returns(Path.GetTempPath());
+        storage.Setup(service => service.GetApplicationScratchFolderPath()).Returns(Path.GetTempPath());
         storage.Setup(service => service.GetTemporaryFileName()).Returns($"{Guid.NewGuid()}.tmp");
 
         var videoTrimmer = trimmer ?? new Mock<IVideoFileTrimmer>();
@@ -327,7 +327,7 @@ public class VideoEditPageViewModelTrimTests
             {
                 if (request.TrimStart.HasValue && request.TrimEnd.HasValue)
                 {
-                    string destinationPath = Path.Combine(storage.Object.GetApplicationTemporaryFolderPath(), storage.Object.GetTemporaryFileName());
+                    string destinationPath = Path.Combine(storage.Object.GetApplicationScratchFolderPath(), storage.Object.GetTemporaryFileName());
                     await videoTrimmer.Object.TrimAsync(request.VideoPath, destinationPath, request.TrimStart.Value, request.TrimEnd.Value, cancellationToken);
                 }
                 return UseCaseResponse<CopyVideoFileResponse>.Success(new CopyVideoFileResponse());


### PR DESCRIPTION
## Summary

- separates catalog-backed captures into durable application-local storage
- introduces isolated, leased scratch owner directories for working copies, previews, clipboard trims, Paint exports, and AI derivatives
- protects active leases from manual cleanup and seven-day startup scavenging
- releases editor-owned scratch artifacts on disposal and avoids trim-preview cleanup races

## Root cause

Retained captures and disposable work products shared one platform temporary folder. The clear-temp command enumerated that folder indiscriminately, so it could delete a catalog-backed capture that was the user's only copy or race an active render/generation operation.

## User impact

Clearing temporary files now affects scratch data only. Non-auto-saved captures remain in the recent-capture library, active editors keep their files, and abandoned scratch directories are reclaimed automatically.

## Validation

- 707 non-UI tests pass across all six test projects
- `dotnet build CaptureTool.slnx -c Debug -p:Platform=x64 --no-restore -m:1`
- focused regression coverage for retained-capture survival, active-lease protection, session disposal, clipboard relinquishment, and stale startup scavenging

Closes #423
