### PR TITLE
[ARCH-20] Coalesce Home recent-capture refreshes

### DIFF
--- a/docs/prd-425-coalesce-home-recent-capture-refresh.md
+++ b/docs/prd-425-coalesce-home-recent-capture-refresh.md
@@ -1,0 +1,77 @@
+# PRD: Coalesce Home recent-capture refresh notifications
+
+- Issue: [#425](https://github.com/shanebweaver/CaptureTool/issues/425)
+- Architecture finding: `ARCH-20`
+- Severity: Low
+- Status: Implemented
+- Affected features: `APP-03`, `APP-06`
+
+## Summary
+
+Home must not lose a recent-capture invalidation that arrives while its recent-captures query is already running. Refresh requests that overlap an active initial load, refresh, or load-more query will mark the collection dirty. The active loader will drain that pending invalidation with a reset query before it exits.
+
+Multiple invalidations during one query are coalesced into one follow-up query. If another invalidation arrives during the follow-up query, the loader runs again so the final collection represents the newest catalog state it was notified about.
+
+## Problem
+
+Capture-state and catalog-change events fire-and-forget `RefreshRecentCapturesAsync`. `LoadRecentCapturesPageAsync` currently returns immediately whenever `IsLoadingRecentCaptures` is true.
+
+If the active query took its catalog snapshot before a new capture was recorded, a notification arriving before that query completes is discarded. The stale response then replaces the Home collection, and the new capture remains invisible until navigation or another catalog event causes a later refresh.
+
+The same race can occur while Home is appending a load-more page: a catalog invalidation is ignored because the pagination query owns the loading flag.
+
+## Goals
+
+1. Preserve refresh invalidations received during any recent-captures query.
+2. Rerun a reset query after the active query completes.
+3. Coalesce repeated invalidations during one query into a single follow-up request.
+4. Continue draining when an invalidation arrives during the follow-up request.
+5. Keep pagination, loading indicators, command availability, and cancellation behavior intact.
+6. Avoid concurrent mutations of the observable collection.
+
+## Non-goals
+
+- Do not change recent-capture catalog ordering or pagination contracts.
+- Do not make capture/catalog event handlers await refresh completion.
+- Do not add polling or debounce delays.
+- Do not redesign the notifier or capture-state event sources.
+- Do not preserve intermediate catalog snapshots when a newer reset response supersedes them.
+
+## Functional requirements
+
+### Pending refresh state
+
+- When a reset request arrives during an active load, set a pending-refresh flag instead of discarding the request.
+- A blocked load-more request remains a no-op because load-more commands are already disabled while loading.
+- Keep one loader responsible for collection mutation at a time.
+
+### Drain loop
+
+- After each completed query, inspect and clear the pending-refresh flag.
+- If the flag was set, issue another query with `Skip = 0`, clear the displayed collection, and rebuild it from that response.
+- Keep the loading state active until no pending refresh remains.
+- Allow an invalidation during the follow-up query to request another pass.
+- Preserve the caller's cancellation token across the drain loop.
+
+## Reliability requirements
+
+- A notification between query start and completion must be reflected before the active load task completes.
+- Multiple notifications during the same query must not create concurrent or redundant queries.
+- A refresh queued during load-more must replace the paged collection with a fresh first page.
+- Existing query failure behavior remains bounded by the use-case response contract and the loader's `finally` state cleanup.
+
+## Test plan
+
+- Start Home loading with a controlled in-flight first-page query.
+- Raise multiple catalog notifications before completing that query.
+- Return a stale first response and a newer follow-up response; verify only the newer collection remains and exactly two queries run.
+- Start a load-more query, notify while it is active, then verify a reset query runs after pagination and replaces the collection.
+- Run all non-UI tests and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] A notification during an initial or refresh query cannot be lost.
+- [x] A notification during load-more triggers a subsequent reset query.
+- [x] Repeated overlapping notifications coalesce without concurrent collection mutation.
+- [x] Home finishes with the latest notified catalog snapshot.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Presentation/Features/Home/HomePageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/Home/HomePageViewModel.cs
@@ -36,6 +36,7 @@ public sealed partial class HomePageViewModel : AsyncLoadableViewModelBase
     private readonly IRecentCapturesChangeNotifier _recentCapturesChangeNotifier;
     private readonly IFactoryServiceWithArgs<RecentCaptureViewModel, string> _recentCaptureViewModelFactory;
     private readonly ObservableCollection<RecentCaptureViewModel> _recentCaptures = [];
+    private bool _recentCapturesRefreshPending;
 
     public event EventHandler? StoreReviewPromptRequested;
 
