### PR TITLE
Refresh add-on entitlement after purchase

### DIFF
--- a/docs/prd-427-refresh-store-entitlement-after-purchase.md
+++ b/docs/prd-427-refresh-store-entitlement-after-purchase.md
@@ -1,0 +1,108 @@
+# PRD: Refresh Store entitlement after add-on purchase
+
+- Issue: [#427](https://github.com/shanebweaver/CaptureTool/issues/427)
+- Finding: `ARCH-22`
+- Severity: Low
+- Status: Implemented
+- Affected features: `IMG-08`, `PLT-09`
+
+## Summary
+
+The Store page must own the add-on purchase workflow rather than binding its button directly to the purchase use case. While a purchase is running, duplicate attempts must be disabled. When the Store reports success—including its already-purchased result—the page must refresh product and entitlement state immediately. A failed or canceled attempt must leave the product retryable and show bounded feedback.
+
+## Problem
+
+`StorePageViewModel` assigns add-on ownership, price, logo, and availability only during `LoadAsync`. Its purchase command delegates directly to `PurchaseChromaKeyAddOnUseCase`, discarding `PurchaseChromaKeyAddOnResponse`. The page therefore never reloads Store product state after a successful purchase.
+
+The Windows Store adapter maps both `Succeeded` and `AlreadyPurchased` to a successful purchase response, so both paths currently leave stale UI. The purchase button can continue to appear enabled and the add-on can continue to appear unowned until the page is reopened.
+
+## Goals
+
+1. Consume the purchase response in `StorePageViewModel`.
+2. Disable duplicate purchase attempts while a request is in flight.
+3. Refresh Store product and entitlement state after successful or already-owned outcomes.
+4. Prevent a confirmed purchase from returning to an actionable unowned state if Store propagation is delayed.
+5. Show bounded failure/cancellation feedback while keeping retry available.
+6. Keep Store-specific platform statuses inside infrastructure.
+
+## Non-goals
+
+- Do not enable the currently disabled Store feature.
+- Do not redesign the Store page or purchase use case.
+- Do not add receipt validation, refund handling, or license-change push notifications.
+- Do not expose Store error text, product identifiers, or account information in UI or telemetry.
+- Do not alter the image editor’s entitlement lookup.
+
+## State model
+
+The Store page maintains these independent concerns:
+
+- **Product state:** available/unavailable, owned/unowned, price, and logo.
+- **Purchase state:** idle or purchasing.
+- **Purchase feedback:** none or a bounded unsuccessful-attempt message.
+
+The purchase command is available only when the product is available, is not owned, and no purchase is in flight.
+
+## Functional requirements
+
+### Initial product load
+
+- Query the add-on through `IGetChromaKeyAddOnUseCase` using the linked application cancellation token.
+- Apply ownership, availability, price, and logo through one shared state-update path.
+- Preserve the existing unavailable state when no product is returned.
+
+### Purchase workflow
+
+- Clear stale purchase feedback before starting an attempt.
+- Set purchasing state before invoking `IPurchaseChromaKeyAddOnUseCase`.
+- Disable the purchase command for the full in-flight interval.
+- Restore idle state in `finally`, including exception and cancellation paths.
+- Treat only `PurchaseChromaKeyAddOnResponse.Purchased == true` as confirmation.
+
+### Successful or already-owned outcome
+
+- Re-query product information after confirmation.
+- Apply refreshed price, logo, and entitlement state.
+- Treat the confirmed purchase response as authoritative if the refreshed product temporarily reports unowned or cannot be returned.
+- Show the localized owned label and keep purchase disabled.
+
+### Failure or cancellation
+
+- Do not re-query product state.
+- Preserve the pre-purchase product state.
+- Show a generic localized message that the purchase was not completed.
+- Keep the purchase action available for retry.
+
+## User experience
+
+- Replace the price label with an in-button progress indicator during purchase.
+- Disable the purchase button while purchasing and after ownership is confirmed.
+- Show failure feedback adjacent to the purchase action.
+- Do not display raw Store statuses or exception content.
+
+## Reliability requirements
+
+- A command invoked twice while the first attempt is running must issue only one purchase request.
+- Purchase state must return to idle after every completed attempt.
+- A confirmed purchase must not leave `IsChromaKeyAddOnAvailable` true.
+- Failure feedback must clear when a retry begins or ownership is confirmed.
+- Linked cancellation sources must be disposed after load and purchase operations.
+
+## Test plan
+
+- Load an unowned add-on and verify purchase is available.
+- Complete a successful purchase and verify product state is queried again and becomes owned.
+- Return an unowned or missing product after confirmed purchase and verify purchase remains disabled and ownership is shown.
+- Hold a purchase in flight and verify duplicate execution is disabled.
+- Return unsuccessful and canceled responses and verify feedback plus retry availability.
+- Build WinUI to validate the Store-page bindings.
+- Run every non-UI test project.
+
+## Acceptance criteria
+
+- [x] Successful and already-owned purchase outcomes refresh entitlement UI immediately.
+- [x] Duplicate purchase attempts are disabled while Store UI is active.
+- [x] Confirmed ownership disables further purchase attempts.
+- [x] Failure and cancellation produce bounded, retryable feedback.
+- [x] Existing non-UI tests remain green.
+- [x] The WinUI x64 Debug project builds successfully.

--- a/src/CaptureTool.Presentation.Windows.WinUI/Strings/en-US/Resources.resw
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Strings/en-US/Resources.resw
@@ -933,6 +933,10 @@ Adjust the tolerance to remove the background, then desaturate the key color to 
     <value>Owned</value>
     <comment>The label for the purchase button when an add on is already owned.</comment>
   </data>
+  <data name="AddOns_ChromaKeyPurchaseNotCompletedLabel.Text" xml:space="preserve">
+    <value>The purchase wasn't completed. Try again.</value>
+    <comment>Shown after an add-on purchase fails or is canceled.</comment>
+  </data>
   <data name="ContentDialog_Close" xml:space="preserve">
     <value>Close</value>
     <comment>The text for the close button in a content dialog</comment>

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/AddOnsPage.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/AddOnsPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:CaptureTool.Presentation.Windows.WinUI.Xaml.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:utils="using:CaptureTool.Presentation.Windows.WinUI.Utils"
     xmlns:viewmodels="using:CaptureTool.Presentation.Features.Store"
     d:DataContext="{d:DesignInstance Type=viewmodels:StorePageViewModel}"
     mc:Ignorable="d">
@@ -74,7 +75,8 @@
                         <Grid RowSpacing="12">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
                             <Grid
@@ -99,7 +101,7 @@
                                 Background="{ThemeResource AccentFillColorDefaultBrush}"
                                 Command="{x:Bind ViewModel.PurchaseChromaKeyAddOnCommand}"
                                 Foreground="{ThemeResource SystemAltHighColor}"
-                                IsEnabled="{x:Bind ViewModel.IsChromaKeyAddOnAvailable, Mode=OneWay}">
+                                IsEnabled="{x:Bind ViewModel.CanPurchaseChromaKeyAddOn, Mode=OneWay}">
                                 <Grid>
                                     <ProgressRing
                                         Width="16"
@@ -107,13 +109,25 @@
                                         HorizontalAlignment="Center"
                                         IsActive="True"
                                         Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+                                    <ProgressRing
+                                        Width="16"
+                                        Height="16"
+                                        HorizontalAlignment="Center"
+                                        IsActive="True"
+                                        Visibility="{x:Bind utils:VisibilityUtility.BoolToVisibility(ViewModel.IsPurchasingChromaKeyAddOn), Mode=OneWay}" />
                                     <TextBlock
                                         HorizontalAlignment="Left"
                                         FontWeight="SemiBold"
-                                        Text="{x:Bind ViewModel.ChromaKeyAddOnPrice, Mode=OneWay}"
+                                        Text="{x:Bind ViewModel.ChromaKeyAddOnPurchaseButtonText, Mode=OneWay}"
                                         Visibility="{x:Bind ViewModel.IsLoaded, Mode=OneWay}" />
                                 </Grid>
                             </Button>
+                            <TextBlock
+                                x:Uid="AddOns_ChromaKeyPurchaseNotCompletedLabel"
+                                Grid.Row="2"
+                                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                TextWrapping="Wrap"
+                                Visibility="{x:Bind utils:VisibilityUtility.BoolToVisibility(ViewModel.HasChromaKeyAddOnPurchaseFailure), Mode=OneWay}" />
                         </Grid>
                         <Grid
                             Grid.Column="1"

--- a/src/CaptureTool.Presentation/Features/Store/StorePageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/Store/StorePageViewModel.cs
@@ -24,12 +24,17 @@ public sealed partial class StorePageViewModel : AsyncLoadableViewModelBase
 
         ChromaKeyAddOnPrice = localizationService.GetString("AddOns_ItemUnknown");
         GoBackCommand = leaveStorePageCommand.ToRelayCommand(() => new LeaveStorePageRequest());
-        PurchaseChromaKeyAddOnCommand = purchaseChromaKeyAddOnCommand.ToAsyncRelayCommand(() => new PurchaseChromaKeyAddOnRequest());
+        PurchaseChromaKeyAddOnCommand = new AsyncRelayCommand(
+            PurchaseChromaKeyAddOnAsync,
+            () => CanPurchaseChromaKeyAddOn,
+            AsyncRelayCommandOptions.FlowExceptionsToTaskScheduler);
+        _purchaseChromaKeyAddOnCommand = purchaseChromaKeyAddOnCommand;
         _getChromaKeyAddOnQuery = getChromaKeyAddOnQuery;
     }
 
     private readonly ILocalizationService _localizationService;
     private readonly ICancellationService _cancellationService;
