### PR TITLE
Add QR code actions to text extraction

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.2.3" />
     <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageVersion Include="ZXing.Net" Version="0.16.11" />
     <!-- Test packages -->
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="FlaUI.UIA3" Version="5.0.0" />

--- a/src/CaptureTool.Application.Abstractions/Edit/Image/TextExtraction/RecognizedQrCodeRegion.cs
+++ b/src/CaptureTool.Application.Abstractions/Edit/Image/TextExtraction/RecognizedQrCodeRegion.cs
@@ -1,0 +1,7 @@
+using System.Drawing;
+
+namespace CaptureTool.Application.Abstractions.Edit.Image.TextExtraction;
+
+public sealed record RecognizedQrCodeRegion(
+    string Value,
+    RectangleF Bounds);

--- a/src/CaptureTool.Application.Abstractions/Edit/Image/TextExtraction/RecognizedTextDocument.cs
+++ b/src/CaptureTool.Application.Abstractions/Edit/Image/TextExtraction/RecognizedTextDocument.cs
@@ -2,8 +2,26 @@ using System.Drawing;
 
 namespace CaptureTool.Application.Abstractions.Edit.Image.TextExtraction;
 
-public sealed record RecognizedTextDocument(
-    string Text,
-    Size ImageSize,
-    IReadOnlyList<RecognizedTextRegion> Regions);
+public sealed record RecognizedTextDocument
+{
+    public RecognizedTextDocument(
+        string text,
+        Size imageSize,
+        IReadOnlyList<RecognizedTextRegion> regions,
+        IReadOnlyList<RecognizedQrCodeRegion>? qrCodes = null)
+    {
+        Text = text;
+        ImageSize = imageSize;
+        Regions = regions;
+        QrCodes = qrCodes ?? [];
+    }
+
+    public string Text { get; }
+
+    public Size ImageSize { get; }
+
+    public IReadOnlyList<RecognizedTextRegion> Regions { get; }
+
+    public IReadOnlyList<RecognizedQrCodeRegion> QrCodes { get; }
+}
 

--- a/src/CaptureTool.Infrastructure.Edit.Windows/CaptureTool.Infrastructure.Edit.Windows.csproj
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/CaptureTool.Infrastructure.Edit.Windows.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.WindowsAppSDK.AI" />
     <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="ZXing.Net" />
   </ItemGroup>
 
   <!-- Project references -->

