### PR TITLE
Represent mixed-DPI capture metadata

### DIFF
--- a/docs/prd-428-mixed-dpi-mcp-capture-metadata.md
+++ b/docs/prd-428-mixed-dpi-mcp-capture-metadata.md
@@ -1,0 +1,95 @@
+# PRD: Mixed-DPI MCP Capture Metadata
+
+- Issue: [#428](https://github.com/shanebweaver/CaptureTool/issues/428)
+- Architecture finding: `ARCH-23`
+- Severity: Medium
+- Status: Implemented
+- Affected features: `MCP-03`, `MCP-04`
+
+## Summary
+
+MCP captures that combine pixels from multiple monitors must not present one monitor's DPI and scale as if those scalar values described the entire image. Mixed-DPI results will expose nullable scalar DPI/scale values, an explicit uniformity indicator, and a per-monitor segment map relating virtual-screen source coordinates to image coordinates.
+
+## Problem
+
+All-screens capture currently selects the primary monitor as a metadata reference. A spanning region selects the monitor with the largest intersection. Both then publish that monitor's DPI and scale for a composite PNG, even when another part of the image came from a monitor with different scaling.
+
+The scalar metadata appears authoritative, so an MCP client can apply the wrong conversion when locating or annotating content on another monitor. The response also omits the segment geometry needed to determine which scale applies to a given image coordinate.
+
+## Goals
+
+1. Preserve scalar DPI and scale for single-monitor and uniform-DPI captures.
+2. Return null scalar DPI and scale for mixed-DPI composite captures.
+3. Expose whether scalar DPI/scale is uniform across the image.
+4. Include every contributing monitor's source bounds, image bounds, DPI, scale, ID, and primary status.
+5. Preserve the segment map when creating an annotated derivative.
+6. Keep existing capture IDs, image bytes, coordinate spaces, and uniform-capture behavior compatible.
+
+## Non-goals
+
+- Resampling monitor pixels into a single logical-DPI coordinate system.
+- Changing Windows monitor enumeration or bitmap-combination behavior.
+- Changing window-capture DPI semantics, which are outside the two composite capture paths identified by ARCH-23.
+- Adding monitor names or persistent monitor identifiers.
+
+## Metadata contract
+
+### Uniform capture
+
+- `dpi` and `scale` contain the common values.
+- `isDpiScaleUniform` is `true`.
+- All-screens output includes `monitorSegments`; a single-monitor region continues using its existing monitor fields.
+
+### Mixed-DPI capture
+
+- `dpi` and `scale` are `null`.
+- `isDpiScaleUniform` is `false`.
+- `monitorSegments` contains one entry for every monitor intersecting the captured source bounds.
+
+Each segment includes:
+
+- `monitorId`: process-local `hmonitor:<value>` identifier;
+- `sourceBounds`: the contributing rectangle in virtual-screen coordinates;
+- `imageBounds`: the same pixels translated into returned-image coordinates;
+- `dpi` and `scale`: values for that monitor;
+- `isPrimary`: whether the monitor is primary.
+
+## Coordinate requirements
+
+1. Segment source bounds are clipped to the capture source rectangle.
+2. Segment image bounds use the capture source rectangle's top-left as image origin.
+3. Negative virtual-screen coordinates translate to non-negative image coordinates.
+4. Monitor ordering follows the capture service's monitor enumeration order.
+5. Desktop gaps are not represented as monitor segments.
+
+## Reliability and compatibility
+
+- Empty monitor sets continue to fail explicitly.
+- A requested region that intersects no monitor continues to fail explicitly.
+- Uniform composites no longer depend on which monitor is primary; their common DPI is used.
+- Existing clients reading scalar values continue to receive them for uniform output.
+- Clients must use the segment map when `isDpiScaleUniform` is false.
+
+## Test plan
+
+Add tests for:
+
+- uniform all-screens capture preserving scalar DPI/scale and publishing all segments;
+- mixed-DPI all-screens capture nulling scalars and translating negative monitor coordinates;
+- mixed-DPI spanning region clipping source segments and mapping them into image coordinates;
+- annotated mixed-DPI captures preserving the source segment map.
+
+Run all non-UI test projects and build the WinUI x64 Debug project.
+
+## Acceptance criteria
+
+- [x] Mixed-DPI composite captures do not publish a single authoritative DPI or scale.
+- [x] Uniform composite captures retain scalar DPI and scale.
+- [x] Per-monitor segments map source and image bounds with monitor DPI and scale.
+- [x] Annotated derivatives preserve mixed-DPI metadata.
+- [x] Regression coverage exercises mixed-DPI all-screens and spanning-region paths.
+- [x] Existing non-UI tests pass and the WinUI x64 Debug project builds.
+
+## Rollout
+
+No migration or feature flag is required. The structured metadata change is additive except that mixed-DPI composite scalar values become nullable instead of misleading reference-monitor values.

--- a/src/CaptureTool.Mcp.CaptureServer/Annotations/AnnotationService.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Annotations/AnnotationService.cs
@@ -67,7 +67,8 @@ public sealed class AnnotationService : IAnnotationService
             sourceCapture.Metadata.WorkAreaBounds?.ToRectangle(),
             sourceCapture.Metadata.IsPrimary,
             sourceCaptureId: sourceCapture.Metadata.CaptureId,
-            annotationPlacements: annotationDrawables.Placements);
+            annotationPlacements: annotationDrawables.Placements,
+            monitorSegments: sourceCapture.Metadata.MonitorSegments);
 
         var annotatedCapture = new McpCapture(outputStream.ToArray(), metadata);
         _captureStore.Store(annotatedCapture);

