### PR TITLE
Fix diagnostics view-model lifecycle and log dispatch

### DIFF
--- a/docs/prd-424-diagnostics-view-model-lifecycle.md
+++ b/docs/prd-424-diagnostics-view-model-lifecycle.md
@@ -1,0 +1,75 @@
+# PRD: Bound diagnostics log rendering to the view lifetime
+
+- Issue: [#424](https://github.com/shanebweaver/CaptureTool/issues/424)
+- Architecture finding: `ARCH-19`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `PLT-07`
+
+## Summary
+
+The diagnostics view model must receive live log updates only while its view is active, apply those updates on the UI task environment, and retain a bounded amount of rendered log text. Closing diagnostics deterministically removes its singleton log-service subscription through the existing view-unload disposal path.
+
+## Problem
+
+`DiagnosticsViewModel` subscribes to the singleton `ILogService` in its constructor and removes the handler only from a finalizer. The event subscription itself holds the view model alive, so the finalizer cannot run and every diagnostics instance remains subscribed after its view closes.
+
+The log service raises `LogAdded` synchronously on the thread that produced the log. The handler directly changes the UI-bound `Logs` property, allowing background capture or finalization work to raise property changes off the UI thread. Each update also concatenates onto an unbounded string for as long as a leaked instance remains alive.
+
+## Goals
+
+1. Remove the live-log subscription deterministically when diagnostics closes.
+2. Marshal live log rendering through `ITaskEnvironment`.
+3. Prevent callbacks queued before disposal from changing disposed view-model state.
+4. Bound displayed history to the newest 1,000 entries, matching the short-term log service limit.
+5. Preserve logging enablement, clear, and export behavior.
+
+## Non-goals
+
+- Do not change the log service's retention period or persistence behavior.
+- Do not redesign diagnostics as a virtualized item collection.
+- Do not alter the formatting or export format of log entries.
+- Do not keep diagnostics subscribed while its view is unloaded.
+
+## Functional requirements
+
+### Deterministic lifetime
+
+- `DiagnosticsViewModel.Dispose` removes the `LogAdded` handler exactly once.
+- The existing `ViewBase.OnUnloaded` call to `ViewModel.Dispose` owns diagnostics cleanup.
+- Disposal remains safe when called more than once.
+- A live log callback that was queued before disposal becomes a no-op after disposal.
+
+### UI-thread delivery
+
+- A `LogAdded` notification requests execution through `ITaskEnvironment`.
+- The `Logs` property changes only inside the dispatched action.
+- A notification received after disposal does not request UI work.
+
+### Bounded rendering
+
+- Initial and live history retain at most the newest 1,000 rendered entries.
+- When the limit is exceeded, the oldest displayed entries are removed first.
+- Clearing logs also clears the view model's bounded rendered history.
+
+## Reliability requirements
+
+- The singleton log service must not retain diagnostics view models after their views unload.
+- Background log producers must not directly raise `Logs` property changes.
+- Disposal races must not restore or append text to a closed diagnostics surface.
+- If the platform task environment rejects dispatch, the notification is dropped without an off-thread fallback.
+
+## Test plan
+
+- Raise a live log notification and verify text remains unchanged until the task-environment action executes.
+- Queue a notification, dispose twice, and verify the subscription is removed once and queued or later updates are ignored.
+- Raise more than 1,000 notifications and verify only the newest 1,000 are rendered.
+- Run all non-UI tests and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] Closing diagnostics deterministically unsubscribes its view model.
+- [x] Live log updates are applied through the UI task environment.
+- [x] Disposed diagnostics instances ignore queued and future log updates.
+- [x] Rendered log history remains bounded to the newest 1,000 entries.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.

--- a/src/CaptureTool.Presentation/Features/Diagnostics/DiagnosticsViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/Diagnostics/DiagnosticsViewModel.cs
@@ -4,6 +4,7 @@ using CaptureTool.Application.Abstractions.Diagnostics.GetCurrentLogs;
 using CaptureTool.Application.Abstractions.Diagnostics.GetIsLoggingEnabled;
 using CaptureTool.Application.Abstractions.Diagnostics.UpdateLoggingState;
 using CaptureTool.Application.Abstractions.Logging;