--- a/src/CaptureTool.Infrastructure.Edit.Windows/QrCodeDetector.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/QrCodeDetector.cs
@@ -1,0 +1,107 @@
+using CaptureTool.Application.Abstractions.Edit.Image.TextExtraction;
+using System.Drawing;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
+using ZXing;
+using ZXing.Common;
+
+namespace CaptureTool.Infrastructure.Edit.Windows;
+
+internal static class QrCodeDetector
+{
+    internal static bool ShouldExcludeText(
+        RectangleF textBounds,
+        IReadOnlyList<RecognizedQrCodeRegion> qrCodes)
+    {
+        if (textBounds.Width <= 0 || textBounds.Height <= 0)
+        {
+            return false;
+        }
+
+        PointF textCenter = new(
+            textBounds.Left + (textBounds.Width / 2),
+            textBounds.Top + (textBounds.Height / 2));
+        foreach (RecognizedQrCodeRegion qrCode in qrCodes)
+        {
+            RectangleF exclusionBounds = qrCode.Bounds;
+            float padding = Math.Clamp(
+                Math.Min(exclusionBounds.Width, exclusionBounds.Height) * 0.04f,
+                2,
+                10);
+            exclusionBounds.Inflate(padding, padding);
+            if (exclusionBounds.Contains(textCenter))
+            {
+                return true;
+            }
+
+            RectangleF overlap = RectangleF.Intersect(textBounds, exclusionBounds);
+            if (overlap.Width * overlap.Height >= textBounds.Width * textBounds.Height * 0.35f)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static IReadOnlyList<RecognizedQrCodeRegion> Detect(SoftwareBitmap bitmap)
+    {
+        int byteCount = checked(bitmap.PixelWidth * bitmap.PixelHeight * 4);
+        var buffer = new global::Windows.Storage.Streams.Buffer((uint)byteCount);
+        bitmap.CopyToBuffer(buffer);
+        byte[] pixels = new byte[byteCount];
+        using DataReader dataReader = DataReader.FromBuffer(buffer);
+        dataReader.ReadBytes(pixels);
+
+        return Detect(pixels, bitmap.PixelWidth, bitmap.PixelHeight);
+    }
+
+    internal static IReadOnlyList<RecognizedQrCodeRegion> Detect(byte[] bgraPixels, int width, int height)
+    {
+        var source = new RGBLuminanceSource(
+            bgraPixels,
+            width,
+            height,
+            RGBLuminanceSource.BitmapFormat.BGRA32);
+        var reader = new BarcodeReaderGeneric
+        {
+            AutoRotate = true,
+            Options = new DecodingOptions
+            {
+                PossibleFormats = [BarcodeFormat.QR_CODE],
+                TryHarder = true,
+                TryInverted = true
+            }
+        };
+
+        Result[] results = reader.DecodeMultiple(source) ?? [];
+        return results
+            .Where(result => !string.IsNullOrWhiteSpace(result.Text))
+            .Select(result => new RecognizedQrCodeRegion(result.Text, GetBounds(result.ResultPoints)))
+            .Where(region => region.Bounds.Width > 0 && region.Bounds.Height > 0)
+            .GroupBy(region => (region.Value, region.Bounds))
+            .Select(group => group.First())
+            .ToArray();
+    }
+
+    private static RectangleF GetBounds(ResultPoint[]? points)
+    {
+        if (points is null || points.Length == 0)
+        {
+            return RectangleF.Empty;
+        }
+
+        float left = points.Min(point => point.X);
+        float top = points.Min(point => point.Y);
+        float right = points.Max(point => point.X);
+        float bottom = points.Max(point => point.Y);
+        RectangleF bounds = RectangleF.FromLTRB(left, top, right, bottom);
+        float padding = Math.Max(bounds.Width, bounds.Height) * 0.12f;
+        bounds.Inflate(padding, padding);
+        return RectangleF.FromLTRB(
+            Math.Max(0, bounds.Left),
+            Math.Max(0, bounds.Top),
+            bounds.Right,
+            bounds.Bottom);
+    }
+}

--- a/src/CaptureTool.Infrastructure.Edit.Windows/WindowsTextExtractionService.cs
+++ b/src/CaptureTool.Infrastructure.Edit.Windows/WindowsTextExtractionService.cs
@@ -53,25 +53,43 @@ public sealed class WindowsTextExtractionService : ITextExtractionService
             OcrResult ocrResult = await engine.RecognizeAsync(sourceBitmap);
             cancellationToken.ThrowIfCancellationRequested();
 
+            IReadOnlyList<RecognizedQrCodeRegion> qrCodes = QrCodeDetector.Detect(sourceBitmap);
+            cancellationToken.ThrowIfCancellationRequested();
+
             List<RecognizedTextRegion> regions = [];
+            List<string> recognizedLines = [];
             for (int lineIndex = 0; lineIndex < ocrResult.Lines.Count; lineIndex++)
             {
                 OcrLine line = ocrResult.Lines[lineIndex];
+                List<string> recognizedWords = [];
                 for (int wordIndex = 0; wordIndex < line.Words.Count; wordIndex++)
                 {
                     OcrWord word = line.Words[wordIndex];
                     RectangleF bounds = ToRectangleF(word.BoundingRect);
-                    if (!string.IsNullOrWhiteSpace(word.Text) && bounds.Width > 0 && bounds.Height > 0)
+                    if (!string.IsNullOrWhiteSpace(word.Text) &&
+                        bounds.Width > 0 &&
+                        bounds.Height > 0 &&
+                        !QrCodeDetector.ShouldExcludeText(bounds, qrCodes))
                     {
                         regions.Add(new RecognizedTextRegion(word.Text, bounds, lineIndex, wordIndex));
+                        recognizedWords.Add(word.Text);
                     }
+                }
+
+                if (recognizedWords.Count > 0)
+                {
+                    recognizedLines.Add(string.Join(' ', recognizedWords));
                 }
             }
 
+            string documentText = CombineRecognizedValues(
+                string.Join(Environment.NewLine, recognizedLines),
+                qrCodes);
             return TextExtractionResult.Success(new RecognizedTextDocument(
-                ocrResult.Text ?? string.Empty,
+                documentText,
                 request.SourceSize,
-                regions));
+                regions,
+                qrCodes));
         }
         catch (OperationCanceledException)
         {
@@ -102,6 +120,19 @@ public sealed class WindowsTextExtractionService : ITextExtractionService
             (float)rect.Y,
             (float)rect.Width,
             (float)rect.Height);
+    }
+
+    private static string CombineRecognizedValues(
+        string? recognizedText,
+        IReadOnlyList<RecognizedQrCodeRegion> qrCodes)
+    {
+        IEnumerable<string> values = qrCodes.Select(qrCode => qrCode.Value);
+        if (!string.IsNullOrWhiteSpace(recognizedText))
+        {
+            values = values.Prepend(recognizedText.TrimEnd());
+        }
+
+        return string.Join(Environment.NewLine, values);
     }
 }
 

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/ImageCanvas.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/ImageCanvas.xaml
@@ -94,6 +94,12 @@
                         Visibility="Collapsed" />
                 </Grid>
 
+                <Canvas
+                    x:Name="QrCodeOverlayCanvas"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Visibility="Collapsed" />
+
                 <!--  Preview Shape Overlay  -->
                 <Canvas
                     x:Name="PreviewShapeCanvas"

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/ImageCanvas.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/ImageCanvas.xaml.cs
@@ -142,6 +142,7 @@ public sealed partial class ImageCanvas : UserControlBase
         if (d is ImageCanvas control)
         {
             control.UpdateTextExtractionOverlayPath();
+            control.UpdateQrCodeOverlay();
             control.UpdateTouchInputLock();
         }
     }
@@ -207,6 +208,22 @@ public sealed partial class ImageCanvas : UserControlBase
             control.RebuildTextExtractionLayout();
             control.UpdateTextExtractionOverlayPath();
             control.UpdateTouchInputLock();