--- a/src/CaptureTool.Mcp.CaptureServer/Capture/AllScreensCaptureService.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Capture/AllScreensCaptureService.cs
@@ -28,27 +28,23 @@ public sealed class AllScreensCaptureService : IAllScreensCaptureService
             throw new InvalidOperationException("No monitors are available to capture.");
         }
 
-        MonitorCaptureResult referenceMonitor = monitors.FirstOrDefault(monitor => monitor.IsPrimary);
-        if (!referenceMonitor.IsPrimary)
-        {
-            referenceMonitor = monitors[0];
-        }
-
         using var bitmap = _screenCapture.CombineMonitors(monitors);
         using var stream = new MemoryStream();
         bitmap.Save(stream, ImageFormat.Png);
 
         Rectangle sourceBounds = CaptureTargetSelection.CombineBounds(monitors.Select(monitor => monitor.MonitorBounds));
+        CaptureDisplayMetadata displayMetadata = CaptureDisplayMetadata.Create(monitors, sourceBounds);
         var metadata = McpCaptureMetadata.Create(
             McpCaptureIds.Create(),
             _timeProvider.GetUtcNow(),
             bitmap.Width,
             bitmap.Height,
-            referenceMonitor.Dpi,
-            referenceMonitor.Scale,
+            displayMetadata.Dpi,
+            displayMetadata.Scale,
             sourceBounds,
             "allScreens",
-            "png");
+            "png",
+            monitorSegments: displayMetadata.MonitorSegments);
 
         var capture = new McpCapture(stream.ToArray(), metadata);
         _captureStore.Store(capture);