+    private readonly IPurchaseChromaKeyAddOnUseCase _purchaseChromaKeyAddOnCommand;
     private readonly IGetChromaKeyAddOnUseCase _getChromaKeyAddOnQuery;
 
     public IAsyncRelayCommand PurchaseChromaKeyAddOnCommand { get; }
@@ -38,13 +43,26 @@ public sealed partial class StorePageViewModel : AsyncLoadableViewModelBase
     public bool IsChromaKeyAddOnOwned
     {
         get;
-        private set => Set(ref field, value);
+        private set
+        {
+            if (Set(ref field, value))
+            {
+                RaisePropertyChanged(nameof(CanPurchaseChromaKeyAddOn));
+                PurchaseChromaKeyAddOnCommand.NotifyCanExecuteChanged();
+            }
+        }
     }
 
     public string ChromaKeyAddOnPrice
     {
         get;
-        private set => Set(ref field, value);
+        private set
+        {
+            if (Set(ref field, value))
+            {
+                RaisePropertyChanged(nameof(ChromaKeyAddOnPurchaseButtonText));
+            }
+        }
     }
 
     public Uri? ChromaKeyAddOnLogoImage
@@ -56,40 +74,128 @@ public sealed partial class StorePageViewModel : AsyncLoadableViewModelBase
     public bool IsChromaKeyAddOnAvailable
     {
         get;
+        private set
+        {
+            if (Set(ref field, value))
+            {
+                RaisePropertyChanged(nameof(CanPurchaseChromaKeyAddOn));
+                PurchaseChromaKeyAddOnCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool IsPurchasingChromaKeyAddOn
+    {
+        get;
+        private set
+        {
+            if (Set(ref field, value))
+            {
+                RaisePropertyChanged(nameof(CanPurchaseChromaKeyAddOn));
+                RaisePropertyChanged(nameof(ChromaKeyAddOnPurchaseButtonText));
+                PurchaseChromaKeyAddOnCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool HasChromaKeyAddOnPurchaseFailure
+    {
+        get;
         private set => Set(ref field, value);
     }
+
+    public bool CanPurchaseChromaKeyAddOn =>
+        IsChromaKeyAddOnAvailable &&
+        !IsChromaKeyAddOnOwned &&
+        !IsPurchasingChromaKeyAddOn;
+
+    public string ChromaKeyAddOnPurchaseButtonText =>
+        IsPurchasingChromaKeyAddOn ? string.Empty : ChromaKeyAddOnPrice;
 
     public override async Task LoadAsync(CancellationToken cancellationToken)
     {
         ThrowIfNotReadyToLoad();
         StartLoading();
 
-        var cts = _cancellationService.GetLinkedCancellationTokenSource(cancellationToken);
+        using CancellationTokenSource cts =
+            _cancellationService.GetLinkedCancellationTokenSource(cancellationToken);
+        await RefreshChromaKeyAddOnAsync(false, cts.Token);
+        await base.LoadAsync(cts.Token);
+    }
+
+    private async Task PurchaseChromaKeyAddOnAsync(CancellationToken cancellationToken)
+    {
+        if (!CanPurchaseChromaKeyAddOn)
+        {
+            return;
+        }
+
+        HasChromaKeyAddOnPurchaseFailure = false;
+        IsPurchasingChromaKeyAddOn = true;
+        using CancellationTokenSource cts =
+            _cancellationService.GetLinkedCancellationTokenSource(cancellationToken);
         try
         {
-            IStoreAddOn? addOn = (await _getChromaKeyAddOnQuery.ExecuteAsync(new GetChromaKeyAddOnRequest(), cancellationToken)).Value?.AddOn;
-
-            if (addOn != null)
+            var response = await _purchaseChromaKeyAddOnCommand.ExecuteAsync(
+                new PurchaseChromaKeyAddOnRequest(),
+                cts.Token);
+            if (response.Value?.Purchased != true)
             {
-                bool isOwned = addOn.IsOwned;
-                IsChromaKeyAddOnAvailable = !isOwned;
-                IsChromaKeyAddOnOwned = isOwned;
-                ChromaKeyAddOnPrice = isOwned ? _localizationService.GetString("AddOns_ItemOwned") : addOn.Price;
-                ChromaKeyAddOnLogoImage = addOn.LogoImage;
-            }
-            else
-            {
-                IsChromaKeyAddOnAvailable = false;
-                IsChromaKeyAddOnOwned = false;
-                ChromaKeyAddOnPrice = _localizationService.GetString("AddOns_ItemNotAvailable");
-                ChromaKeyAddOnLogoImage = null;
+                HasChromaKeyAddOnPurchaseFailure = true;
+                return;
             }
 
-            await base.LoadAsync(cancellationToken);
+            await RefreshChromaKeyAddOnAsync(true, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            HasChromaKeyAddOnPurchaseFailure = true;
         }
         finally
         {
-            cts.Dispose();
+            IsPurchasingChromaKeyAddOn = false;
+        }
+    }
+
+    private async Task RefreshChromaKeyAddOnAsync(
+        bool purchaseConfirmed,
+        CancellationToken cancellationToken)
+    {
+        var response = await _getChromaKeyAddOnQuery.ExecuteAsync(
+            new GetChromaKeyAddOnRequest(),
+            cancellationToken);
+        ApplyChromaKeyAddOn(response.Value?.AddOn, purchaseConfirmed);
+    }
+
+    private void ApplyChromaKeyAddOn(IStoreAddOn? addOn, bool purchaseConfirmed)
+    {
+        if (addOn is not null)
+        {
+            bool isOwned = purchaseConfirmed || addOn.IsOwned;
+            IsChromaKeyAddOnAvailable = !isOwned;
+            IsChromaKeyAddOnOwned = isOwned;
+            ChromaKeyAddOnPrice = isOwned
+                ? _localizationService.GetString("AddOns_ItemOwned")
+                : addOn.Price;
+            ChromaKeyAddOnLogoImage = addOn.LogoImage;
+        }
+        else if (purchaseConfirmed)
+        {
+            IsChromaKeyAddOnAvailable = false;
+            IsChromaKeyAddOnOwned = true;
+            ChromaKeyAddOnPrice = _localizationService.GetString("AddOns_ItemOwned");
+        }
+        else
+        {
+            IsChromaKeyAddOnAvailable = false;
+            IsChromaKeyAddOnOwned = false;
+            ChromaKeyAddOnPrice = _localizationService.GetString("AddOns_ItemNotAvailable");
+            ChromaKeyAddOnLogoImage = null;
+        }
+
+        if (IsChromaKeyAddOnOwned)
+        {
+            HasChromaKeyAddOnPurchaseFailure = false;
         }
     }
 }

--- a/tests/CaptureTool.Presentation.Tests/Features/StorePageViewModelTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/StorePageViewModelTests.cs
@@ -1,0 +1,195 @@
+using CaptureTool.Application.Abstractions.Cancellation;
+using CaptureTool.Application.Abstractions.Localization;
+using CaptureTool.Application.Abstractions.Store;
+using CaptureTool.Application.Abstractions.Store.GetChromaKeyAddOn;
+using CaptureTool.Application.Abstractions.Store.LeaveStorePage;
+using CaptureTool.Application.Abstractions.Store.PurchaseChromaKeyAddOn;
+using CaptureTool.Application.Abstractions.UseCases;
+using CaptureTool.Presentation.Features.Store;
+using FluentAssertions;
+using Moq;
+
+namespace CaptureTool.Presentation.Tests.Features;
+
+[TestClass]
+public sealed class StorePageViewModelTests
+{
+    [TestMethod]
+    public async Task PurchaseChromaKeyAddOnCommand_WhenPurchaseSucceeds_RefreshesAndOwnsAddOn()
+    {
+        IStoreAddOn initialAddOn = CreateAddOn(false, "$4.99");
+        IStoreAddOn delayedStoreAddOn = CreateAddOn(false, "$4.99");
+        var getAddOn = new Mock<IGetChromaKeyAddOnUseCase>();
+        getAddOn
+            .SetupSequence(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGetResponse(initialAddOn))
+            .ReturnsAsync(CreateGetResponse(delayedStoreAddOn));
+        var purchase = new Mock<IPurchaseChromaKeyAddOnUseCase>();
+        purchase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<PurchaseChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreatePurchaseResponse(true));
+        StorePageViewModel viewModel = CreateViewModel(purchase.Object, getAddOn.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        await viewModel.PurchaseChromaKeyAddOnCommand.ExecuteAsync(null);
+
+        viewModel.IsChromaKeyAddOnOwned.Should().BeTrue();
+        viewModel.IsChromaKeyAddOnAvailable.Should().BeFalse();
+        viewModel.CanPurchaseChromaKeyAddOn.Should().BeFalse();
+        viewModel.ChromaKeyAddOnPrice.Should().Be("Owned");
+        viewModel.HasChromaKeyAddOnPurchaseFailure.Should().BeFalse();
+        getAddOn.Verify(
+            useCase => useCase.ExecuteAsync(
+                It.IsAny<GetChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task PurchaseChromaKeyAddOnCommand_WhilePurchaseIsRunning_DisablesDuplicateAttempt()
+    {
+        var purchaseCompletion = new TaskCompletionSource<UseCaseResponse<PurchaseChromaKeyAddOnResponse>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var purchase = new Mock<IPurchaseChromaKeyAddOnUseCase>();
+        purchase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<PurchaseChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(purchaseCompletion.Task);
+        var getAddOn = CreateGetAddOnUseCase(CreateAddOn(false, "$4.99"));
+        StorePageViewModel viewModel = CreateViewModel(purchase.Object, getAddOn.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        Task purchaseTask = viewModel.PurchaseChromaKeyAddOnCommand.ExecuteAsync(null);
+
+        viewModel.IsPurchasingChromaKeyAddOn.Should().BeTrue();
+        viewModel.CanPurchaseChromaKeyAddOn.Should().BeFalse();
+        viewModel.ChromaKeyAddOnPurchaseButtonText.Should().BeEmpty();
+        viewModel.PurchaseChromaKeyAddOnCommand.CanExecute(null).Should().BeFalse();
+        purchase.Verify(
+            useCase => useCase.ExecuteAsync(
+                It.IsAny<PurchaseChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        purchaseCompletion.SetResult(CreatePurchaseResponse(false));
+        await purchaseTask;
+        viewModel.IsPurchasingChromaKeyAddOn.Should().BeFalse();
+        viewModel.ChromaKeyAddOnPurchaseButtonText.Should().Be("$4.99");
+    }
+
+    [TestMethod]
+    public async Task PurchaseChromaKeyAddOnCommand_WhenRetrySucceeds_ClearsFailureAndOwnsAddOn()
+    {
+        var purchase = new Mock<IPurchaseChromaKeyAddOnUseCase>();
+        purchase
+            .SetupSequence(useCase => useCase.ExecuteAsync(
+                It.IsAny<PurchaseChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreatePurchaseResponse(false))
+            .ReturnsAsync(CreatePurchaseResponse(true));
+        var getAddOn = new Mock<IGetChromaKeyAddOnUseCase>();
+        getAddOn
+            .SetupSequence(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGetResponse(CreateAddOn(false, "$4.99")))
+            .ReturnsAsync(CreateGetResponse(null));
+        StorePageViewModel viewModel = CreateViewModel(purchase.Object, getAddOn.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        await viewModel.PurchaseChromaKeyAddOnCommand.ExecuteAsync(null);
+
+        viewModel.HasChromaKeyAddOnPurchaseFailure.Should().BeTrue();
+        viewModel.CanPurchaseChromaKeyAddOn.Should().BeTrue();
+
+        await viewModel.PurchaseChromaKeyAddOnCommand.ExecuteAsync(null);
+
+        viewModel.HasChromaKeyAddOnPurchaseFailure.Should().BeFalse();
+        viewModel.IsChromaKeyAddOnOwned.Should().BeTrue();
+        viewModel.CanPurchaseChromaKeyAddOn.Should().BeFalse();
+        purchase.Verify(
+            useCase => useCase.ExecuteAsync(
+                It.IsAny<PurchaseChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task PurchaseChromaKeyAddOnCommand_WhenCanceled_ShowsRetryableFailure()
+    {
+        var purchase = new Mock<IPurchaseChromaKeyAddOnUseCase>();
+        purchase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<PurchaseChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<PurchaseChromaKeyAddOnResponse>.Cancelled());
+        var getAddOn = CreateGetAddOnUseCase(CreateAddOn(false, "$4.99"));
+        StorePageViewModel viewModel = CreateViewModel(purchase.Object, getAddOn.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        await viewModel.PurchaseChromaKeyAddOnCommand.ExecuteAsync(null);
+
+        viewModel.HasChromaKeyAddOnPurchaseFailure.Should().BeTrue();
+        viewModel.IsPurchasingChromaKeyAddOn.Should().BeFalse();
+        viewModel.CanPurchaseChromaKeyAddOn.Should().BeTrue();
+    }
+
+    private static StorePageViewModel CreateViewModel(
+        IPurchaseChromaKeyAddOnUseCase purchase,
+        IGetChromaKeyAddOnUseCase getAddOn)
+    {
+        var localization = new Mock<ILocalizationService>();
+        localization
+            .Setup(service => service.GetString(It.IsAny<string>()))
+            .Returns<string>(key => key switch
+            {
+                "AddOns_ItemUnknown" => "Unknown",
+                "AddOns_ItemNotAvailable" => "Unavailable",
+                "AddOns_ItemOwned" => "Owned",
+                _ => key
+            });
+        var cancellation = new Mock<ICancellationService>();
+        cancellation
+            .Setup(service => service.GetLinkedCancellationTokenSource(
+                It.IsAny<CancellationToken?>()))
+            .Returns<CancellationToken?>(token =>
+                CancellationTokenSource.CreateLinkedTokenSource(token ?? CancellationToken.None));
+        return new StorePageViewModel(
+            Mock.Of<ILeaveStorePageUseCase>(),
+            purchase,
+            getAddOn,
+            localization.Object,
+            cancellation.Object);
+    }
+
+    private static Mock<IGetChromaKeyAddOnUseCase> CreateGetAddOnUseCase(IStoreAddOn addOn)
+    {
+        var getAddOn = new Mock<IGetChromaKeyAddOnUseCase>();
+        getAddOn
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetChromaKeyAddOnRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateGetResponse(addOn));
+        return getAddOn;
+    }
+
+    private static IStoreAddOn CreateAddOn(bool isOwned, string price)
+    {
+        return Mock.Of<IStoreAddOn>(addOn =>
+            addOn.IsOwned == isOwned &&
+            addOn.Price == price);
+    }
+
+    private static UseCaseResponse<GetChromaKeyAddOnResponse> CreateGetResponse(IStoreAddOn? addOn)
+        => UseCaseResponse<GetChromaKeyAddOnResponse>.Success(new(addOn));
+
+    private static UseCaseResponse<PurchaseChromaKeyAddOnResponse> CreatePurchaseResponse(bool purchased)
+        => UseCaseResponse<PurchaseChromaKeyAddOnResponse>.Success(new(purchased));
+
+    public TestContext TestContext { get; set; } = null!;
+}


### PR DESCRIPTION
## Summary

- move the Chroma Key add-on purchase flow into `StorePageViewModel`
- disable duplicate purchase attempts and show an in-button purchase progress state
- refresh product and entitlement state after confirmed or already-owned outcomes
- keep confirmed ownership authoritative during delayed Store propagation
- show bounded, retryable feedback for failed or canceled attempts
- document the ARCH-22 behavior and add focused Store-page regression tests

## Root cause

The Store page bound its purchase button directly to `PurchaseChromaKeyAddOnUseCase`. The response was discarded, while ownership, price, logo, and availability were populated only during initial page loading. Successful and already-purchased outcomes therefore left stale unowned UI until the page was reopened.

## Impact

After purchase confirmation, the page immediately shows the add-on as owned and disables further purchase attempts. Failed or canceled attempts leave the product available for retry and show a generic message without exposing Store details.

## Validation

- 750 tests passed across all seven non-UI test projects
- 202 CaptureTool.Presentation tests passed, including 4 new Store purchase-state tests
- CaptureTool.Presentation.Windows.WinUI built for x64 Debug with 0 warnings and 0 errors
- formatting and analyzer verification passed for all affected projects

Fixes #427.