+        }
+    }
+
+    public static readonly DependencyProperty TextExtractionQrCodesProperty = DependencyProperty.Register(
+        nameof(TextExtractionQrCodes),
+        typeof(IReadOnlyList<RecognizedQrCodeRegion>),
+        typeof(ImageCanvas),
+        new PropertyMetadata(Array.Empty<RecognizedQrCodeRegion>(), OnTextExtractionQrCodesPropertyChanged));
+
+    private static void OnTextExtractionQrCodesPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is ImageCanvas control)
+        {
+            control.InvalidateTextExtractionOverlayGeometry();
+            control.UpdateTextExtractionOverlayPath();
+            control.UpdateQrCodeOverlay();
         }
     }
 
@@ -447,6 +464,12 @@ public sealed partial class ImageCanvas : UserControlBase
     {
         get => Get<IReadOnlyList<RecognizedTextRegion>>(TextExtractionRegionsProperty) ?? [];
         set => Set(TextExtractionRegionsProperty, value);
+    }
+
+    public IReadOnlyList<RecognizedQrCodeRegion> TextExtractionQrCodes
+    {
+        get => Get<IReadOnlyList<RecognizedQrCodeRegion>>(TextExtractionQrCodesProperty) ?? [];
+        set => Set(TextExtractionQrCodesProperty, value);
     }
 
     public string SelectedExtractedText => _textExtractionSelection.Text;
@@ -962,6 +985,7 @@ public sealed partial class ImageCanvas : UserControlBase
             RenderCanvas.Width = width;
             RenderCanvas.Height = height;
             UpdateTextExtractionOverlayPath();
+            UpdateQrCodeOverlay();
             RenderCanvas.Invalidate();
         }
     }
@@ -1106,7 +1130,7 @@ public sealed partial class ImageCanvas : UserControlBase
             return;
         }
 