--- a/src/CaptureTool.Mcp.CaptureServer/Capture/CaptureDisplayMetadata.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Capture/CaptureDisplayMetadata.cs
@@ -1,0 +1,46 @@
+using CaptureTool.Domain.Capture;
+using CaptureTool.Mcp.CaptureServer.Models;
+using System.Drawing;
+
+namespace CaptureTool.Mcp.CaptureServer.Capture;
+
+internal sealed record CaptureDisplayMetadata(
+    uint? Dpi,
+    float? Scale,
+    MonitorSegmentDto[] MonitorSegments)
+{
+    public static CaptureDisplayMetadata Create(
+        IReadOnlyList<MonitorCaptureResult> monitors,
+        Rectangle captureSourceBounds)
+    {
+        MonitorSegmentDto[] segments =
+        [
+            .. monitors
+                .Select(monitor => (Monitor: monitor, Intersection: Rectangle.Intersect(monitor.MonitorBounds, captureSourceBounds)))
+                .Where(item => item.Intersection.Width > 0 && item.Intersection.Height > 0)
+                .Select(item => new MonitorSegmentDto(
+                    $"hmonitor:{item.Monitor.HMonitor}",
+                    RectangleDto.FromRectangle(item.Intersection),
+                    RectangleDto.FromRectangle(new Rectangle(
+                        item.Intersection.X - captureSourceBounds.X,
+                        item.Intersection.Y - captureSourceBounds.Y,
+                        item.Intersection.Width,
+                        item.Intersection.Height)),
+                    item.Monitor.Dpi,
+                    item.Monitor.Scale,
+                    item.Monitor.IsPrimary)),
+        ];
+
+        if (segments.Length == 0)
+        {
+            throw new InvalidOperationException("Capture bounds do not intersect an available monitor.");
+        }
+
+        uint firstDpi = segments[0].Dpi;
+        bool isUniform = segments.All(segment => segment.Dpi == firstDpi);
+        return new CaptureDisplayMetadata(
+            isUniform ? firstDpi : null,
+            isUniform ? firstDpi / 96f : null,
+            segments);
+    }
+}

--- a/src/CaptureTool.Mcp.CaptureServer/Capture/RegionCaptureService.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Capture/RegionCaptureService.cs
@@ -42,10 +42,6 @@ public sealed class RegionCaptureService : IRegionCaptureService
             throw new InvalidOperationException("The requested capture region does not intersect any monitor.");
         }
 
-        MonitorCaptureResult referenceMonitor = monitors
-            .OrderByDescending(monitor => Rectangle.Intersect(monitor.MonitorBounds, region).Width * Rectangle.Intersect(monitor.MonitorBounds, region).Height)
-            .First();
-
         MonitorCaptureResult? containingMonitor = monitors
             .Cast<MonitorCaptureResult?>()
             .FirstOrDefault(monitor => monitor!.Value.MonitorBounds.Contains(region));
@@ -71,17 +67,24 @@ public sealed class RegionCaptureService : IRegionCaptureService
         }
 
         using Bitmap regionBitmap = CaptureSpanningRegionBitmap(region, monitors);
-        return StoreRegionCapture(regionBitmap, region, referenceMonitor.Dpi, referenceMonitor.Scale);
+        CaptureDisplayMetadata displayMetadata = CaptureDisplayMetadata.Create(monitors, region);
+        return StoreRegionCapture(
+            regionBitmap,
+            region,
+            displayMetadata.Dpi,
+            displayMetadata.Scale,
+            monitorSegments: displayMetadata.MonitorSegments);
     }
 
     private McpCapture StoreRegionCapture(
         Bitmap regionBitmap,
         Rectangle sourceBounds,
-        uint dpi,
-        float scale,
+        uint? dpi,
+        float? scale,
         Rectangle? monitorBounds = null,
         Rectangle? workAreaBounds = null,
-        bool? isPrimary = null)
+        bool? isPrimary = null,
+        MonitorSegmentDto[]? monitorSegments = null)
     {
         using var stream = new MemoryStream();
         regionBitmap.Save(stream, ImageFormat.Png);
@@ -98,7 +101,8 @@ public sealed class RegionCaptureService : IRegionCaptureService
             "png",
             monitorBounds,
             workAreaBounds,
-            isPrimary);
+            isPrimary,
+            monitorSegments: monitorSegments);
 
         var capture = new McpCapture(stream.ToArray(), metadata);
         _captureStore.Store(capture);

--- a/src/CaptureTool.Mcp.CaptureServer/Models/GeometryDtos.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Models/GeometryDtos.cs
@@ -11,3 +11,11 @@ public sealed record RectangleDto(int X, int Y, int Width, int Height)
 }
 
 public sealed record PointDto(int X, int Y);