+using CaptureTool.Application.Abstractions.TaskEnvironment;
 using CaptureTool.Application.Abstractions.Telemetry;
 using CaptureTool.Application.Abstractions.UseCases;
 using CaptureTool.Presentation.ViewModels;
@@ -13,13 +14,18 @@ namespace CaptureTool.Presentation.Features.Diagnostics;
 
 public sealed partial class DiagnosticsViewModel : ViewModelBase
 {
+    private const int MaxRenderedLogEntries = 1000;
+
     private readonly IClearLogsUseCase _clearLogsCommand;
     private readonly IExportLogsUseCase _exportLogsCommand;
     private readonly IUpdateLoggingStateUseCase _updateLoggingStateCommand;
     private readonly IGetIsLoggingEnabledUseCase _getIsLoggingEnabledQuery;
     private readonly IGetCurrentLogsUseCase _getCurrentLogsQuery;
     private readonly ILogService _logService;
+    private readonly ITaskEnvironment _taskEnvironment;
     private readonly ITelemetryService? _telemetryService;
+    private readonly Queue<string> _renderedLogs = [];
+    private int _isDisposed;
 
     public IAsyncRelayCommand ClearLogsCommand { get; }
     public IAsyncRelayCommand ExportLogsCommand { get; }
@@ -44,6 +50,7 @@ public sealed partial class DiagnosticsViewModel : ViewModelBase
         IGetIsLoggingEnabledUseCase getIsLoggingEnabledQuery,
         IGetCurrentLogsUseCase getCurrentLogsQuery,
         ILogService logService,
+        ITaskEnvironment taskEnvironment,
         ITelemetryService? telemetryService = null)
     {
         _clearLogsCommand = clearLogsCommand;
@@ -52,6 +59,7 @@ public sealed partial class DiagnosticsViewModel : ViewModelBase
         _getIsLoggingEnabledQuery = getIsLoggingEnabledQuery;
         _getCurrentLogsQuery = getCurrentLogsQuery;
         _telemetryService = telemetryService;
+        _taskEnvironment = taskEnvironment;
 
         _logService = logService;
         _logService.LogAdded += OnLogAdded;
@@ -68,17 +76,67 @@ public sealed partial class DiagnosticsViewModel : ViewModelBase
     private async Task InitializeAsync()
     {
         IsLoggingEnabled = (await _getIsLoggingEnabledQuery.ExecuteAsync(new GetIsLoggingEnabledRequest(), CancellationToken.None)).Value?.IsEnabled == true;
-        Logs = string.Join(Environment.NewLine, ((await _getCurrentLogsQuery.ExecuteAsync(new GetCurrentLogsRequest(), CancellationToken.None)).Value?.Logs ?? []).Select(log => log.ToString()));
+        SetRenderedLogs((await _getCurrentLogsQuery.ExecuteAsync(new GetCurrentLogsRequest(), CancellationToken.None)).Value?.Logs ?? []);
     }
 
-    ~DiagnosticsViewModel()
+    public override void Dispose()
     {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+        {
+            return;
+        }
+
         _logService.LogAdded -= OnLogAdded;
+        base.Dispose();
     }
 
     private void OnLogAdded(object? sender, ILogEntry e)
     {
-        Logs += e.ToString() + Environment.NewLine;
+        if (Volatile.Read(ref _isDisposed) != 0)
+        {
+            return;
+        }
+
+        string renderedLog = e.ToString() ?? string.Empty;
+        _taskEnvironment.TryExecute(() =>
+        {
+            if (Volatile.Read(ref _isDisposed) == 0)
+            {
+                AppendRenderedLog(renderedLog);
+            }
+        });
+    }
+
+    private void SetRenderedLogs(IEnumerable<ILogEntry> logs)
+    {
+        _renderedLogs.Clear();
+        foreach (ILogEntry log in logs)
+        {
+            _renderedLogs.Enqueue(log.ToString() ?? string.Empty);
+            TrimRenderedLogs();
+        }
+
+        UpdateRenderedLogText();
+    }
+
+    private void AppendRenderedLog(string renderedLog)
+    {
+        _renderedLogs.Enqueue(renderedLog);
+        TrimRenderedLogs();
+        UpdateRenderedLogText();
+    }
+
+    private void TrimRenderedLogs()
+    {
+        while (_renderedLogs.Count > MaxRenderedLogEntries)
+        {
+            _renderedLogs.Dequeue();
+        }
+    }
+
+    private void UpdateRenderedLogText()
+    {
+        Logs = string.Join(Environment.NewLine, _renderedLogs);
     }
 
     private async Task UpdateLoggingEnablementAsync(bool newValue)
@@ -95,7 +153,8 @@ public sealed partial class DiagnosticsViewModel : ViewModelBase
 
     private async Task ClearLogsAsync()
     {
-        Logs = string.Empty;
+        _renderedLogs.Clear();
+        UpdateRenderedLogText();
         var response = await _clearLogsCommand.ExecuteAsync(new ClearLogsRequest(), CancellationToken.None);
         TrackDiagnosticsAction("clear_logs", response?.Result ?? UseCaseResult.Failed);
     }

--- a/tests/CaptureTool.Presentation.Tests/Features/DiagnosticsViewModelTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/DiagnosticsViewModelTests.cs
@@ -1,0 +1,136 @@
+using CaptureTool.Application.Abstractions.Diagnostics.ClearLogs;
+using CaptureTool.Application.Abstractions.Diagnostics.ExportLogs;
+using CaptureTool.Application.Abstractions.Diagnostics.GetCurrentLogs;
+using CaptureTool.Application.Abstractions.Diagnostics.GetIsLoggingEnabled;
+using CaptureTool.Application.Abstractions.Diagnostics.UpdateLoggingState;
+using CaptureTool.Application.Abstractions.Logging;
+using CaptureTool.Application.Abstractions.TaskEnvironment;
+using CaptureTool.Application.Abstractions.UseCases;
+using CaptureTool.Presentation.Features.Diagnostics;
+using FluentAssertions;
+using Moq;
+
+namespace CaptureTool.Presentation.Tests.Features;
+
+[TestClass]
+public sealed class DiagnosticsViewModelTests
+{
+    [TestMethod]
+    public void LogAdded_ShouldMarshalRenderedTextThroughTaskEnvironment()
+    {
+        var logService = new Mock<ILogService>();
+        var taskEnvironment = new Mock<ITaskEnvironment>();
+        Action? dispatchedAction = null;
+        taskEnvironment
+            .Setup(environment => environment.TryExecute(It.IsAny<Action>()))
+            .Callback<Action>(action => dispatchedAction = action)
+            .Returns(true);
+        DiagnosticsViewModel viewModel = CreateViewModel(logService, taskEnvironment);
+
+        logService.Raise(
+            service => service.LogAdded += null,
+            logService.Object,
+            new TestLogEntry("background log"));
+
+        viewModel.Logs.Should().BeEmpty();
+        dispatchedAction.Should().NotBeNull();
+
+        dispatchedAction!();
+
+        viewModel.Logs.Should().Be("background log");
+        viewModel.Dispose();
+    }
+
+    [TestMethod]
+    public void Dispose_ShouldUnsubscribeAndIgnoreQueuedLogUpdates()
+    {
+        var logService = new Mock<ILogService>();
+        var taskEnvironment = new Mock<ITaskEnvironment>();
+        Action? dispatchedAction = null;
+        taskEnvironment
+            .Setup(environment => environment.TryExecute(It.IsAny<Action>()))
+            .Callback<Action>(action => dispatchedAction = action)
+            .Returns(true);
+        DiagnosticsViewModel viewModel = CreateViewModel(logService, taskEnvironment);
+        logService.Raise(
+            service => service.LogAdded += null,
+            logService.Object,
+            new TestLogEntry("queued log"));
+
+        viewModel.Dispose();
+        viewModel.Dispose();
+        dispatchedAction!();
+        logService.Raise(
+            service => service.LogAdded += null,
+            logService.Object,
+            new TestLogEntry("late log"));
+
+        viewModel.Logs.Should().BeEmpty();
+        taskEnvironment.Verify(
+            environment => environment.TryExecute(It.IsAny<Action>()),
+            Times.Once);
+        logService.VerifyRemove(
+            service => service.LogAdded -= It.IsAny<EventHandler<ILogEntry>>(),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public void LogAdded_WhenRenderedHistoryIsFull_ShouldRetainNewestEntries()
+    {
+        var logService = new Mock<ILogService>();
+        var taskEnvironment = new Mock<ITaskEnvironment>();
+        taskEnvironment
+            .Setup(environment => environment.TryExecute(It.IsAny<Action>()))
+            .Callback<Action>(action => action())
+            .Returns(true);
+        DiagnosticsViewModel viewModel = CreateViewModel(logService, taskEnvironment);
+
+        for (int index = 0; index < 1005; index++)
+        {
+            logService.Raise(
+                service => service.LogAdded += null,
+                logService.Object,
+                new TestLogEntry($"log-{index}"));
+        }
+
+        string[] renderedLogs = viewModel.Logs.Split(Environment.NewLine);
+        renderedLogs.Should().HaveCount(1000);
+        renderedLogs[0].Should().Be("log-5");
+        renderedLogs[^1].Should().Be("log-1004");
+        viewModel.Dispose();
+    }
+
+    private static DiagnosticsViewModel CreateViewModel(
+        Mock<ILogService> logService,
+        Mock<ITaskEnvironment> taskEnvironment)
+    {
+        var getIsLoggingEnabledUseCase = new Mock<IGetIsLoggingEnabledUseCase>();
+        getIsLoggingEnabledUseCase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetIsLoggingEnabledRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<GetIsLoggingEnabledResponse>.Success(new(false)));
+        var getCurrentLogsUseCase = new Mock<IGetCurrentLogsUseCase>();
+        getCurrentLogsUseCase
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<GetCurrentLogsRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<GetCurrentLogsResponse>.Success(new([])));
+
+        return new DiagnosticsViewModel(
+            Mock.Of<IClearLogsUseCase>(),
+            Mock.Of<IExportLogsUseCase>(),
+            Mock.Of<IUpdateLoggingStateUseCase>(),
+            getIsLoggingEnabledUseCase.Object,
+            getCurrentLogsUseCase.Object,
+            logService.Object,
+            taskEnvironment.Object);
+    }
+
+    private sealed class TestLogEntry(string message) : ILogEntry
+    {
+        public string Message => message;
+        public DateTime Timestamp => DateTime.UtcNow;
+        public override string ToString() => Message;
+    }
+}


### PR DESCRIPTION
## What

- add the ARCH-19 PRD for diagnostics lifecycle and threading behavior
- deterministically unsubscribe `DiagnosticsViewModel` when its view unloads
- dispatch live log rendering through `ITaskEnvironment`
- retain only the newest 1,000 rendered log entries
- cover dispatch, disposal races, unsubscription, and bounded history with regression tests

## Why

`DiagnosticsViewModel` subscribed to the singleton log service but relied on a finalizer to unsubscribe. The subscription kept each closed view model alive, so reopened diagnostics surfaces leaked and continued processing logs. Log events also updated the UI-bound `Logs` property synchronously on whichever thread produced the entry, and the rendered string grew without limit.

The existing WinUI `ViewBase` already disposes view models on unload. This change makes that lifecycle deterministic inside diagnostics, marshals producer-thread events to the UI task environment, ignores queued callbacks after disposal, and bounds rendered history.

## Impact

Closed diagnostics surfaces no longer remain subscribed or accumulate text. Background capture and finalization logs no longer mutate diagnostics bindings off the dispatcher thread. The visible log history remains capped while clear, export, and logging enablement behavior stay unchanged.

## Checks

- 755 non-UI tests passed in Release x64
- `CaptureTool.Presentation.Windows.WinUI` built in Debug x64 with 0 warnings and 0 errors
- focused `DiagnosticsViewModelTests`: 3 passed

Closes #424