@@ -281,7 +282,17 @@ public sealed partial class HomePageViewModel : AsyncLoadableViewModelBase
 
     private async Task LoadRecentCapturesPageAsync(bool reset, CancellationToken cancellationToken)
     {
-        if (IsLoadingRecentCaptures || (!reset && !HasMoreRecentCaptures))
+        if (IsLoadingRecentCaptures)
+        {
+            if (reset)
+            {
+                _recentCapturesRefreshPending = true;
+            }
+
+            return;
+        }
+
+        if (!reset && !HasMoreRecentCaptures)
         {
             return;
         }
@@ -290,25 +301,32 @@ public sealed partial class HomePageViewModel : AsyncLoadableViewModelBase
 
         try
         {
-            if (reset)
+            bool shouldReset = reset;
+            do
             {
-                _recentCaptures.Clear();
-                HasMoreRecentCaptures = true;
-                RaiseRecentCaptureStateChanged();
+                _recentCapturesRefreshPending = false;
+                if (shouldReset)
+                {
+                    _recentCaptures.Clear();
+                    HasMoreRecentCaptures = true;
+                    RaiseRecentCaptureStateChanged();
+                }
+
+                var response = await _getRecentCapturesQuery.ExecuteAsync(
+                    new GetRecentCapturesRequest(_recentCaptures.Count, RecentCapturesPageSize),
+                    cancellationToken);
+
+                var recentCaptures = response.Value?.Captures ?? [];
+                foreach (var recentCapture in recentCaptures)
+                {
+                    _recentCaptures.Add(_recentCaptureViewModelFactory.Create(recentCapture.FilePath));
+                }
+
+                HasMoreRecentCaptures = response.Value?.HasMore == true;
+                HasLoadedRecentCaptures = true;
+                shouldReset = _recentCapturesRefreshPending;
             }
-
-            var response = await _getRecentCapturesQuery.ExecuteAsync(
-                new GetRecentCapturesRequest(_recentCaptures.Count, RecentCapturesPageSize),
-                cancellationToken);
-
-            var recentCaptures = response.Value?.Captures ?? [];
-            foreach (var recentCapture in recentCaptures)
-            {
-                _recentCaptures.Add(_recentCaptureViewModelFactory.Create(recentCapture.FilePath));
-            }
-
-            HasMoreRecentCaptures = response.Value?.HasMore == true;
-            HasLoadedRecentCaptures = true;
+            while (shouldReset);
         }
         finally
         {

--- a/tests/CaptureTool.Presentation.Tests/Features/ViewModelContractTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ViewModelContractTests.cs
@@ -164,6 +164,106 @@ public sealed class ViewModelContractTests
     }
 
     [TestMethod]
+    public async Task HomePageViewModel_RecentCapturesChangedDuringRefresh_ShouldCoalesceAndRerun()
+    {
+        var notifier = new Mock<IRecentCapturesChangeNotifier>();
+        var getRecentCapturesUseCase = new Mock<IGetRecentCapturesUseCase>();
+        var firstQueryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstQueryCompletion = new TaskCompletionSource<UseCaseResponse<GetRecentCapturesResponse>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var staleCapture = new RecentCapture(@"C:\Temp\stale.png", "stale.png", CaptureFileType.Image);
+        var currentCapture = new RecentCapture(@"C:\Temp\current.png", "current.png", CaptureFileType.Image);
+        int queryCount = 0;
+        getRecentCapturesUseCase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetRecentCapturesRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                queryCount++;
+                if (queryCount == 1)
+                {
+                    firstQueryStarted.SetResult();
+                    return firstQueryCompletion.Task;
+                }
+
+                return Task.FromResult(UseCaseResponse<GetRecentCapturesResponse>.Success(
+                    new GetRecentCapturesResponse([currentCapture])));
+            });
+        var viewModel = CreateHomePageViewModel(
+            getRecentCapturesUseCase: getRecentCapturesUseCase.Object,
+            recentCapturesChangeNotifier: notifier.Object);
+
+        Task loadTask = viewModel.LoadAsync(TestContext.CancellationToken);
+        await firstQueryStarted.Task;
+        notifier.Raise(source => source.RecentCapturesChanged += null, EventArgs.Empty);
+        notifier.Raise(source => source.RecentCapturesChanged += null, EventArgs.Empty);
+        firstQueryCompletion.SetResult(UseCaseResponse<GetRecentCapturesResponse>.Success(
+            new GetRecentCapturesResponse([staleCapture])));
+        await loadTask;
+
+        Assert.AreEqual(2, queryCount);
+        Assert.HasCount(1, viewModel.RecentCaptures);
+        Assert.AreEqual(currentCapture.FilePath, viewModel.RecentCaptures[0].FilePath);
+    }
+
+    [TestMethod]
+    public async Task HomePageViewModel_RecentCapturesChangedDuringLoadMore_ShouldRerunFromFirstPage()
+    {
+        var notifier = new Mock<IRecentCapturesChangeNotifier>();
+        var getRecentCapturesUseCase = new Mock<IGetRecentCapturesUseCase>();
+        var loadMoreStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var loadMoreCompletion = new TaskCompletionSource<UseCaseResponse<GetRecentCapturesResponse>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        RecentCapture[] firstPage = Enumerable.Range(0, 24)
+            .Select(index => new RecentCapture(
+                $@"C:\Temp\capture-{index}.png",
+                $"capture-{index}.png",
+                CaptureFileType.Image))
+            .ToArray();
+        var pagedCapture = new RecentCapture(@"C:\Temp\paged.png", "paged.png", CaptureFileType.Image);
+        var refreshedCapture = new RecentCapture(@"C:\Temp\refreshed.png", "refreshed.png", CaptureFileType.Image);
+        int queryCount = 0;
+        getRecentCapturesUseCase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetRecentCapturesRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                queryCount++;
+                return queryCount switch
+                {
+                    1 => Task.FromResult(UseCaseResponse<GetRecentCapturesResponse>.Success(
+                        new GetRecentCapturesResponse(firstPage, HasMore: true))),
+                    2 => StartLoadMoreQuery(),
+                    _ => Task.FromResult(UseCaseResponse<GetRecentCapturesResponse>.Success(
+                        new GetRecentCapturesResponse([refreshedCapture]))),
+                };
+            });
+        var viewModel = CreateHomePageViewModel(
+            getRecentCapturesUseCase: getRecentCapturesUseCase.Object,
+            recentCapturesChangeNotifier: notifier.Object);
+        await viewModel.LoadAsync(TestContext.CancellationToken);
+
+        Task loadMoreTask = viewModel.LoadMoreRecentCapturesCommand.ExecuteAsync(null);
+        await loadMoreStarted.Task;
+        notifier.Raise(source => source.RecentCapturesChanged += null, EventArgs.Empty);
+        loadMoreCompletion.SetResult(UseCaseResponse<GetRecentCapturesResponse>.Success(
+            new GetRecentCapturesResponse([pagedCapture])));
+        await loadMoreTask;
+
+        Assert.AreEqual(3, queryCount);
+        Assert.HasCount(1, viewModel.RecentCaptures);
+        Assert.AreEqual(refreshedCapture.FilePath, viewModel.RecentCaptures[0].FilePath);
+
+        Task<UseCaseResponse<GetRecentCapturesResponse>> StartLoadMoreQuery()
+        {
+            loadMoreStarted.SetResult();
+            return loadMoreCompletion.Task;
+        }
+    }
+
+    [TestMethod]
     public async Task HomePageViewModel_ClearRecentCapturesCommand_ShouldClearCatalogAndRefresh()
     {
         var clearRecentCapturesUseCase = new Mock<IClearRecentCapturesUseCase>();


### PR DESCRIPTION
## Summary

- add the ARCH-20 PRD for Home recent-capture refresh coalescing
- retain reset invalidations that arrive while an initial, refresh, or load-more query is active
- let the active loader drain pending invalidations with a serialized first-page refresh before leaving the loading state
- coalesce repeated notifications during one query while allowing notifications during a rerun to request another pass
- add deterministic concurrency regressions for refresh and load-more races

## Why

Home's capture-state and catalog events fire-and-forget a recent-captures refresh. `LoadRecentCapturesPageAsync` previously returned immediately whenever another query owned `IsLoadingRecentCaptures`, without recording that the catalog had changed. If the active query took its snapshot before the change, its stale response became the displayed collection and the new capture remained hidden until a later event or navigation.

Reset requests received during loading now mark the collection dirty. The active loader keeps ownership of collection mutation and reruns from `Skip = 0` until no pending invalidation remains. This also covers notifications that arrive during load-more without introducing concurrent observable-collection updates.

Fixes #425.

## User impact

New, removed, or otherwise changed recent captures now appear on Home even when the notification overlaps an existing query. Duplicate notifications are coalesced instead of starting redundant concurrent loads.

## Validation

- all seven non-UI test projects, Release/x64: 748 passed, 0 failed
- `dotnet build src\CaptureTool.Presentation.Windows.WinUI\CaptureTool.Presentation.Windows.WinUI.csproj --configuration Debug -p:Platform=x64 -m:1 -p:BuildInParallel=false --no-restore`: succeeded with 0 warnings and 0 errors