+
+public sealed record MonitorSegmentDto(
+    string MonitorId,
+    RectangleDto SourceBounds,
+    RectangleDto ImageBounds,
+    uint Dpi,
+    float Scale,
+    bool IsPrimary);

--- a/src/CaptureTool.Mcp.CaptureServer/Models/McpCaptureJsonSerializerContext.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Models/McpCaptureJsonSerializerContext.cs
@@ -5,5 +5,6 @@ namespace CaptureTool.Mcp.CaptureServer.Models;
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(McpCaptureMetadata))]
 [JsonSerializable(typeof(AnnotationPlacementDto[]))]
+[JsonSerializable(typeof(MonitorSegmentDto[]))]
 [JsonSerializable(typeof(ListWindowsResult))]
 internal sealed partial class McpCaptureJsonSerializerContext : JsonSerializerContext;

--- a/src/CaptureTool.Mcp.CaptureServer/Models/McpCaptureMetadata.cs
+++ b/src/CaptureTool.Mcp.CaptureServer/Models/McpCaptureMetadata.cs
@@ -7,8 +7,8 @@ public sealed record McpCaptureMetadata(
     DateTimeOffset CapturedAtUtc,
     int Width,
     int Height,
-    uint Dpi,
-    float Scale,
+    uint? Dpi,
+    float? Scale,
     RectangleDto SourceBounds,
     RectangleDto ImageBounds,
     string SourceKind,
@@ -19,15 +19,18 @@ public sealed record McpCaptureMetadata(
     string? TargetId = null,
     string? TargetTitle = null,
     string? SourceCaptureId = null,
-    AnnotationPlacementDto[]? AnnotationPlacements = null)
+    AnnotationPlacementDto[]? AnnotationPlacements = null,
+    MonitorSegmentDto[]? MonitorSegments = null)
 {
+    public bool IsDpiScaleUniform => Dpi.HasValue && Scale.HasValue;
+
     public static McpCaptureMetadata Create(
         string captureId,
         DateTimeOffset capturedAtUtc,
         int width,
         int height,
-        uint dpi,
-        float scale,
+        uint? dpi,
+        float? scale,
         Rectangle sourceBounds,
         string sourceKind,
         string format,
@@ -37,7 +40,8 @@ public sealed record McpCaptureMetadata(
         string? targetId = null,
         string? targetTitle = null,
         string? sourceCaptureId = null,
-        AnnotationPlacementDto[]? annotationPlacements = null)
+        AnnotationPlacementDto[]? annotationPlacements = null,
+        MonitorSegmentDto[]? monitorSegments = null)
         => new(
             captureId,
             capturedAtUtc,
@@ -55,5 +59,6 @@ public sealed record McpCaptureMetadata(
             targetId,
             targetTitle,
             sourceCaptureId,
-            annotationPlacements);
+            annotationPlacements,
+            monitorSegments);
 }

--- a/tests/CaptureTool.Mcp.CaptureServer.Tests/AllScreensCaptureServiceTests.cs
+++ b/tests/CaptureTool.Mcp.CaptureServer.Tests/AllScreensCaptureServiceTests.cs
@@ -31,10 +31,42 @@ public sealed class AllScreensCaptureServiceTests
         capture.Metadata.SourceBounds.Should().Be(new RectangleDto(0, 0, 150, 80));
         capture.Metadata.Width.Should().Be(150);
         capture.Metadata.Height.Should().Be(80);
+        capture.Metadata.Dpi.Should().Be(96);
+        capture.Metadata.Scale.Should().Be(1);
+        capture.Metadata.IsDpiScaleUniform.Should().BeTrue();
+        capture.Metadata.MonitorSegments.Should().BeEquivalentTo([
+            new MonitorSegmentDto("hmonitor:1", new RectangleDto(0, 0, 100, 80), new RectangleDto(0, 0, 100, 80), 96, 1, true),
+            new MonitorSegmentDto("hmonitor:2", new RectangleDto(100, 0, 50, 80), new RectangleDto(100, 0, 50, 80), 96, 1, false),
+        ], options => options.WithStrictOrdering());
         captureStore.TryGet(capture.Metadata.CaptureId, out McpCapture storedCapture).Should().BeTrue();
         storedCapture.Should().BeSameAs(capture);
     }
 