-        if (_textExtractionLayout.CutoutContours.Count == 0 ||
+        if ((_textExtractionLayout.CutoutContours.Count == 0 && TextExtractionQrCodes.Count == 0) ||
             CanvasContainer.Width <= 0 ||
             CanvasContainer.Height <= 0)
         {
@@ -1274,7 +1298,7 @@ public sealed partial class ImageCanvas : UserControlBase
             _textExtractionOverlayGeometryHeight != height)
         {
             _textExtractionOverlayGeometry = CreateTextPathGeometry(
-                _textExtractionLayout.CutoutContours,
+                GetTextExtractionCutoutContours(),
                 width,
                 height,
                 includeOuterBounds: true);
@@ -1283,6 +1307,178 @@ public sealed partial class ImageCanvas : UserControlBase
         }
 
         return _textExtractionOverlayGeometry;
+    }
+
+    private IReadOnlyList<IReadOnlyList<PointF>> GetTextExtractionCutoutContours()
+    {
+        List<IReadOnlyList<PointF>> contours = [.. _textExtractionLayout.CutoutContours];
+        foreach (RecognizedQrCodeRegion qrCode in TextExtractionQrCodes)
+        {
+            RectangleF bounds = qrCode.Bounds;
+            float padding = Math.Clamp(Math.Min(bounds.Width, bounds.Height) * 0.03f, 3, 12);
+            bounds.Inflate(padding, padding);
+            contours.Add([
+                new PointF(bounds.Left, bounds.Top),
+                new PointF(bounds.Right, bounds.Top),
+                new PointF(bounds.Right, bounds.Bottom),
+                new PointF(bounds.Left, bounds.Bottom)
+            ]);
+        }
+
+        return contours;
+    }
+
+    private void InvalidateTextExtractionOverlayGeometry()
+    {
+        _textExtractionOverlayGeometry = null;
+        _textExtractionOverlayGeometryWidth = 0;
+        _textExtractionOverlayGeometryHeight = 0;
+    }
+
+    private void UpdateQrCodeOverlay()
+    {
+        QrCodeOverlayCanvas.Children.Clear();
+        if (!IsTextExtractionOverlayEnabled ||
+            TextExtractionQrCodes.Count == 0 ||
+            CanvasContainer.Width <= 0 ||
+            CanvasContainer.Height <= 0)
+        {
+            QrCodeOverlayCanvas.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        for (int index = 0; index < TextExtractionQrCodes.Count; index++)
+        {
+            AddQrCodeVisual(TextExtractionQrCodes[index], index);
+        }
+
+        QrCodeOverlayCanvas.Visibility = QrCodeOverlayCanvas.Children.Count > 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private void AddQrCodeVisual(RecognizedQrCodeRegion qrCode, int index)
+    {
+        RectangleF bounds = RectangleF.Intersect(
+            new RectangleF(0, 0, (float)CanvasContainer.Width, (float)CanvasContainer.Height),
+            qrCode.Bounds);
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+        {
+            return;
+        }
+
+        var actions = new StackPanel
+        {
+            Orientation = Microsoft.UI.Xaml.Controls.Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 6
+        };
+        actions.Children.Add(CreateQrCodeActionButton(
+            "\uE8C8",
+            "Copy QR code value",
+            $"ImageCanvas_QrCodeCopyButton_{index}",
+            () => CopyQrCodeValueAsync(qrCode.Value)));
+
+        if (TryGetWebUri(qrCode.Value, out Uri? uri))
+        {
+            actions.Children.Add(CreateQrCodeActionButton(
+                "\uE8A7",
+                "Open QR code link",
+                $"ImageCanvas_QrCodeOpenButton_{index}",
+                async () =>
+                {
+                    _ = await Launcher.LaunchUriAsync(uri);
+                }));
+        }
+
+        var actionSurface = new Border
+        {
+            Padding = new Thickness(7),
+            Background = new SolidColorBrush(WinUIColor.FromArgb(220, 24, 24, 27)),
+            BorderBrush = new SolidColorBrush(WinUIColor.FromArgb(180, 255, 255, 255)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(10),
+            Child = actions
+        };
+
+        var visual = new Border
+        {
+            Width = bounds.Width,
+            Height = bounds.Height,
+            BorderBrush = (Microsoft.UI.Xaml.Media.Brush)global::Microsoft.UI.Xaml.Application.Current.Resources["AccentFillColorDefaultBrush"],
+            BorderThickness = new Thickness(3),
+            CornerRadius = new CornerRadius(6),
+            Child = actionSurface
+        };
+        AutomationProperties.SetName(visual, $"QR code: {qrCode.Value}");
+        AutomationProperties.SetAutomationId(visual, $"ImageCanvas_QrCodeOverlay_{index}");
+        Canvas.SetLeft(visual, bounds.Left);
+        Canvas.SetTop(visual, bounds.Top);
+        QrCodeOverlayCanvas.Children.Add(visual);
+    }
+
+    private static Button CreateQrCodeActionButton(
+        string glyph,
+        string accessibleName,
+        string automationId,
+        Func<Task> action)
+    {
+        var button = new Button
+        {
+            Width = 42,
+            Height = 42,
+            Padding = new Thickness(0),
+            CornerRadius = new CornerRadius(7),
+            Style = (Style)global::Microsoft.UI.Xaml.Application.Current.Resources["AccentButtonStyle"],
+            Content = new FontIcon { Glyph = glyph, FontSize = 18 },
+            RenderTransform = new ScaleTransform(),
+            RenderTransformOrigin = new Point(0.5, 0.5)
+        };
+        AutomationProperties.SetName(button, accessibleName);
+        AutomationProperties.SetAutomationId(button, automationId);
+        ToolTipService.SetToolTip(button, accessibleName);
+        button.PointerEntered += (_, _) => button.Opacity = 0.9;
+        button.PointerExited += (_, _) =>
+        {
+            button.Opacity = 1;
+            SetButtonScale(button, 1);
+        };
+        button.PointerPressed += (_, _) => SetButtonScale(button, 0.9);
+        button.PointerReleased += (_, _) => SetButtonScale(button, 1);
+        button.Click += async (_, _) => await action();
+        return button;
+    }
+
+    private static void SetButtonScale(Button button, double scale)
+    {
+        if (button.RenderTransform is ScaleTransform transform)
+        {
+            transform.ScaleX = scale;
+            transform.ScaleY = scale;
+        }
+    }
+
+    private static Task CopyQrCodeValueAsync(string value)
+    {
+        var package = new DataPackage();
+        package.SetText(value);
+        global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
+        global::Windows.ApplicationModel.DataTransfer.Clipboard.Flush();
+        return Task.CompletedTask;
+    }
+
+    private static bool TryGetWebUri(string value, out Uri? uri)
+    {
+        if (Uri.TryCreate(value, UriKind.Absolute, out Uri? parsed) &&
+            (parsed.Scheme == Uri.UriSchemeHttp || parsed.Scheme == Uri.UriSchemeHttps))
+        {
+            uri = parsed;
+            return true;
+        }
+
+        uri = null;
+        return false;
     }
 
     private void UpdateTextExtractionSelectionPath()

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/ImageEditPage.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Pages/ImageEditPage.xaml
@@ -295,6 +295,7 @@
                 TextBackgroundColor="{x:Bind ViewModel.TextTool.TextBackgroundColor, Mode=OneWay}"
                 TextBoxDrawn="ImageCanvas_TextBoxDrawn"
                 TextExtractionRegions="{x:Bind ViewModel.TextExtractionRegions, Mode=OneWay}"
+                TextExtractionQrCodes="{x:Bind ViewModel.TextExtractionQrCodes, Mode=OneWay}"
                 TextDrawableSelected="ImageCanvas_TextDrawableSelected"
                 TextFontFamily="{x:Bind ViewModel.TextTool.TextFontFamily, Mode=OneWay}"
                 TextFontSize="{x:Bind ViewModel.TextTool.TextFontSize, Mode=OneWay}"

--- a/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
@@ -11,6 +11,7 @@ using CaptureTool.Application.Abstractions.Edit.Image.Rendering;
 using CaptureTool.Application.Abstractions.Edit.Image.SuperResolution;
 using CaptureTool.Application.Abstractions.Edit.Image.TextExtraction;
 using CaptureTool.Application.Abstractions.EditSessions;
+using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Localization;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Settings;
@@ -67,6 +68,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
     private readonly IShareService _shareService;
     private readonly IOpenExternalEditorUseCase _openExternalEditorAction;
     private readonly IStorageService _storageService;
+    private readonly IFileSystem? _fileSystem;
     private readonly IScratchArtifactStore? _scratchArtifactStore;
     private readonly HashSet<string> _scratchArtifactPaths = new(StringComparer.OrdinalIgnoreCase);
     private readonly ISettingsService _settingsService;
@@ -749,7 +751,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         IImageObjectEraseFeatureAvailability? imageObjectEraseFeatureAvailability = null,
         IImageObjectExtractionFeatureAvailability? imageObjectExtractionFeatureAvailability = null,
         ITelemetryService? telemetryService = null,
-        IScratchArtifactStore? scratchArtifactStore = null)
+        IScratchArtifactStore? scratchArtifactStore = null,
+        IFileSystem? fileSystem = null)
     {
         _localizationService = localizationService;
         _cancellationService = cancellationService;
@@ -774,6 +777,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         _openExternalEditorAction = openExternalEditorAction;
         _storageService = storageService;
         _scratchArtifactStore = scratchArtifactStore;
+        _fileSystem = fileSystem;
         _imageCanvasExporter = imageCanvasExporter;
         _settingsService = settingsService;
         _openScreenshotsFolderAction = openScreenshotsFolderAction;
@@ -903,6 +907,8 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         StartLoading();
         ClearImageDescriptionResults();
 
+        imageFile = RestoreMissingWorkingCopy(imageFile);
+
         var cts = _cancellationService.GetLinkedCancellationTokenSource(cancellationToken);
         try
         {
@@ -944,6 +950,32 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         UpdateObjectExtractionAvailability();
         UpdateCanToggleObjectExtraction();
         TrackEditorOpened();
+    }
+
+    private ImageFile RestoreMissingWorkingCopy(ImageFile imageFile)
+    {
+        if (_fileSystem is null ||
+            _scratchArtifactStore is null ||
+            _fileSystem.FileExists(imageFile.FilePath) ||
+            string.IsNullOrWhiteSpace(imageFile.PersistentFilePath) ||
+            !_fileSystem.FileExists(imageFile.PersistentFilePath))
+        {
+            return imageFile;
+        }
+
+        string restoredPath = _scratchArtifactStore.CreateLeasedArtifactPath(
+            "recent-capture-working-copy",
+            Path.GetExtension(imageFile.PersistentFilePath));
+        try
+        {
+            _fileSystem.CopyFile(imageFile.PersistentFilePath, restoredPath, true);
+            return new ImageFile(restoredPath, imageFile.PersistentFilePath);
+        }
+        catch
+        {
+            _scratchArtifactStore.DeleteArtifact(restoredPath);
+            throw;
+        }
     }
 
     public override void Dispose()

--- a/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/ImageEdit/ImageEditPageViewModel.cs
@@ -549,6 +549,18 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         }
     } = [];
 