-    private static MonitorCaptureResult CreateMonitor(Rectangle bounds, bool isPrimary)
-        => new(isPrimary ? 1 : 2, [], 96, bounds, bounds, isPrimary);
+    [TestMethod]
+    public void Capture_WithMixedDpi_OmitsScalarDpiAndMapsEachMonitor()
+    {
+        MonitorCaptureResult primary = CreateMonitor(new Rectangle(0, 0, 100, 80), isPrimary: true, dpi: 96);
+        MonitorCaptureResult secondary = CreateMonitor(new Rectangle(-50, 0, 50, 80), isPrimary: false, dpi: 144);
+        using var combined = new Bitmap(150, 80);
+        var screenCapture = new Mock<IScreenCapture>();
+        screenCapture.Setup(service => service.CaptureAllMonitors()).Returns([primary, secondary]);
+        screenCapture.Setup(service => service.CombineMonitors(It.IsAny<IList<MonitorCaptureResult>>())).Returns(combined);
+        var captureService = new AllScreensCaptureService(
+            screenCapture.Object,
+            new InMemoryMcpCaptureStore(),
+            new ManualTimeProvider(CaptureTime));
+
+        McpCapture capture = captureService.Capture();
+
+        capture.Metadata.Dpi.Should().BeNull();
+        capture.Metadata.Scale.Should().BeNull();
+        capture.Metadata.IsDpiScaleUniform.Should().BeFalse();
+        capture.Metadata.MonitorSegments.Should().BeEquivalentTo([
+            new MonitorSegmentDto("hmonitor:1", new RectangleDto(0, 0, 100, 80), new RectangleDto(50, 0, 100, 80), 96, 1, true),
+            new MonitorSegmentDto("hmonitor:2", new RectangleDto(-50, 0, 50, 80), new RectangleDto(0, 0, 50, 80), 144, 1.5f, false),
+        ], options => options.WithStrictOrdering());
+    }
+
+    private static MonitorCaptureResult CreateMonitor(Rectangle bounds, bool isPrimary, uint dpi = 96)
+        => new(isPrimary ? 1 : 2, [], dpi, bounds, bounds, isPrimary);
 }