+    public IReadOnlyList<RecognizedQrCodeRegion> TextExtractionQrCodes
+    {
+        get;
+        private set
+        {
+            if (Set(ref field, value))
+            {
+                RaisePropertyChanged(nameof(IsTextExtractionOverlayVisible));
+            }
+        }
+    } = [];
+
     public bool HasTextExtractionRegions
     {
         get;
@@ -562,7 +574,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
     }
 
     public bool IsTextExtractionOverlayVisible =>
-        IsTextExtractionModeActive && HasTextExtractionRegions;
+        IsTextExtractionModeActive && (HasTextExtractionRegions || TextExtractionQrCodes.Count > 0);
 
     public bool IsImageDescriptionFeatureEnabled
     {
@@ -966,6 +978,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         IsTextExtractionRunning = false;
         TextExtractionStatusMessage = string.Empty;
         TextExtractionRegions = [];
+        TextExtractionQrCodes = [];
         TextExtractionTool.Reset();
         IsImageDescriptionFeatureEnabled = _imageDescriptionFeatureAvailability.IsImageDescriptionEnabled;
         IsImageDescriptionAvailable = false;
@@ -2289,6 +2302,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
 
         TextExtractionStatusMessage = string.Empty;
         TextExtractionRegions = [];
+        TextExtractionQrCodes = [];
         TextExtractionTool.Reset();
 
         using ImageEditOperationCoordinator.OperationLease operation =
@@ -2335,6 +2349,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
             }
 
             TextExtractionRegions = NormalizeTextExtractionRegions(result.Document.Regions, result.Document.ImageSize);
+            TextExtractionQrCodes = NormalizeQrCodeRegions(result.Document.QrCodes, result.Document.ImageSize);
             TextExtractionTool.SetText(result.Document.Text);
             _textExtractionProcessedRevision = processedRevision;
             InvalidateCanvasRequested?.Invoke(this, EventArgs.Empty);
@@ -2393,6 +2408,26 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
         }
 
         return normalizedRegions;