--- a/tests/CaptureTool.Mcp.CaptureServer.Tests/AllScreensCaptureToolTests.cs
+++ b/tests/CaptureTool.Mcp.CaptureServer.Tests/AllScreensCaptureToolTests.cs
@@ -1,0 +1,54 @@
+using CaptureTool.Mcp.CaptureServer.Abstractions;
+using CaptureTool.Mcp.CaptureServer.Models;
+using CaptureTool.Mcp.CaptureServer.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Drawing;
+using System.Text.Json;
+
+namespace CaptureTool.Mcp.CaptureServer.Tests;
+
+[TestClass]
+public sealed class AllScreensCaptureToolTests
+{
+    [TestMethod]
+    public void CaptureAllScreens_WithMixedDpi_ReturnsNonUniformStructuredMetadata()
+    {
+        MonitorSegmentDto[] segments =
+        [
+            new("hmonitor:1", new RectangleDto(0, 0, 100, 80), new RectangleDto(0, 0, 100, 80), 96, 1, true),
+            new("hmonitor:2", new RectangleDto(100, 0, 100, 80), new RectangleDto(100, 0, 100, 80), 144, 1.5f, false),
+        ];
+        McpCaptureMetadata metadata = McpCaptureMetadata.Create(
+            "capture:mixed",
+            new DateTimeOffset(2026, 8, 6, 12, 0, 0, TimeSpan.Zero),
+            200,
+            80,
+            dpi: null,
+            scale: null,
+            new Rectangle(0, 0, 200, 80),
+            "allScreens",
+            "png",
+            monitorSegments: segments);
+        var captureService = new Mock<IAllScreensCaptureService>();
+        captureService
+            .Setup(service => service.Capture())
+            .Returns(new McpCapture([0x89, 0x50, 0x4E, 0x47], metadata));
+
+        var result = AllScreensCaptureTool.CaptureAllScreens(
+            captureService.Object,
+            Mock.Of<ILogger<AllScreensCaptureTool>>(),
+            "mixed DPI test");
+
+        result.IsError.Should().BeFalse();
+        JsonElement structuredContent = result.StructuredContent!.Value;
+        structuredContent.GetProperty("dpi").ValueKind.Should().Be(JsonValueKind.Null);
+        structuredContent.GetProperty("scale").ValueKind.Should().Be(JsonValueKind.Null);
+        structuredContent.GetProperty("isDpiScaleUniform").GetBoolean().Should().BeFalse();
+        JsonElement monitorSegments = structuredContent.GetProperty("monitorSegments");
+        monitorSegments.GetArrayLength().Should().Be(2);
+        monitorSegments[1].GetProperty("imageBounds").GetProperty("x").GetInt32().Should().Be(100);
+        monitorSegments[1].GetProperty("dpi").GetUInt32().Should().Be(144);
+    }
+}

--- a/tests/CaptureTool.Mcp.CaptureServer.Tests/AnnotationServiceTests.cs
+++ b/tests/CaptureTool.Mcp.CaptureServer.Tests/AnnotationServiceTests.cs
@@ -43,7 +43,26 @@ public sealed class AnnotationServiceTests
         annotated.PngBytes.Should().StartWith([0x89, 0x50, 0x4E, 0x47]);
     }
 
-    private static McpCapture CreateStoredCapture(string captureId, Size size)
+    [TestMethod]
+    public void AnnotateWithArrow_PreservesMixedDpiMonitorSegments()
+    {
+        var captureStore = new InMemoryMcpCaptureStore();
+        McpCapture sourceCapture = CreateStoredCapture("capture:mixed", new Size(300, 200), mixedDpi: true);
+        captureStore.Store(sourceCapture);
+        var annotationService = new AnnotationService(
+            captureStore,
+            new AnnotationDrawableFactory(),
+            new ManualTimeProvider(AnnotationTime));
+
+        McpCapture annotated = annotationService.AnnotateWithArrow("capture:mixed", 20, 30, 220, 150, null);
+
+        annotated.Metadata.Dpi.Should().BeNull();
+        annotated.Metadata.Scale.Should().BeNull();
+        annotated.Metadata.IsDpiScaleUniform.Should().BeFalse();
+        annotated.Metadata.MonitorSegments.Should().BeEquivalentTo(sourceCapture.Metadata.MonitorSegments);
+    }
+
+    private static McpCapture CreateStoredCapture(string captureId, Size size, bool mixedDpi = false)
     {
         using var bitmap = new Bitmap(size.Width, size.Height);
         using Graphics graphics = Graphics.FromImage(bitmap);
@@ -51,16 +70,23 @@ public sealed class AnnotationServiceTests
         using var stream = new MemoryStream();
         bitmap.Save(stream, ImageFormat.Png);
 
+        MonitorSegmentDto[]? monitorSegments = mixedDpi
+            ? [
+                new("hmonitor:1", new RectangleDto(0, 0, 150, 200), new RectangleDto(0, 0, 150, 200), 96, 1, true),
+                new("hmonitor:2", new RectangleDto(150, 0, 150, 200), new RectangleDto(150, 0, 150, 200), 144, 1.5f, false),
+            ]
+            : null;
         var metadata = McpCaptureMetadata.Create(
             captureId,
             AnnotationTime,
             size.Width,
             size.Height,
-            dpi: 96,
-            scale: 1,
+            dpi: mixedDpi ? null : 96,
+            scale: mixedDpi ? null : 1,
             new Rectangle(Point.Empty, size),
             "region",
-            "png");
+            "png",
+            monitorSegments: monitorSegments);
 
         return new McpCapture(stream.ToArray(), metadata);
     }