+    }
+
+    private static IReadOnlyList<RecognizedQrCodeRegion> NormalizeQrCodeRegions(
+        IReadOnlyList<RecognizedQrCodeRegion> qrCodes,
+        Size imageSize)
+    {
+        if (imageSize.Width <= 0 || imageSize.Height <= 0)
+        {
+            return [];
+        }
+
+        RectangleF imageBounds = new(0, 0, imageSize.Width, imageSize.Height);
+        return qrCodes
+            .Where(qrCode => !string.IsNullOrWhiteSpace(qrCode.Value))
+            .Select(qrCode => qrCode with
+            {
+                Bounds = RectangleF.Intersect(imageBounds, qrCode.Bounds)
+            })
+            .Where(qrCode => qrCode.Bounds.Width > 0 && qrCode.Bounds.Height > 0)
+            .ToArray();
     }
 
     private async Task GenerateImageDescriptionAsync(ImageDescriptionMode mode)
@@ -2894,6 +2929,7 @@ public sealed partial class ImageEditPageViewModel : AsyncLoadableViewModelBase<
     {
         _textExtractionProcessedRevision = null;
         TextExtractionRegions = [];
+        TextExtractionQrCodes = [];
         TextExtractionStatusMessage = string.Empty;
         TextExtractionTool.Reset();
     }

--- a/tests/CaptureTool.Infrastructure.Edit.Windows.Tests/QrCodeDetectorTests.cs
+++ b/tests/CaptureTool.Infrastructure.Edit.Windows.Tests/QrCodeDetectorTests.cs
@@ -1,0 +1,60 @@
+using CaptureTool.Application.Abstractions.Edit.Image.TextExtraction;
+using CaptureTool.Infrastructure.Edit.Windows;
+using FluentAssertions;
+using ZXing;
+using ZXing.Common;
+using ZXing.Rendering;
+
+namespace CaptureTool.Infrastructure.Edit.Windows.Tests;
+
+[TestClass]
+public sealed class QrCodeDetectorTests
+{
+    [TestMethod]
+    public void Detect_WhenImageContainsQrCode_ReturnsPayloadAndBounds()
+    {
+        const string payload = "https://example.com/capture/42";
+        var writer = new BarcodeWriterPixelData
+        {
+            Format = BarcodeFormat.QR_CODE,
+            Options = new EncodingOptions
+            {
+                Width = 240,
+                Height = 240,
+                Margin = 4
+            }
+        };
+        PixelData image = writer.Write(payload);
+
+        var result = QrCodeDetector.Detect(image.Pixels, image.Width, image.Height);
+
+        result.Should().ContainSingle();
+        result[0].Value.Should().Be(payload);
+        result[0].Bounds.Width.Should().BeGreaterThan(150);
+        result[0].Bounds.Height.Should().BeGreaterThan(150);
+    }
+
+    [TestMethod]
+    public void Detect_WhenImageHasNoQrCode_ReturnsEmptyResult()
+    {
+        byte[] whitePixels = Enumerable.Repeat((byte)255, 100 * 100 * 4).ToArray();
+
+        QrCodeDetector.Detect(whitePixels, 100, 100).Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldExcludeText_WhenOcrRegionIsInsideQrCode_ReturnsTrue()
+    {
+        RecognizedQrCodeRegion[] qrCodes =
+        [
+            new("https://example.com", new System.Drawing.RectangleF(40, 40, 120, 120))
+        ];
+
+        QrCodeDetector.ShouldExcludeText(
+            new System.Drawing.RectangleF(70, 85, 28, 14),
+            qrCodes).Should().BeTrue();
+        QrCodeDetector.ShouldExcludeText(
+            new System.Drawing.RectangleF(10, 10, 24, 12),
+            qrCodes).Should().BeFalse();
+    }
+}

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelDefaultsTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelDefaultsTests.cs
@@ -5,6 +5,7 @@ using CaptureTool.Application.Abstractions.Edit.Image;
 using CaptureTool.Application.Abstractions.Edit.Image.ChromaKey;
 using CaptureTool.Application.Abstractions.Edit.Image.Rendering;
 using CaptureTool.Application.Abstractions.Edit.Image.SuperResolution;
+using CaptureTool.Application.Abstractions.Files;
 using CaptureTool.Application.Abstractions.Localization;
 using CaptureTool.Application.Abstractions.Logging;
 using CaptureTool.Application.Abstractions.Settings;
@@ -27,6 +28,49 @@ namespace CaptureTool.Presentation.Tests.Features;
 [TestClass]
 public sealed class ImageEditPageViewModelDefaultsTests
 {
+    [TestMethod]
+    public async Task LoadAsync_WhenRecentWorkingCopyWasReleased_RecreatesItFromPersistentCapture()
+    {
+        const string missingWorkingPath = "scratch/missing.png";
+        const string persistentPath = "captures/original.png";
+        const string restoredWorkingPath = "scratch/restored.png";
+        var requestedImage = new ImageFile(missingWorkingPath, persistentPath);
+        var fileSystem = new Mock<IFileSystem>();
+        var scratchArtifacts = new Mock<IScratchArtifactStore>();
+        var imageMetadata = new Mock<IImageMetadataService>();
+        var cancellationService = new Mock<ICancellationService>();
+
+        fileSystem.Setup(service => service.FileExists(missingWorkingPath)).Returns(false);
+        fileSystem.Setup(service => service.FileExists(persistentPath)).Returns(true);
+        scratchArtifacts
+            .Setup(service => service.CreateLeasedArtifactPath("recent-capture-working-copy", ".png"))
+            .Returns(restoredWorkingPath);
+        imageMetadata
+            .Setup(service => service.GetImageFileSize(It.Is<ImageFile>(file => file.FilePath == restoredWorkingPath)))
+            .Returns(new Size(320, 180));
+        cancellationService
+            .Setup(service => service.GetLinkedCancellationTokenSource(It.IsAny<CancellationToken>()))
+            .Returns(() => new CancellationTokenSource());
+
+        var viewModel = CreateViewModel(
+            imageMetadata: imageMetadata.Object,
+            cancellationService: cancellationService.Object,
+            fileSystem: fileSystem.Object,
+            scratchArtifactStore: scratchArtifacts.Object);
+
+        await viewModel.LoadAsync(requestedImage, CancellationToken.None);
+
+        viewModel.ImageFile.Should().NotBeNull();
+        viewModel.ImageFile!.FilePath.Should().Be(restoredWorkingPath);
+        viewModel.ImageFile.PersistentFilePath.Should().Be(persistentPath);
+        fileSystem.Verify(
+            service => service.CopyFile(persistentPath, restoredWorkingPath, true),
+            Times.Once);
+
+        viewModel.Dispose();
+        scratchArtifacts.Verify(service => service.DeleteArtifact(restoredWorkingPath), Times.Once);
+    }
+
     [TestMethod]
     public async Task LoadAsync_ShouldScaleInitialShapeAndTextDefaults_ForLargeImages()
     {
@@ -291,7 +335,9 @@ public sealed class ImageEditPageViewModelDefaultsTests
         ICancellationService? cancellationService = null,
         IChromaKeyAccessService? chromaKeyAccess = null,
         IChromaKeyService? chromaKeyService = null,
-        IOpenScreenshotsFolderUseCase? openScreenshotsFolderAction = null)
+        IOpenScreenshotsFolderUseCase? openScreenshotsFolderAction = null,
+        IFileSystem? fileSystem = null,
+        IScratchArtifactStore? scratchArtifactStore = null)
     {
         IAppNotificationService notifications = Mock.Of<IAppNotificationService>();
 
@@ -325,7 +371,9 @@ public sealed class ImageEditPageViewModelDefaultsTests
             new TextExtractionToolViewModel(
                 Mock.Of<IClipboardService>(),
                 Mock.Of<ILocalizationService>(),
-                notifications));
+                notifications),
+            scratchArtifactStore: scratchArtifactStore,
+            fileSystem: fileSystem);
     }
 
     private static ImageChromaKeyEffect GetChromaKeyEffect(ImageEditPageViewModel viewModel)

--- a/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelTextExtractionTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/ImageEditPageViewModelTextExtractionTests.cs
@@ -207,6 +207,45 @@ public sealed class ImageEditPageViewModelTextExtractionTests
     }
 
     [TestMethod]
+    public async Task ToggleTextExtractionMode_WhenQrCodeIsDetected_ShowsNormalizedQrOverlayAndIncludesItsValue()
+    {
+        var exporter = new Mock<IImageCanvasExporter>();
+        var textExtraction = new Mock<ITextExtractionService>();
+        exporter
+            .Setup(service => service.RenderToStreamAsync(
+                It.IsAny<IDrawable[]>(),
+                It.IsAny<ImageCanvasRenderOptions>()))
+            .ReturnsAsync(new MemoryStream([1, 2, 3]));
+        textExtraction
+            .Setup(service => service.GetReadyState())
+            .Returns(TextExtractionReadyState.Ready);
+        textExtraction
+            .Setup(service => service.ExtractAsync(
+                It.IsAny<TextExtractionRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TextExtractionResult.Success(new RecognizedTextDocument(
+                "https://example.com/qr",
+                new Size(100, 50),
+                [],
+                [new RecognizedQrCodeRegion(
+                    "https://example.com/qr",
+                    new RectangleF(-5, 10, 40, 30))])));
+
+        ImageEditPageViewModel viewModel = CreateViewModel(
+            imageCanvasExporter: exporter.Object,
+            textExtractionService: textExtraction.Object);
+
+        await viewModel.LoadAsync(new ImageFile("original.png"), CancellationToken.None);
+        await viewModel.ToggleTextExtractionModeCommand.ExecuteAsync(null);
+
+        viewModel.TextExtractionRegions.Should().BeEmpty();
+        viewModel.TextExtractionQrCodes.Should().ContainSingle();
+        viewModel.TextExtractionQrCodes[0].Bounds.Should().Be(new RectangleF(0, 10, 35, 30));
+        viewModel.TextExtractionTool.Text.Should().Be("https://example.com/qr");
+        viewModel.IsTextExtractionOverlayVisible.Should().BeTrue();
+    }
+
+    [TestMethod]
     public async Task ToggleTextExtractionMode_WhenEditRevisionChanged_ShouldRunAgainWhenReopened()
     {
         var exporter = new Mock<IImageCanvasExporter>();

--- a/tests/CaptureTool.UiTests/CaptureTool.UiTests.csproj
+++ b/tests/CaptureTool.UiTests/CaptureTool.UiTests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="FlaUI.UIA3" />
     <PackageReference Include="Microsoft.CodeCoverage" />
     <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="ZXing.Net" />
     <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/CaptureTool.UiTests/ImageEditTextExtractionUiTests.cs
+++ b/tests/CaptureTool.UiTests/ImageEditTextExtractionUiTests.cs
@@ -7,6 +7,8 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Text;
+using ZXing;
+using ZXing.Common;
 
 namespace CaptureTool.UiTests;
 
@@ -113,6 +115,16 @@ public sealed class ImageEditTextExtractionUiTests
                 "ImageEdit_TextExtractionCopyAllButton",
                 InteractionTimeout);
             Assert.IsTrue(copyAllTextButton.IsEnabled, "Copy all text should be enabled after OCR completes.");
+            WaitForElement(
+                mainWindow,
+                automation,
+                "ImageCanvas_QrCodeCopyButton_0",
+                InteractionTimeout);
+            WaitForElement(
+                mainWindow,
+                automation,
+                "ImageCanvas_QrCodeOpenButton_0",
+                InteractionTimeout);
 
             Thread.Sleep(500);
             File.Delete(screenshotPath);
@@ -461,7 +473,7 @@ public sealed class ImageEditTextExtractionUiTests
 
     private static void CreateOcrFixtureImage(string filePath)
     {
-        using Bitmap bitmap = new(420, 220);
+        using Bitmap bitmap = new(640, 300);
         using Graphics graphics = Graphics.FromImage(bitmap);
         graphics.SmoothingMode = SmoothingMode.AntiAlias;
         graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
@@ -473,9 +485,36 @@ public sealed class ImageEditTextExtractionUiTests
         using Font titleFont = new("Segoe UI", 34, FontStyle.Bold, GraphicsUnit.Pixel);
         using Font subtitleFont = new("Segoe UI", 30, FontStyle.Regular, GraphicsUnit.Pixel);
 
-        graphics.DrawRectangle(guidePen, 24, 24, 372, 172);
+        graphics.DrawRectangle(guidePen, 24, 24, 592, 252);
         graphics.DrawString("OCR MODE", titleFont, titleBrush, 50, 40);
         graphics.DrawString("SAMPLE TEXT", subtitleFont, subtitleBrush, 50, 110);
+
+        var qrWriter = new BarcodeWriterPixelData
+        {
+            Format = BarcodeFormat.QR_CODE,
+            Options = new EncodingOptions
+            {
+                Width = 190,
+                Height = 190,
+                Margin = 3
+            }
+        };
+        ZXing.Rendering.PixelData qrPixels = qrWriter.Write("https://example.com/capturetool");
+        using Bitmap qrBitmap = new(qrPixels.Width, qrPixels.Height, PixelFormat.Format32bppArgb);
+        BitmapData qrData = qrBitmap.LockBits(
+            new Rectangle(0, 0, qrBitmap.Width, qrBitmap.Height),
+            ImageLockMode.WriteOnly,
+            PixelFormat.Format32bppArgb);
+        try
+        {
+            Marshal.Copy(qrPixels.Pixels, 0, qrData.Scan0, qrPixels.Pixels.Length);
+        }
+        finally
+        {
+            qrBitmap.UnlockBits(qrData);
+        }
+
+        graphics.DrawImage(qrBitmap, 400, 55, 190, 190);
 
         bitmap.Save(filePath, ImageFormat.Png);
     }


### PR DESCRIPTION
## Summary

- detect QR codes alongside OCR on the image edit page
- keep QR regions visible in the Text Extraction overlay and expose copy/open actions
- exclude blocky QR modules from OCR text regions and copied text
- improve QR action visibility with a high-contrast surface and interactive accent buttons
- restore missing leased image working copies when a back-stack entry reopens a recent capture
- add detector, view-model, scratch-recovery, and UI automation coverage

## Why

Text Extraction previously treated QR modules as ordinary image content, which could produce noisy OCR fragments and offered no way to use the encoded value directly. Testing also exposed that navigating through Settings disposes an editor and releases its scratch file while the back stack retains the old file parameter. Returning to that editor then failed during metadata loading.

## User impact

Users can copy a QR payload or open validated HTTP/HTTPS links directly from the image overlay. OCR text no longer includes artifacts detected inside QR bounds. Recent images can also be reopened through back navigation after Settings or theme changes without showing the error page.

## Validation

- `dotnet build CaptureTool.slnx --no-restore -m:1`
- `dotnet build src/CaptureTool.Presentation.Windows.WinUI/CaptureTool.Presentation.Windows.WinUI.csproj --no-restore -p:Platform=x64`
- `dotnet test tests/CaptureTool.Infrastructure.Edit.Windows.Tests/CaptureTool.Infrastructure.Edit.Windows.Tests.csproj --no-restore -p:Platform=x64` (42 passed)
- focused Text Extraction presentation tests (10 passed)
- focused image editor defaults/scratch-recovery tests (10 passed)
- `git diff --check`