--- a/tests/CaptureTool.Mcp.CaptureServer.Tests/RegionCaptureServiceTests.cs
+++ b/tests/CaptureTool.Mcp.CaptureServer.Tests/RegionCaptureServiceTests.cs
@@ -56,6 +56,36 @@ public sealed class RegionCaptureServiceTests
             .WithMessage("The requested capture region does not intersect any monitor.");
     }
 
-    private static MonitorCaptureResult CreateMonitor(Rectangle bounds)
-        => new(1, [], 96, bounds, bounds, true);
+    [TestMethod]
+    public void Capture_WhenRegionSpansMixedDpiMonitors_MapsSegmentsWithoutScalarDpi()
+    {
+        MonitorCaptureResult primary = CreateMonitor(new Rectangle(0, 0, 100, 80), hMonitor: 1, dpi: 96, isPrimary: true);
+        MonitorCaptureResult secondary = CreateMonitor(new Rectangle(100, 0, 100, 80), hMonitor: 2, dpi: 144);
+        using var combined = new Bitmap(200, 80);
+        var screenCapture = new Mock<IScreenCapture>();
+        screenCapture.Setup(service => service.CaptureAllMonitors()).Returns([primary, secondary]);
+        screenCapture.Setup(service => service.CombineMonitors(It.IsAny<IList<MonitorCaptureResult>>())).Returns(combined);
+        var captureService = new RegionCaptureService(
+            screenCapture.Object,
+            new InMemoryMcpCaptureStore(),
+            new ManualTimeProvider(CaptureTime));
+
+        McpCapture capture = captureService.Capture(50, 10, 100, 50);
+
+        capture.Metadata.Dpi.Should().BeNull();
+        capture.Metadata.Scale.Should().BeNull();
+        capture.Metadata.IsDpiScaleUniform.Should().BeFalse();
+        capture.Metadata.MonitorBounds.Should().BeNull();
+        capture.Metadata.MonitorSegments.Should().BeEquivalentTo([
+            new MonitorSegmentDto("hmonitor:1", new RectangleDto(50, 10, 50, 50), new RectangleDto(0, 0, 50, 50), 96, 1, true),
+            new MonitorSegmentDto("hmonitor:2", new RectangleDto(100, 10, 50, 50), new RectangleDto(50, 0, 50, 50), 144, 1.5f, false),
+        ], options => options.WithStrictOrdering());
+    }
+
+    private static MonitorCaptureResult CreateMonitor(
+        Rectangle bounds,
+        nint hMonitor = 1,
+        uint dpi = 96,
+        bool isPrimary = false)
+        => new(hMonitor, [], dpi, bounds, bounds, isPrimary);
 }


### PR DESCRIPTION
## Summary
- make MCP capture DPI and scale nullable for non-uniform composite images
- add an explicit uniformity flag and per-monitor source-to-image segment map
- populate segments for all-screens and spanning-region captures, including negative virtual coordinates
- preserve mixed-DPI segment metadata in annotated derivatives
- document the contract and add service plus structured-JSON regressions

## Why
All-screens capture published the primary monitor's DPI/scale for the whole virtual desktop, while spanning regions published the largest-intersection monitor's values. On mixed-DPI desktops those scalars looked authoritative but described only part of the returned image.

## Impact
Uniform captures retain their existing scalar DPI and scale. Mixed-DPI composites now return null scalars, `isDpiScaleUniform: false`, and a `monitorSegments` map with source bounds, image bounds, DPI, scale, monitor ID, and primary status.

## Validation
- 750 non-UI tests passed
- x64 Debug WinUI build succeeded with 0 warnings and 0 errors
- branch is current with `main`

Closes #428
