### PR TITLE
Fix overlay toolbar shadows and teardown

### DIFF
--- a/src/CaptureTool.Infrastructure.Windows/Clipboard/WindowsClipboardService.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Clipboard/WindowsClipboardService.cs
@@ -60,17 +60,28 @@ public partial class WindowsClipboardService : IClipboardService
 
     public async Task CopyFileAsync(ClipboardFile clipboardFile)
     {
-        if (!File.Exists(clipboardFile.FilePath))
+        DataPackage? package = await CreateFileDataPackageAsync(clipboardFile);
+        if (package == null)
         {
             return;
         }
 
-        var package = new DataPackage();
-        var file = await StorageFile.GetFileFromPathAsync(clipboardFile.FilePath);
-        List<IStorageItem> items = [file];
-        package.SetStorageItems(items);
         global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
         global::Windows.ApplicationModel.DataTransfer.Clipboard.Flush();
+    }
+
+    internal static async Task<DataPackage?> CreateFileDataPackageAsync(ClipboardFile clipboardFile)
+    {
+        if (!File.Exists(clipboardFile.FilePath))
+        {
+            return null;
+        }
+
+        var package = new DataPackage();
+        var file = await StorageFile.GetFileFromPathAsync(clipboardFile.FilePath);
+        IStorageItem[] items = [file];
+        package.SetStorageItems(items);
+        return package;
     }
 
     private static async Task<InMemoryRandomAccessStream> CreateClipboardBitmapStreamAsync(IRandomAccessStream stream)

--- a/src/CaptureTool.Infrastructure.Windows/Share/StorageFileShare.cs
+++ b/src/CaptureTool.Infrastructure.Windows/Share/StorageFileShare.cs
@@ -34,7 +34,7 @@ public sealed partial class StorageFileShare : IDisposable
 
         if (_file != null)
         {
-            request.Data.SetStorageItems(new List<StorageFile> { _file });
+            request.Data.SetStorageItems(new IStorageItem[] { _file });
         }
         else
         {

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/CaptureOverlayToolbar.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/CaptureOverlayToolbar.xaml
@@ -11,6 +11,7 @@
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     xmlns:utils="using:CaptureTool.Presentation.Windows.WinUI.Utils"
     d:DataContext="{d:DesignInstance Type=local:CaptureOverlayToolbar}"
+    IsTextScaleFactorEnabled="False"
     mc:Ignorable="d">
     <Grid
         x:Name="ToolbarPanel"

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/CaptureOverlayToolbar.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/CaptureOverlayToolbar.xaml
@@ -90,7 +90,6 @@
                 Height="32"
                 Padding="6,0"
                 Background="Transparent"
-                BorderBrush="Transparent"
                 Click="LocalAudioToggleButton_Click">
                 <SplitButton.Content>
                     <Grid Width="20">
@@ -129,8 +128,8 @@
                                 Minimum="0"
                                 SmallChange="1"
                                 StepFrequency="1"
-                                Value="{x:Bind LocalAudioVolumePercentage, Mode=OneWay}"
-                                ValueChanged="LocalAudioVolumeSlider_ValueChanged" />
+                                ValueChanged="LocalAudioVolumeSlider_ValueChanged"
+                                Value="{x:Bind LocalAudioVolumePercentage, Mode=OneWay}" />
                         </StackPanel>
                     </Flyout>
                 </SplitButton.Flyout>
@@ -148,6 +147,7 @@
 
             <Button
                 x:Uid="SelectionOverlay_CloseButton"
+                AutomationProperties.AutomationId="CaptureOverlay_CloseButton"
                 Command="{x:Bind CloseCommand, Mode=OneWay}"
                 Style="{StaticResource IconButtonStyle}">
                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="{StaticResource Cancel}" />

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/CaptureOverlayToolbar.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/CaptureOverlayToolbar.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using System.Collections;
 using System.Windows.Input;
+using Windows.Foundation;
 
 namespace CaptureTool.Presentation.Windows.WinUI.Xaml.Controls;
 
@@ -282,6 +283,13 @@ public sealed partial class CaptureOverlayToolbar : UserControlBase
 
     public string FormatVolumePercentage(int volumePercentage)
         => $"{Math.Clamp(volumePercentage, 0, 100)}%";
+
+    internal Size MeasureNaturalSize()
+    {
+        ToolbarPanel.InvalidateMeasure();
+        ToolbarPanel.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        return ToolbarPanel.DesiredSize;
+    }
 
     private void LocalAudioToggleButton_Click(SplitButton sender, SplitButtonClickEventArgs args)
     {

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/SelectionOverlayToolbar.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/SelectionOverlayToolbar.xaml
@@ -12,6 +12,7 @@
     xmlns:utils="using:CaptureTool.Presentation.Windows.WinUI.Utils"
     xmlns:viewmodels="using:CaptureTool.Presentation.Features.SelectionOverlay"
     d:DataContext="{d:DesignInstance Type=local:SelectionOverlayToolbar}"
+    IsTextScaleFactorEnabled="False"
     mc:Ignorable="d">
     <StackPanel
         x:Name="ToolbarPanel"

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/SelectionOverlayToolbar.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Controls/SelectionOverlayToolbar.xaml
@@ -22,7 +22,12 @@
         Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
         CornerRadius="4"
         Orientation="Horizontal"
-        Spacing="8">
+        Spacing="8"
+        Translation="0,0,16">
+        <StackPanel.Shadow>
+            <ThemeShadow />
+        </StackPanel.Shadow>
+
         <!--  Capture mode  -->
         <toolkit:Segmented
             x:Name="CaptureModeSegmentedControl"

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayShadowView.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayShadowView.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<controls:UserControlBase
+    x:Class="CaptureTool.Presentation.Windows.WinUI.Xaml.Views.CaptureOverlayShadowView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CaptureTool.Presentation.Windows.WinUI.Xaml.Controls"
+    IsHitTestVisible="False"
+    IsTabStop="False">
+
+    <Grid
+        x:Name="ShadowHost"
+        Background="Transparent"
+        IsHitTestVisible="False">
+        <Rectangle
+            x:Name="ShadowCaster"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Top"
+            Fill="White"
+            IsHitTestVisible="False" />
+    </Grid>
+</controls:UserControlBase>

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayShadowView.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayShadowView.xaml.cs
@@ -1,0 +1,317 @@
+using CaptureTool.Presentation.Windows.WinUI.Xaml.Controls;
+using Microsoft.UI;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Hosting;
+using System.Numerics;
+
+namespace CaptureTool.Presentation.Windows.WinUI.Xaml.Views;
+
+internal sealed class CaptureOverlayShadowInitializationEventArgs(bool succeeded) : EventArgs
+{
+    public bool Succeeded { get; } = succeeded;
+}
+
+internal sealed partial class CaptureOverlayShadowView : UserControlBase, IDisposable
+{
+    internal const double ShadowPaddingDips = 16;
+    private const float ToolbarCornerRadiusDips = 4;
+    private const float ShadowBlurRadiusDips = 12;
+    private const float ShadowVerticalOffsetDips = 4;
+
+    private SpriteVisual? _shadowVisual;
+    private DropShadow? _shadow;
+    private CompositionColorBrush? _casterFillBrush;
+    private CompositionMaskBrush? _casterMaskBrush;
+    private CompositionBrush? _casterAlphaMask;
+    private XamlRoot? _observedXamlRoot;
+    private Vector2 _casterOffsetPixels;
+    private Vector2 _casterSizePixels;
+    private double _toolbarRasterizationScale = 1;
+    private bool _initializationCompleted;
+    private bool _disposed;
+
+    internal event EventHandler<CaptureOverlayShadowInitializationEventArgs>? InitializationCompleted;
+
+    public CaptureOverlayShadowView()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+        ShadowHost.SizeChanged += ShadowHost_SizeChanged;
+    }
+
+    internal bool QueueInitialization()
+    {
+        if (_disposed)
+        {
+            return false;
+        }
+
+        if (_initializationCompleted)
+        {
+            return true;
+        }
+
+        return DispatcherQueue.TryEnqueue(() =>
+        {
+            if (IsLoaded)
+            {
+                InitializeShadow();
+            }
+        });
+    }
+
+    internal void UpdateCaster(
+        int offsetXPixels,
+        int offsetYPixels,
+        int widthPixels,
+        int heightPixels,
+        double toolbarRasterizationScale)
+    {
+        if (_disposed ||
+            offsetXPixels < 0 ||
+            offsetYPixels < 0 ||
+            widthPixels <= 0 ||
+            heightPixels <= 0 ||
+            !double.IsFinite(toolbarRasterizationScale) ||
+            toolbarRasterizationScale <= 0)
+        {
+            return;
+        }
+
+        _casterOffsetPixels = new Vector2(offsetXPixels, offsetYPixels);
+        _casterSizePixels = new Vector2(widthPixels, heightPixels);
+        _toolbarRasterizationScale = toolbarRasterizationScale;
+        ApplyCasterLayout();
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ObserveXamlRoot();
+        ApplyCasterLayout();
+        InitializeShadow();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        StopObservingXamlRoot();
+        CleanupCompositionResources();
+    }
+
+    private void ObserveXamlRoot()
+    {
+        XamlRoot? xamlRoot = XamlRoot;
+        if (ReferenceEquals(_observedXamlRoot, xamlRoot))
+        {
+            return;
+        }
+
+        StopObservingXamlRoot();
+        _observedXamlRoot = xamlRoot;
+        if (_observedXamlRoot != null)
+        {
+            _observedXamlRoot.Changed += XamlRoot_Changed;
+        }
+    }
+
+    private void StopObservingXamlRoot()
+    {
+        if (_observedXamlRoot != null)
+        {
+            _observedXamlRoot.Changed -= XamlRoot_Changed;
+            _observedXamlRoot = null;
+        }
+    }
+
+    private void XamlRoot_Changed(XamlRoot sender, XamlRootChangedEventArgs args)
+    {
+        ApplyCasterLayout();
+    }
+
+    private void ShadowHost_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        ApplyCasterLayout();
+    }
+
+    private void InitializeShadow()
+    {
+        if (_disposed || _initializationCompleted)
+        {
+            return;
+        }
+
+        bool succeeded = false;
+        try
+        {
+            Compositor compositor = ElementCompositionPreview.GetElementVisual(ShadowCaster).Compositor;
+
+            _casterAlphaMask = ShadowCaster.GetAlphaMask();
+            _casterFillBrush = compositor.CreateColorBrush(Colors.White);
+            _casterMaskBrush = compositor.CreateMaskBrush();
+            _casterMaskBrush.Source = _casterFillBrush;
+            _casterMaskBrush.Mask = _casterAlphaMask;
+
+            _shadow = compositor.CreateDropShadow();
+            _shadow.Color = Colors.Black;
+            _shadow.Opacity = 0.35f;
+            _shadow.SourcePolicy = CompositionDropShadowSourcePolicy.Default;
+
+            _shadowVisual = compositor.CreateSpriteVisual();
+            _shadowVisual.RelativeSizeAdjustment = Vector2.One;
+            _shadowVisual.Brush = _casterMaskBrush;
+            _shadowVisual.Shadow = _shadow;
+
+            ElementCompositionPreview.SetElementChildVisual(ShadowCaster, _shadowVisual);
+            ApplyShadowEffects();
+            succeeded = true;
+        }
+        catch
+        {
+            CleanupCompositionResources();
+        }
+
+        _initializationCompleted = true;
+        InitializationCompleted?.Invoke(
+            this,
+            new CaptureOverlayShadowInitializationEventArgs(succeeded));
+    }
+
+    private void ApplyCasterLayout()
+    {
+        if (ShadowHost.ActualWidth <= 0 || ShadowHost.ActualHeight <= 0)
+        {
+            return;
+        }
+
+        float physicalHostWidth = _casterSizePixels.X + (2 * _casterOffsetPixels.X);
+        float physicalHostHeight = _casterSizePixels.Y + (2 * _casterOffsetPixels.Y);
+        if (physicalHostWidth <= 0 || physicalHostHeight <= 0)
+        {
+            return;
+        }
+
+        double hostUnitsPerPixelX = ShadowHost.ActualWidth / physicalHostWidth;
+        double hostUnitsPerPixelY = ShadowHost.ActualHeight / physicalHostHeight;
+        double insetX = _casterOffsetPixels.X * hostUnitsPerPixelX;
+        double insetY = _casterOffsetPixels.Y * hostUnitsPerPixelY;
+
+        ShadowCaster.Margin = new Thickness(insetX, insetY, 0, 0);
+        ShadowCaster.Width = Math.Max(0, ShadowHost.ActualWidth - (2 * insetX));
+        ShadowCaster.Height = Math.Max(0, ShadowHost.ActualHeight - (2 * insetY));
+
+        double physicalCornerRadius = ToolbarCornerRadiusDips * _toolbarRasterizationScale;
+        ShadowCaster.RadiusX = physicalCornerRadius * hostUnitsPerPixelX;
+        ShadowCaster.RadiusY = physicalCornerRadius * hostUnitsPerPixelY;
+        ApplyShadowEffects();
+    }
+
+    private void ApplyShadowEffects()
+    {
+        if (_shadow == null || ShadowHost.ActualWidth <= 0 || ShadowHost.ActualHeight <= 0)
+        {
+            return;
+        }
+
+        float physicalHostWidth = _casterSizePixels.X + (2 * _casterOffsetPixels.X);
+        float physicalHostHeight = _casterSizePixels.Y + (2 * _casterOffsetPixels.Y);
+        if (physicalHostWidth <= 0 || physicalHostHeight <= 0)
+        {
+            return;
+        }
+
+        float hostUnitsPerPixelX = (float)(ShadowHost.ActualWidth / physicalHostWidth);
+        float hostUnitsPerPixelY = (float)(ShadowHost.ActualHeight / physicalHostHeight);
+        float averageHostUnitsPerPixel = (hostUnitsPerPixelX + hostUnitsPerPixelY) / 2;
+
+        _shadow.BlurRadius =
+            ShadowBlurRadiusDips *
+            (float)_toolbarRasterizationScale *
+            averageHostUnitsPerPixel;
+        _shadow.Offset = new Vector3(
+            0,
+            ShadowVerticalOffsetDips *
+                (float)_toolbarRasterizationScale *
+                hostUnitsPerPixelY,
+            0);
+    }
+
+    private void CleanupCompositionResources()
+    {
+        try
+        {
+            ElementCompositionPreview.SetElementChildVisual(ShadowCaster, null);
+        }
+        catch { }
+
+        SpriteVisual? shadowVisual = _shadowVisual;
+        _shadowVisual = null;
+        try
+        {
+            if (shadowVisual != null)
+            {
+                shadowVisual.Shadow = null;
+                shadowVisual.Brush = null;
+                shadowVisual.Dispose();
+            }
+        }
+        catch { }
+
+        DropShadow? shadow = _shadow;
+        _shadow = null;
+        try
+        {
+            shadow?.Dispose();
+        }
+        catch { }
+
+        CompositionMaskBrush? casterMaskBrush = _casterMaskBrush;
+        _casterMaskBrush = null;
+        try
+        {
+            if (casterMaskBrush != null)
+            {
+                casterMaskBrush.Source = null;
+                casterMaskBrush.Mask = null;
+                casterMaskBrush.Dispose();
+            }
+        }
+        catch { }
+
+        CompositionBrush? casterAlphaMask = _casterAlphaMask;
+        _casterAlphaMask = null;
+        try
+        {
+            casterAlphaMask?.Dispose();
+        }
+        catch { }
+
+        CompositionColorBrush? casterFillBrush = _casterFillBrush;
+        _casterFillBrush = null;
+        try
+        {
+            casterFillBrush?.Dispose();
+        }
+        catch
+        {
+            // Native composition teardown is best effort during overlay shutdown.
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Loaded -= OnLoaded;
+        Unloaded -= OnUnloaded;
+        ShadowHost.SizeChanged -= ShadowHost_SizeChanged;
+        StopObservingXamlRoot();
+        InitializationCompleted = null;
+        CleanupCompositionResources();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayView.xaml
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayView.xaml
@@ -14,12 +14,13 @@
 
     <Grid x:Name="RootPanel" CornerRadius="8">
         <Grid
+            x:Name="ToolbarContainer"
             HorizontalAlignment="Center"
             VerticalAlignment="Top"
             Visibility="{x:Bind utils:VisibilityUtility.InverseBoolToVisibility(ViewModel.HasRecordingError), Mode=OneWay}">
-            <Grid x:Name="ToolbarHost" />
             <controls:CaptureOverlayToolbar
                 x:Name="Toolbar"
+                AutomationProperties.AutomationId="CaptureOverlayToolbar"
                 AudioInputSources="{x:Bind ViewModel.AudioInputSources, Mode=OneWay}"
                 CaptureTime="{x:Bind ViewModel.CaptureTime, Mode=OneWay}"
                 CloseCommand="{x:Bind ViewModel.CloseOverlayCommand}"
@@ -44,7 +45,7 @@
 
         <InfoBar
             x:Name="RecordingErrorInfoBar"
-            HorizontalAlignment="Stretch"
+            HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Canvas.ZIndex="1"
             CloseButtonCommand="{x:Bind ViewModel.DismissRecordingErrorCommand, Mode=OneWay}"

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayView.xaml.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Views/CaptureOverlayView.xaml.cs
@@ -2,101 +2,262 @@ using CaptureTool.Application.Abstractions.Themes;
 using CaptureTool.Domain.Capture;
 using CaptureTool.Presentation.Features.CaptureOverlay;
 using CaptureTool.Presentation.Windows.WinUI.Capture;
-using Microsoft.UI;
-using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Hosting;
-using System.Numerics;
+using System.ComponentModel;
+using Windows.Foundation;
 
 namespace CaptureTool.Presentation.Windows.WinUI.Xaml.Views;
+
+internal readonly record struct CaptureOverlaySurfaceMetrics(
+    double Width,
+    double Height,
+    double RasterizationScale,
+    bool ShowsToolbar);
 
 public sealed partial class CaptureOverlayView : CaptureOverlayViewBase
 {
     private readonly NewCaptureArgs _captureArgs;
     private readonly WinUICaptureDiscardConfirmationService _captureDiscardConfirmationService;
-    private SpriteVisual? _shadowVisual;
-    private DropShadow? _shadow;
+    private CaptureOverlaySurfaceMetrics _lastPublishedMetrics;
+    private XamlRoot? _observedXamlRoot;
+    private double _lastToolbarWidth;
+    private bool _surfaceUpdateQueued;
+    private bool _isLoaded;
+    private bool _lastPublishedMetricsWereValid;
+    private bool _unloaded;
+
+    internal event EventHandler<CaptureOverlaySurfaceMetrics>? SurfaceMetricsChanged;
+    internal event EventHandler? SurfaceMetricsInvalidated;
 
     public CaptureOverlayView(NewCaptureArgs captureArgs)
     {
         _captureArgs = captureArgs;
         _captureDiscardConfirmationService = App.Current.ServiceProvider.GetService<WinUICaptureDiscardConfirmationService>();
 
+        InitializeComponent();
+
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
-
-        InitializeComponent();
+        Toolbar.SizeChanged += OnSurfaceElementSizeChanged;
+        Toolbar.LayoutUpdated += OnSurfaceElementLayoutUpdated;
+        RecordingErrorInfoBar.SizeChanged += OnSurfaceElementSizeChanged;
+        RecordingErrorInfoBar.LayoutUpdated += OnSurfaceElementLayoutUpdated;
 
         DispatcherQueue.TryEnqueue(() =>
         {
-            AddToolbarShadow();
             UpdateRequestedAppTheme();
         });
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
+        _unloaded = false;
         _captureDiscardConfirmationService.XamlRoot = RootPanel.XamlRoot;
         _captureDiscardConfirmationService.DialogHostBounds = _captureArgs.Monitor.MonitorBounds;
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        AttachXamlRoot();
         ViewModel.Load(new CaptureOverlayViewModelOptions(_captureArgs));
+        _isLoaded = true;
+        QueueSurfaceMetricsUpdate();
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
+        _unloaded = true;
+        _isLoaded = false;
         Loaded -= OnLoaded;
         Unloaded -= OnUnloaded;
+        Toolbar.SizeChanged -= OnSurfaceElementSizeChanged;
+        Toolbar.LayoutUpdated -= OnSurfaceElementLayoutUpdated;
+        RecordingErrorInfoBar.SizeChanged -= OnSurfaceElementSizeChanged;
+        RecordingErrorInfoBar.LayoutUpdated -= OnSurfaceElementLayoutUpdated;
+        ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        DetachXamlRoot();
 
+        _captureDiscardConfirmationService.XamlRoot = null;
         _captureDiscardConfirmationService.DialogHostBounds = null;
 
         ViewModel.Dispose();
-
-        CleanupCompositionResources();
     }
 
-    private void CleanupCompositionResources()
+    internal bool TryGetCurrentSurfaceMetrics(out CaptureOverlaySurfaceMetrics metrics)
     {
         try
         {
-            if (_shadowVisual != null)
+            return TryCalculateCurrentSurfaceMetrics(out metrics);
+        }
+        catch
+        {
+            // The XAML island can be between layout passes while it is hidden or
+            // shutting down. The host keeps its last valid bounds in that case.
+            metrics = default;
+            return false;
+        }
+    }
+
+    private bool TryCalculateCurrentSurfaceMetrics(out CaptureOverlaySurfaceMetrics metrics)
+    {
+        if (!_isLoaded)
+        {
+            metrics = default;
+            return false;
+        }
+
+        double fallbackScale = _captureArgs.Monitor.Scale;
+        double scale = RootPanel.XamlRoot?.RasterizationScale ?? fallbackScale;
+        if (!double.IsFinite(scale) || scale <= 0)
+        {
+            metrics = default;
+            return false;
+        }
+
+        bool showsToolbar = !ViewModel.HasRecordingError;
+        Size toolbarSize = GetToolbarSize(scale);
+        if (showsToolbar && IsPositive(toolbarSize.Width) && IsPositive(toolbarSize.Height))
+        {
+            _lastToolbarWidth = toolbarSize.Width;
+        }
+
+        double width = toolbarSize.Width;
+        double height = toolbarSize.Height;
+
+        if (!showsToolbar && IsPositive(_lastToolbarWidth))
+        {
+            width = _lastToolbarWidth;
+            RecordingErrorInfoBar.Width = width;
+            RecordingErrorInfoBar.Measure(new Size(width, double.PositiveInfinity));
+            height = Math.Max(RecordingErrorInfoBar.ActualHeight, RecordingErrorInfoBar.DesiredSize.Height);
+
+            // The binding and InfoBar template can complete on the next layout pass.
+            // Hide the shadow immediately by retaining a usable foreground height.
+            if (!IsPositive(height))
             {
-                _shadowVisual.Shadow = null;
-                _shadowVisual.Dispose();
-                _shadowVisual = null;
+                height = toolbarSize.Height;
             }
-
-            _shadow?.Dispose();
-            _shadow = null;
         }
-        catch { }
-    }
 
-    private void AddToolbarShadow()
-    {
-        try
+        if (!IsPositive(width) || !IsPositive(height))
         {
-            Compositor? compositor = ElementCompositionPreview.GetElementVisual(this).Compositor;
-
-            _shadow = compositor.CreateDropShadow();
-            _shadow.Color = Colors.Black;
-            _shadow.BlurRadius = 12;
-            _shadow.Opacity = 0.3f;
-            _shadow.Offset = new Vector3(0, 4, 0);
-
-            _shadowVisual = compositor.CreateSpriteVisual();
-            _shadowVisual.Shadow = _shadow;
-            _shadowVisual.Size = new Vector2((float)Toolbar.ActualWidth, (float)Toolbar.ActualHeight);
-
-            ElementCompositionPreview.SetElementChildVisual(ToolbarHost, _shadowVisual);
-
-            Toolbar.SizeChanged += Toolbar_SizeChanged;
+            metrics = default;
+            return false;
         }
-        catch { }
+
+        metrics = new(width, height, scale, showsToolbar);
+        return true;
     }
 
-    private void Toolbar_SizeChanged(object s, SizeChangedEventArgs e)
+    private Size GetToolbarSize(double scale)
     {
-        _shadowVisual?.Size = new Vector2((float)e.NewSize.Width, (float)e.NewSize.Height);
+        double availableWidth = _captureArgs.Monitor.MonitorBounds.Width / scale;
+        Size desiredSize = Toolbar.MeasureNaturalSize();
+        double width = Math.Min(desiredSize.Width, availableWidth);
+        double height = desiredSize.Height;
+
+        if (IsPositive(width) && IsPositive(height))
+        {
+            return new Size(width, height);
+        }
+
+        return new Size(Toolbar.ActualWidth, Toolbar.ActualHeight);
     }
+
+    private void OnSurfaceElementSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        QueueSurfaceMetricsUpdate();
+    }
+
+    private void OnSurfaceElementLayoutUpdated(object? sender, object e)
+    {
+        QueueSurfaceMetricsUpdate();
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(CaptureOverlayViewModel.HasRecordingError) &&
+            ViewModel.HasRecordingError)
+        {
+            PublishSurfaceMetrics();
+        }
+
+        QueueSurfaceMetricsUpdate();
+    }
+
+    private void AttachXamlRoot()
+    {
+        XamlRoot? xamlRoot = RootPanel.XamlRoot;
+        if (ReferenceEquals(_observedXamlRoot, xamlRoot))
+        {
+            return;
+        }
+
+        DetachXamlRoot();
+        _observedXamlRoot = xamlRoot;
+        if (_observedXamlRoot != null)
+        {
+            _observedXamlRoot.Changed += XamlRoot_Changed;
+        }
+    }
+
+    private void DetachXamlRoot()
+    {
+        if (_observedXamlRoot != null)
+        {
+            _observedXamlRoot.Changed -= XamlRoot_Changed;
+            _observedXamlRoot = null;
+        }
+    }
+
+    private void XamlRoot_Changed(XamlRoot sender, XamlRootChangedEventArgs args)
+    {
+        QueueSurfaceMetricsUpdate();
+    }
+
+    private void QueueSurfaceMetricsUpdate()
+    {
+        if (_unloaded || _surfaceUpdateQueued)
+        {
+            return;
+        }
+
+        _surfaceUpdateQueued = true;
+        if (!DispatcherQueue.TryEnqueue(() =>
+        {
+            _surfaceUpdateQueued = false;
+            PublishSurfaceMetrics();
+        }))
+        {
+            _surfaceUpdateQueued = false;
+        }
+    }
+
+    private void PublishSurfaceMetrics()
+    {
+        if (_unloaded)
+        {
+            return;
+        }
+
+        if (!TryGetCurrentSurfaceMetrics(out CaptureOverlaySurfaceMetrics metrics))
+        {
+            if (_lastPublishedMetricsWereValid)
+            {
+                _lastPublishedMetricsWereValid = false;
+                SurfaceMetricsInvalidated?.Invoke(this, EventArgs.Empty);
+            }
+            return;
+        }
+
+        if (_lastPublishedMetricsWereValid && metrics == _lastPublishedMetrics)
+        {
+            return;
+        }
+
+        _lastPublishedMetricsWereValid = true;
+        _lastPublishedMetrics = metrics;
+        SurfaceMetricsChanged?.Invoke(this, metrics);
+    }
+
+    private static bool IsPositive(double value) => double.IsFinite(value) && value > 0;
 
     private void UpdateRequestedAppTheme()
     {

--- a/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/CaptureOverlayHost.cs
+++ b/src/CaptureTool.Presentation.Windows.WinUI/Xaml/Windows/CaptureOverlayHost.cs
@@ -1,10 +1,14 @@
 using CaptureTool.Domain.Capture;
+using CaptureTool.Presentation.Features.CaptureOverlay;
 using CaptureTool.Presentation.Windows.WinUI.Utils;
 using CaptureTool.Presentation.Windows.WinUI.Xaml.Controls;
 using CaptureTool.Presentation.Windows.WinUI.Xaml.Views;
 using Microsoft.UI;
+using Microsoft.UI.Content;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.Win32.SafeHandles;
+using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Win32;
@@ -16,6 +20,13 @@ namespace CaptureTool.Presentation.Windows.WinUI.Xaml.Windows;
 
 internal sealed partial class CaptureOverlayHost : IDisposable
 {
+    private const int ToolbarTopInsetPixels = 14;
+    private const double ProvisionalToolbarWidthDips = 468;
+    private const double ProvisionalToolbarHeightDips = 48;
+
+    private static readonly HWND HWND_TOPMOST = new(-1);
+    private static readonly ConcurrentDictionary<nint, CaptureOverlayHost> _windowInstances = new();
+
     internal sealed partial class DestroyIconSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public DestroyIconSafeHandle(HINSTANCE hINSTANCE) : base(true)
@@ -30,13 +41,27 @@ internal sealed partial class CaptureOverlayHost : IDisposable
     }
 
     private HWND? _hwnd;
+    private HWND? _shadowHwnd;
     private HWND? _borderHwnd;
     private DesktopWindowXamlSource? _xamlSource;
+    private DesktopWindowXamlSource? _shadowXamlSource;
     private DesktopWindowXamlSource? _borderXamlSource;
     private CaptureOverlayView? _overlayView;
+    private CaptureOverlayShadowView? _shadowView;
     private CaptureOverlayBorder? _borderControl;
+    private Rectangle _monitorBounds;
+    private CaptureOverlayWindowLayout _windowLayout;
+    private double _layoutRasterizationScale;
+    private bool _hasWindowLayout;
+    private bool _showsToolbar = true;
+    private bool _activationRequested;
+    private bool _isToolbarShown;
+    private bool _isShadowInitializationPending;
+    private bool _isShadowReady;
+    private bool _isInitialized;
+    private bool _isClosed;
 
-    private static (HWND hwnd, DesktopWindowXamlSource xamlSource, CaptureOverlayView view) CreateCaptureOverlayWindow(NewCaptureArgs args)
+    private void CreateCaptureOverlayWindow(NewCaptureArgs args)
     {
         unsafe
         {
@@ -63,36 +88,121 @@ internal sealed partial class CaptureOverlayHost : IDisposable
             }
             PInvoke.RegisterClassEx(in wndClass);
 
-            HWND hwnd = PInvoke.CreateWindowEx(
+            int width = Math.Max(1, (int)Math.Ceiling(ProvisionalToolbarWidthDips * monitor.Scale));
+            int height = Math.Max(1, (int)Math.Ceiling(ProvisionalToolbarHeightDips * monitor.Scale));
+            int x = monitor.MonitorBounds.X +
+                (int)Math.Floor((monitor.MonitorBounds.Width - (double)width) / 2d);
+
+            _hwnd = PInvoke.CreateWindowEx(
                 WINDOW_EX_STYLE.WS_EX_LAYERED | WINDOW_EX_STYLE.WS_EX_TOPMOST | WINDOW_EX_STYLE.WS_EX_TOOLWINDOW,
                 className,
                 null,
-                WINDOW_STYLE.WS_VISIBLE | WINDOW_STYLE.WS_POPUP,
-                monitor.MonitorBounds.X, // x
-                monitor.MonitorBounds.Y + 14, // y + padding
-                (int)(468 * monitor.Scale), // w
-                (int)(76 * monitor.Scale), //h
+                WINDOW_STYLE.WS_POPUP,
+                x,
+                monitor.MonitorBounds.Y + ToolbarTopInsetPixels,
+                width,
+                height,
                 new(IntPtr.Zero),
                 null,
                 new DestroyIconSafeHandle(wndClass.hInstance),
                 null);
 
-            PInvoke.SetWindowDisplayAffinity(hwnd, WINDOW_DISPLAY_AFFINITY.WDA_EXCLUDEFROMCAPTURE);
+            EnsureWindowCreated(_hwnd.Value, className);
+            if (!PInvoke.SetWindowDisplayAffinity(
+                _hwnd.Value,
+                WINDOW_DISPLAY_AFFINITY.WDA_EXCLUDEFROMCAPTURE))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "Failed to exclude the capture toolbar from screen capture.");
+            }
 
-            DesktopWindowXamlSource xamlSource = new();
-            WindowId windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
-            xamlSource.Initialize(windowId);
+            _xamlSource = new DesktopWindowXamlSource();
+            WindowId windowId = Win32Interop.GetWindowIdFromWindow(_hwnd.Value);
+            _xamlSource.Initialize(windowId);
+            ConfigureXamlSourceToFillWindow(_xamlSource);
 
-            CaptureOverlayView view = new(args);
-            xamlSource.Content = view;
-
-            Win32WindowHelpers.HorizontalCenterOnScreen(hwnd);
-
-            return (hwnd, xamlSource, view);
+            _overlayView = new CaptureOverlayView(args);
         }
     }
 
-    private static (HWND hwnd, DesktopWindowXamlSource xamlSource, CaptureOverlayBorder border) CreateCaptureOverlayBorderWindow(MonitorCaptureResult monitor, Rectangle area)
+    private unsafe void TryCreateShadowWindow()
+    {
+        const string className = "CaptureOverlayWindowShadow";
+
+        try
+        {
+            WNDCLASSEXW wndClass = new()
+            {
+                cbSize = (uint)Marshal.SizeOf<WNDCLASSEXW>(),
+                style = 0,
+                lpfnWndProc = &ShadowWindowProc,
+                cbClsExtra = 0,
+                cbWndExtra = 0,
+                hInstance = HINSTANCE.Null,
+                hIcon = HICON.Null,
+                hCursor = HCURSOR.Null,
+                hbrBackground = HBRUSH.Null,
+                lpszMenuName = null,
+                hIconSm = HICON.Null
+            };
+            fixed (char* name = className)
+            {
+                wndClass.lpszClassName = name;
+            }
+            PInvoke.RegisterClassEx(in wndClass);
+
+            _shadowHwnd = PInvoke.CreateWindowEx(
+                WINDOW_EX_STYLE.WS_EX_LAYERED |
+                WINDOW_EX_STYLE.WS_EX_TOPMOST |
+                WINDOW_EX_STYLE.WS_EX_TOOLWINDOW |
+                WINDOW_EX_STYLE.WS_EX_TRANSPARENT |
+                WINDOW_EX_STYLE.WS_EX_NOACTIVATE,
+                className,
+                null,
+                WINDOW_STYLE.WS_POPUP,
+                _monitorBounds.X,
+                _monitorBounds.Y + ToolbarTopInsetPixels,
+                1,
+                1,
+                HWND.Null,
+                null,
+                new DestroyIconSafeHandle(wndClass.hInstance),
+                null);
+
+            EnsureWindowCreated(_shadowHwnd.Value, className);
+            if (!PInvoke.SetWindowDisplayAffinity(
+                _shadowHwnd.Value,
+                WINDOW_DISPLAY_AFFINITY.WDA_EXCLUDEFROMCAPTURE))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "Failed to exclude the toolbar shadow from screen capture.");
+            }
+
+            _shadowXamlSource = new DesktopWindowXamlSource();
+            WindowId windowId = Win32Interop.GetWindowIdFromWindow(_shadowHwnd.Value);
+            _shadowXamlSource.Initialize(windowId);
+            ConfigureXamlSourceToFillWindow(_shadowXamlSource);
+
+            _shadowView = new CaptureOverlayShadowView();
+            _shadowView.InitializationCompleted += ShadowView_InitializationCompleted;
+            _isShadowInitializationPending = true;
+            _shadowXamlSource.Content = _shadowView;
+            if (!_shadowView.QueueInitialization())
+            {
+                throw new InvalidOperationException("Failed to queue toolbar shadow initialization.");
+            }
+        }
+        catch
+        {
+            // A shadow is cosmetic. Keep the exact-sized interactive toolbar if
+            // the companion window or its composition surface cannot be created.
+            DestroyShadowWindow();
+        }
+    }
+
+    private void CreateCaptureOverlayBorderWindow(MonitorCaptureResult monitor, Rectangle area)
     {
         unsafe
         {
@@ -124,7 +234,7 @@ internal sealed partial class CaptureOverlayHost : IDisposable
             int scaledWidth = (int)(area.Width * scaling);
             int scaledHeight = (int)(area.Height * scaling);
 
-            HWND borderHwnd = PInvoke.CreateWindowEx(
+            _borderHwnd = PInvoke.CreateWindowEx(
                 WINDOW_EX_STYLE.WS_EX_LAYERED | WINDOW_EX_STYLE.WS_EX_TOPMOST | WINDOW_EX_STYLE.WS_EX_TOOLWINDOW | WINDOW_EX_STYLE.WS_EX_TRANSPARENT,
                 borderClassName,
                 null,
@@ -138,52 +248,117 @@ internal sealed partial class CaptureOverlayHost : IDisposable
                 new DestroyIconSafeHandle(borderWndClass.hInstance),
                 null);
 
-            PInvoke.SetWindowDisplayAffinity(borderHwnd, WINDOW_DISPLAY_AFFINITY.WDA_EXCLUDEFROMCAPTURE);
+            EnsureWindowCreated(_borderHwnd.Value, borderClassName);
+            if (!PInvoke.SetWindowDisplayAffinity(
+                _borderHwnd.Value,
+                WINDOW_DISPLAY_AFFINITY.WDA_EXCLUDEFROMCAPTURE))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(),
+                    "Failed to exclude the capture border from screen capture.");
+            }
 
-            DesktopWindowXamlSource xamlSource = new();
-            WindowId windowId = Win32Interop.GetWindowIdFromWindow(borderHwnd);
-            xamlSource.Initialize(windowId);
+            _borderXamlSource = new DesktopWindowXamlSource();
+            WindowId windowId = Win32Interop.GetWindowIdFromWindow(_borderHwnd.Value);
+            _borderXamlSource.Initialize(windowId);
+            ConfigureXamlSourceToFillWindow(_borderXamlSource);
 
-            CaptureOverlayBorder border = new();
-            xamlSource.Content = border;
-
-            return (borderHwnd, xamlSource, border);
+            _borderControl = new CaptureOverlayBorder();
+            _borderXamlSource.Content = _borderControl;
         }
     }
 
-    public void Initialize(NewCaptureArgs args)
+    public unsafe void Initialize(NewCaptureArgs args)
     {
-        if (_hwnd != null && _borderHwnd != null)
+        if (_isInitialized || _isClosed)
         {
             return;
         }
 
         var monitor = args.Monitor;
         var area = args.Area;
+        _monitorBounds = monitor.MonitorBounds;
 
-        var overlayResult = CreateCaptureOverlayWindow(args);
-        _hwnd = overlayResult.hwnd;
-        _xamlSource = overlayResult.xamlSource;
-        _overlayView = overlayResult.view;
+        try
+        {
+            CreateCaptureOverlayWindow(args);
+            HWND hwnd = _hwnd ?? throw new InvalidOperationException("The capture toolbar window was not created.");
+            CaptureOverlayView overlayView = _overlayView ?? throw new InvalidOperationException("The capture toolbar view was not created.");
+            _windowInstances[(nint)hwnd.Value] = this;
+            overlayView.SurfaceMetricsChanged += OverlayView_SurfaceMetricsChanged;
+            overlayView.SurfaceMetricsInvalidated += OverlayView_SurfaceMetricsInvalidated;
 
-        var (hwnd, xamlSource, border) = CreateCaptureOverlayBorderWindow(monitor, area);
-        _borderHwnd = hwnd;
-        _borderXamlSource = xamlSource;
-        _borderControl = border;
+            // Attaching the hidden island raises Loaded and queues the first safe
+            // measurement. Calling Measure here initializes nested x:Bind trees too early.
+            _xamlSource!.Content = overlayView;
+
+            TryCreateShadowWindow();
+
+            CreateCaptureOverlayBorderWindow(monitor, area);
+
+            _isInitialized = true;
+        }
+        catch
+        {
+            Close();
+            throw;
+        }
     }
 
     public void Activate()
     {
-        if (_hwnd != null && _borderHwnd != null)
+        if (_isClosed || _hwnd == null)
+        {
+            return;
+        }
+
+        _activationRequested = true;
+        TryShowAndActivateToolbar();
+    }
+
+    private void TryShowAndActivateToolbar()
+    {
+        if (!_activationRequested ||
+            !_hasWindowLayout ||
+            _hwnd == null ||
+            (_showsToolbar && _isShadowInitializationPending) ||
+            !ApplyWindowLayout(showWindow: true))
+        {
+            return;
+        }
+
+        if (_borderHwnd != null)
         {
             Win32WindowHelpers.SetActiveWindow(_borderHwnd.Value);
-            Win32WindowHelpers.SetActiveWindow(_hwnd.Value);
-            Win32WindowHelpers.SetForegroundWindow(_hwnd.Value);
         }
+
+        Win32WindowHelpers.SetActiveWindow(_hwnd.Value);
+        Win32WindowHelpers.SetForegroundWindow(_hwnd.Value);
+
+        // Foreground activation can change the order of topmost windows. Put the
+        // unowned shadow immediately behind the toolbar again afterwards.
+        PositionShadowWindow(showWindow: true);
     }
 
     public void Close()
     {
+        if (_isClosed)
+        {
+            return;
+        }
+
+        _isClosed = true;
+        _activationRequested = false;
+
+        HideSurfaceWindows();
+
+        if (_overlayView != null)
+        {
+            _overlayView.SurfaceMetricsChanged -= OverlayView_SurfaceMetricsChanged;
+            _overlayView.SurfaceMetricsInvalidated -= OverlayView_SurfaceMetricsInvalidated;
+        }
+
+        DestroyShadowWindow();
         DestroyBorderWindow();
         DestroyOverlayWindow();
     }
@@ -193,25 +368,176 @@ internal sealed partial class CaptureOverlayHost : IDisposable
         DestroyBorderWindow();
     }
 
-    private void DestroyOverlayWindow()
+    private void OverlayView_SurfaceMetricsChanged(
+        object? sender,
+        CaptureOverlaySurfaceMetrics metrics)
     {
-        if (_overlayView != null)
+        if (_isClosed)
         {
-            try
-            {
-                _overlayView.ViewModel?.Dispose();
-            }
-            catch { }
-            _overlayView = null;
+            return;
         }
 
-        if (_xamlSource != null)
+        UpdateWindowLayout(metrics);
+    }
+
+    private void OverlayView_SurfaceMetricsInvalidated(object? sender, EventArgs e)
+    {
+        if (!_isClosed)
+        {
+            HideSurfaceWindows();
+        }
+    }
+
+    private void ShadowView_InitializationCompleted(
+        object? sender,
+        CaptureOverlayShadowInitializationEventArgs e)
+    {
+        if (_isClosed || !ReferenceEquals(sender, _shadowView))
+        {
+            return;
+        }
+
+        _isShadowInitializationPending = false;
+        _isShadowReady = e.Succeeded;
+        if (!e.Succeeded)
+        {
+            DestroyShadowWindow();
+        }
+
+        if (_activationRequested && !_isToolbarShown)
+        {
+            TryShowAndActivateToolbar();
+        }
+        else
+        {
+            PositionShadowWindow(_isToolbarShown);
+        }
+    }
+
+    private void UpdateWindowLayout(CaptureOverlaySurfaceMetrics metrics)
+    {
+        if (!CaptureOverlayWindowGeometry.TryCalculate(
+            _monitorBounds,
+            metrics.Width,
+            metrics.Height,
+            metrics.RasterizationScale,
+            ToolbarTopInsetPixels,
+            CaptureOverlayShadowView.ShadowPaddingDips,
+            out CaptureOverlayWindowLayout layout))
+        {
+            HideSurfaceWindows();
+            return;
+        }
+
+        bool physicalLayoutChanged =
+            !_hasWindowLayout ||
+            layout != _windowLayout ||
+            metrics.ShowsToolbar != _showsToolbar;
+        bool casterScaleChanged =
+            !_hasWindowLayout ||
+            metrics.RasterizationScale != _layoutRasterizationScale;
+
+        _windowLayout = layout;
+        _layoutRasterizationScale = metrics.RasterizationScale;
+        _hasWindowLayout = true;
+        _showsToolbar = metrics.ShowsToolbar;
+
+        if (physicalLayoutChanged || casterScaleChanged)
+        {
+            Point casterOffset = layout.ShadowCasterOffset;
+            _shadowView?.UpdateCaster(
+                casterOffset.X,
+                casterOffset.Y,
+                layout.ToolbarBounds.Width,
+                layout.ToolbarBounds.Height,
+                metrics.RasterizationScale);
+        }
+
+        if (!physicalLayoutChanged)
+        {
+            if (_activationRequested && !_isToolbarShown)
+            {
+                TryShowAndActivateToolbar();
+            }
+            return;
+        }
+
+        if (_activationRequested && !_isToolbarShown)
+        {
+            TryShowAndActivateToolbar();
+        }
+        else
+        {
+            ApplyWindowLayout(_activationRequested);
+        }
+    }
+
+    private bool ApplyWindowLayout(bool showWindow)
+    {
+        if (!_hasWindowLayout || _hwnd == null)
+        {
+            return false;
+        }
+
+        Rectangle toolbarBounds = _windowLayout.ToolbarBounds;
+        SET_WINDOW_POS_FLAGS toolbarFlags = SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE;
+        toolbarFlags |= showWindow
+            ? SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
+            : SET_WINDOW_POS_FLAGS.SWP_HIDEWINDOW;
+
+        if (!PInvoke.SetWindowPos(
+            _hwnd.Value,
+            HWND_TOPMOST,
+            toolbarBounds.X,
+            toolbarBounds.Y,
+            toolbarBounds.Width,
+            toolbarBounds.Height,
+            toolbarFlags))
+        {
+            HideSurfaceWindows();
+            return false;
+        }
+
+        _isToolbarShown = showWindow;
+        PositionShadowWindow(showWindow);
+        return true;
+    }
+
+    private void PositionShadowWindow(bool showWindow)
+    {
+        if (!_hasWindowLayout || _hwnd == null || _shadowHwnd == null)
+        {
+            return;
+        }
+
+        Rectangle shadowBounds = _windowLayout.ShadowBounds;
+        SET_WINDOW_POS_FLAGS shadowFlags = SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE;
+        shadowFlags |= showWindow && _showsToolbar && _isShadowReady
+            ? SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
+            : SET_WINDOW_POS_FLAGS.SWP_HIDEWINDOW;
+
+        if (!PInvoke.SetWindowPos(
+            _shadowHwnd.Value,
+            _hwnd.Value,
+            shadowBounds.X,
+            shadowBounds.Y,
+            shadowBounds.Width,
+            shadowBounds.Height,
+            shadowFlags))
+        {
+            DestroyShadowWindow();
+        }
+    }
+
+    private void HideSurfaceWindows()
+    {
+        _isToolbarShown = false;
+
+        if (_shadowHwnd != null)
         {
             try
             {
-                _xamlSource.Content = null;
-                (_xamlSource as IDisposable)?.Dispose();
-                _xamlSource = null;
+                PInvoke.ShowWindow(_shadowHwnd.Value, SHOW_WINDOW_CMD.SW_HIDE);
             }
             catch { }
         }
@@ -220,52 +546,192 @@ internal sealed partial class CaptureOverlayHost : IDisposable
         {
             try
             {
-                PInvoke.DestroyWindow(_hwnd.Value);
+                PInvoke.ShowWindow(_hwnd.Value, SHOW_WINDOW_CMD.SW_HIDE);
             }
             catch { }
-            _hwnd = null;
+        }
+    }
+
+    private void DestroyShadowWindow()
+    {
+        _isShadowInitializationPending = false;
+        _isShadowReady = false;
+
+        CaptureOverlayShadowView? shadowView = _shadowView;
+        _shadowView = null;
+        try
+        {
+            if (shadowView != null)
+            {
+                shadowView.InitializationCompleted -= ShadowView_InitializationCompleted;
+                shadowView.Dispose();
+            }
+        }
+        catch { }
+
+        DesktopWindowXamlSource? shadowXamlSource = _shadowXamlSource;
+        _shadowXamlSource = null;
+        if (shadowXamlSource != null)
+        {
+            try
+            {
+                shadowXamlSource.Content = null;
+            }
+            catch { }
+
+            try
+            {
+                (shadowXamlSource as IDisposable)?.Dispose();
+            }
+            catch { }
+        }
+
+        HWND? shadowHwnd = _shadowHwnd;
+        _shadowHwnd = null;
+        if (shadowHwnd != null)
+        {
+            try
+            {
+                PInvoke.DestroyWindow(shadowHwnd.Value);
+            }
+            catch { }
+        }
+    }
+
+    private unsafe void DestroyOverlayWindow()
+    {
+        CaptureOverlayView? overlayView = _overlayView;
+        _overlayView = null;
+        if (overlayView != null)
+        {
+            try
+            {
+                overlayView.SurfaceMetricsChanged -= OverlayView_SurfaceMetricsChanged;
+                overlayView.SurfaceMetricsInvalidated -= OverlayView_SurfaceMetricsInvalidated;
+                overlayView.ViewModel?.Dispose();
+            }
+            catch { }
+        }
+
+        DesktopWindowXamlSource? xamlSource = _xamlSource;
+        _xamlSource = null;
+        if (xamlSource != null)
+        {
+            try
+            {
+                xamlSource.Content = null;
+            }
+            catch { }
+
+            try
+            {
+                (xamlSource as IDisposable)?.Dispose();
+            }
+            catch { }
+        }
+
+        HWND? hwnd = _hwnd;
+        _hwnd = null;
+        if (hwnd != null)
+        {
+            _windowInstances.TryRemove((nint)hwnd.Value.Value, out _);
+            try
+            {
+                PInvoke.DestroyWindow(hwnd.Value);
+            }
+            catch { }
         }
     }
 
     private void DestroyBorderWindow()
     {
-        if (_borderControl != null)
-        {
-            _borderControl = null;
-        }
+        _borderControl = null;
 
-        if (_borderXamlSource != null)
+        DesktopWindowXamlSource? borderXamlSource = _borderXamlSource;
+        _borderXamlSource = null;
+        if (borderXamlSource != null)
         {
             try
             {
-                _borderXamlSource.Content = null;
-                (_borderXamlSource as IDisposable)?.Dispose();
-                _borderXamlSource = null;
+                borderXamlSource.Content = null;
+            }
+            catch { }
+
+            try
+            {
+                (borderXamlSource as IDisposable)?.Dispose();
             }
             catch { }
         }
 
-        if (_borderHwnd != null)
+        HWND? borderHwnd = _borderHwnd;
+        _borderHwnd = null;
+        if (borderHwnd != null)
         {
             try
             {
-                PInvoke.DestroyWindow(_borderHwnd.Value);
+                PInvoke.DestroyWindow(borderHwnd.Value);
             }
             catch { }
-            _borderHwnd = null;
+        }
+    }
+
+    private static unsafe void EnsureWindowCreated(HWND hwnd, string className)
+    {
+        if ((nint)hwnd.Value == IntPtr.Zero)
+        {
+            throw new Win32Exception(
+                Marshal.GetLastWin32Error(),
+                $"Failed to create the {className} window.");
+        }
+    }
+
+    private static void ConfigureXamlSourceToFillWindow(DesktopWindowXamlSource xamlSource)
+    {
+        if (xamlSource.SiteBridge is DesktopChildSiteBridge childSiteBridge)
+        {
+            childSiteBridge.ResizePolicy = ContentSizePolicy.ResizeContentToParentWindow;
         }
     }
 
     [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
-    private static LRESULT WindowProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
+    private static unsafe LRESULT WindowProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
     {
-        return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+        const uint WM_ACTIVATE = 0x0006;
+        const int WA_INACTIVE = 0;
+
+        LRESULT result = PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+        if (msg == WM_ACTIVATE &&
+            ((int)wParam.Value & 0xFFFF) != WA_INACTIVE &&
+            _windowInstances.TryGetValue((nint)hwnd.Value, out CaptureOverlayHost? host) &&
+            !host._isClosed)
+        {
+            host.PositionShadowWindow(host._isToolbarShown);
+        }
+
+        return result;
     }
 
     [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
     private static LRESULT BorderWindowProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
     {
         return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+    private static LRESULT ShadowWindowProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
+    {
+        const uint WM_MOUSEACTIVATE = 0x0021;
+        const uint WM_NCHITTEST = 0x0084;
+        const int MA_NOACTIVATE = 3;
+        const int HTTRANSPARENT = -1;
+
+        return msg switch
+        {
+            WM_NCHITTEST => new LRESULT(HTTRANSPARENT),
+            WM_MOUSEACTIVATE => new LRESULT(MA_NOACTIVATE),
+            _ => PInvoke.DefWindowProc(hwnd, msg, wParam, lParam)
+        };
     }
 
     public void Dispose()

--- a/src/CaptureTool.Presentation/Features/CaptureOverlay/CaptureOverlayViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/CaptureOverlay/CaptureOverlayViewModel.cs
@@ -507,9 +507,20 @@ public sealed partial class CaptureOverlayViewModel : LoadableViewModelBase<Capt
             return;
         }
 
-        IsRecording = false;
         StopTimer();
-        await _stopVideoCaptureCommand.ExecuteAsync(new StopVideoCaptureRequest(), CancellationToken.None);
+        try
+        {
+            await _stopVideoCaptureCommand.ExecuteAsync(new StopVideoCaptureRequest(), CancellationToken.None);
+        }
+        finally
+        {
+            // Keep the recording controls stable while the stop flow navigates away.
+            // If navigation is rejected, switch to the idle layout once stopping is complete.
+            if (!_isDisposed)
+            {
+                IsRecording = false;
+            }
+        }
     }
 
     private async Task TogglePauseResumeAsync()

--- a/src/CaptureTool.Presentation/Features/CaptureOverlay/CaptureOverlayViewModel.cs
+++ b/src/CaptureTool.Presentation/Features/CaptureOverlay/CaptureOverlayViewModel.cs
@@ -321,6 +321,11 @@ public sealed partial class CaptureOverlayViewModel : LoadableViewModelBase<Capt
 
     public override void Dispose()
     {
+        if (_isDisposed)
+        {
+            return;
+        }
+
         _isDisposed = true;
         IsStarting = false;
         CancelRecordingStartWait();

--- a/src/CaptureTool.Presentation/Features/CaptureOverlay/CaptureOverlayWindowGeometry.cs
+++ b/src/CaptureTool.Presentation/Features/CaptureOverlay/CaptureOverlayWindowGeometry.cs
@@ -1,0 +1,111 @@
+using System.Drawing;
+
+namespace CaptureTool.Presentation.Features.CaptureOverlay;
+
+internal readonly record struct CaptureOverlayWindowLayout(
+    Rectangle ToolbarBounds,
+    Rectangle ShadowBounds)
+{
+    public Point ShadowCasterOffset => new(
+        ToolbarBounds.X - ShadowBounds.X,
+        ToolbarBounds.Y - ShadowBounds.Y);
+}
+
+internal static class CaptureOverlayWindowGeometry
+{
+    public static bool TryCalculate(
+        Rectangle monitorBounds,
+        double logicalContentWidth,
+        double logicalContentHeight,
+        double rasterizationScale,
+        int topInsetPixels,
+        double shadowPaddingDips,
+        out CaptureOverlayWindowLayout layout)
+    {
+        layout = default;
+
+        if (monitorBounds.Width <= 0 ||
+            monitorBounds.Height <= 0 ||
+            !IsPositiveFinite(logicalContentWidth) ||
+            !IsPositiveFinite(logicalContentHeight) ||
+            !IsPositiveFinite(rasterizationScale) ||
+            topInsetPixels <= 0 ||
+            !IsPositiveFinite(shadowPaddingDips))
+        {
+            return false;
+        }
+
+        if (!TryRoundUpToPhysicalPixels(logicalContentWidth, rasterizationScale, out int contentWidth) ||
+            !TryRoundUpToPhysicalPixels(logicalContentHeight, rasterizationScale, out int contentHeight) ||
+            !TryRoundUpToPhysicalPixels(shadowPaddingDips, rasterizationScale, out int shadowPadding))
+        {
+            return false;
+        }
+
+        long toolbarX = monitorBounds.X +
+            (long)Math.Floor((monitorBounds.Width - (double)contentWidth) / 2d);
+        long toolbarY = (long)monitorBounds.Y + topInsetPixels;
+        long toolbarRight = toolbarX + contentWidth;
+        long toolbarBottom = toolbarY + contentHeight;
+
+        long shadowX = toolbarX - shadowPadding;
+        long shadowY = toolbarY - shadowPadding;
+        long shadowRight = toolbarRight + shadowPadding;
+        long shadowBottom = toolbarBottom + shadowPadding;
+
+        if (!IsValidCoordinate(toolbarX) ||
+            !IsValidCoordinate(toolbarY) ||
+            !IsValidCoordinate(toolbarRight) ||
+            !IsValidCoordinate(toolbarBottom) ||
+            !IsValidCoordinate(shadowX) ||
+            !IsValidCoordinate(shadowY) ||
+            !IsValidCoordinate(shadowRight) ||
+            !IsValidCoordinate(shadowBottom))
+        {
+            return false;
+        }
+
+        long shadowWidth = shadowRight - shadowX;
+        long shadowHeight = shadowBottom - shadowY;
+        if (shadowWidth > int.MaxValue || shadowHeight > int.MaxValue)
+        {
+            return false;
+        }
+
+        Rectangle toolbarBounds = new(
+            (int)toolbarX,
+            (int)toolbarY,
+            contentWidth,
+            contentHeight);
+        Rectangle shadowBounds = new(
+            (int)shadowX,
+            (int)shadowY,
+            (int)shadowWidth,
+            (int)shadowHeight);
+
+        layout = new CaptureOverlayWindowLayout(toolbarBounds, shadowBounds);
+        return true;
+    }
+
+    private static bool TryRoundUpToPhysicalPixels(
+        double logicalValue,
+        double rasterizationScale,
+        out int physicalValue)
+    {
+        double scaledValue = logicalValue * rasterizationScale;
+        if (!IsPositiveFinite(scaledValue) || scaledValue > int.MaxValue)
+        {
+            physicalValue = 0;
+            return false;
+        }
+
+        physicalValue = (int)Math.Ceiling(scaledValue);
+        return physicalValue > 0;
+    }
+
+    private static bool IsPositiveFinite(double value)
+        => value > 0 && double.IsFinite(value);
+
+    private static bool IsValidCoordinate(long value)
+        => value >= int.MinValue && value <= int.MaxValue;
+}

--- a/tests/CaptureTool.Infrastructure.Windows.Tests/Clipboard/WindowsClipboardServiceTests.cs
+++ b/tests/CaptureTool.Infrastructure.Windows.Tests/Clipboard/WindowsClipboardServiceTests.cs
@@ -1,0 +1,31 @@
+using CaptureTool.Application.Abstractions.Clipboard;
+using CaptureTool.Infrastructure.Windows.Clipboard;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+
+namespace CaptureTool.Infrastructure.Windows.Tests.Clipboard;
+
+[TestClass]
+public sealed class WindowsClipboardServiceTests
+{
+    [TestMethod]
+    public async Task CreateFileDataPackageAsync_ShouldMarshalStorageItemsToWinRT()
+    {
+        string filePath = Path.GetTempFileName();
+
+        try
+        {
+            DataPackage? package = await WindowsClipboardService.CreateFileDataPackageAsync(
+                new ClipboardFile(filePath));
+
+            Assert.IsNotNull(package);
+            IReadOnlyList<IStorageItem> items = await package.GetView().GetStorageItemsAsync();
+            Assert.HasCount(1, items);
+            Assert.AreEqual(filePath, items[0].Path);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+}

--- a/tests/CaptureTool.Presentation.Tests/Features/CaptureOverlayViewModelAudioInputTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/CaptureOverlayViewModelAudioInputTests.cs
@@ -121,6 +121,20 @@ public sealed class CaptureOverlayViewModelAudioInputTests
     }
 
     [TestMethod]
+    public void Dispose_WhenCalledMoreThanOnce_ShouldReleaseResourcesOnce()
+    {
+        TestContext context = CreateViewModel([]);
+        context.ViewModel.Load(CreateOptions());
+
+        context.ViewModel.Dispose();
+        context.ViewModel.Dispose();
+
+        context.AudioInputDetection.Verify(
+            service => service.StopWatching(),
+            Times.Once);
+    }
+
+    [TestMethod]
     public async Task StartVideoCaptureCommand_WhenUseCaseFails_ShouldResetStateAndShowError()
     {
         TestContext context = CreateViewModel([]);

--- a/tests/CaptureTool.Presentation.Tests/Features/CaptureOverlayViewModelAudioInputTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/CaptureOverlayViewModelAudioInputTests.cs
@@ -180,6 +180,61 @@ public sealed class CaptureOverlayViewModelAudioInputTests
     }
 
     [TestMethod]
+    public async Task StopVideoCaptureCommand_ShouldKeepRecordingLayoutUntilStopCompletes()
+    {
+        TestContext context = CreateViewModel([]);
+        TaskCompletionSource<UseCaseResponse<StopVideoCaptureResponse>> stopCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        context.StopVideoCapture
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<StopVideoCaptureRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(stopCompletionSource.Task);
+        context.ViewModel.Load(CreateOptions());
+
+        Task startTask = context.ViewModel.StartVideoCaptureCommand.ExecuteAsync(null);
+        context.VideoCaptureState.Raise(state => state.RecordingStarted += null!, EventArgs.Empty);
+        await startTask;
+
+        Task stopTask = context.ViewModel.StopVideoCaptureCommand.ExecuteAsync(null);
+
+        Assert.IsTrue(context.ViewModel.IsRecording);
+
+        stopCompletionSource.SetResult(
+            UseCaseResponse<StopVideoCaptureResponse>.Success(new StopVideoCaptureResponse()));
+        await stopTask;
+
+        Assert.IsFalse(context.ViewModel.IsRecording);
+        context.ViewModel.Dispose();
+    }
+
+    [TestMethod]
+    public async Task StopVideoCaptureCommand_WhenNavigationDisposesOverlay_ShouldNotSwitchLayouts()
+    {
+        TestContext context = CreateViewModel([]);
+        TaskCompletionSource<UseCaseResponse<StopVideoCaptureResponse>> stopCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        context.StopVideoCapture
+            .Setup(useCase => useCase.ExecuteAsync(
+                It.IsAny<StopVideoCaptureRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(stopCompletionSource.Task);
+        context.ViewModel.Load(CreateOptions());
+
+        Task startTask = context.ViewModel.StartVideoCaptureCommand.ExecuteAsync(null);
+        context.VideoCaptureState.Raise(state => state.RecordingStarted += null!, EventArgs.Empty);
+        await startTask;
+
+        Task stopTask = context.ViewModel.StopVideoCaptureCommand.ExecuteAsync(null);
+        context.ViewModel.Dispose();
+        stopCompletionSource.SetResult(
+            UseCaseResponse<StopVideoCaptureResponse>.Success(new StopVideoCaptureResponse()));
+        await stopTask;
+
+        Assert.IsTrue(context.ViewModel.IsRecording);
+    }
+
+    [TestMethod]
     public void AudioInputSourcesChanged_ShouldSelectDefaultInputAndAppendDefaultSuffix()
     {
         AudioInputSource[] sources =
@@ -419,6 +474,11 @@ public sealed class CaptureOverlayViewModelAudioInputTests
             .Setup(useCase => useCase.ExecuteAsync(It.IsAny<CancelVideoCaptureRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(UseCaseResponse<CancelVideoCaptureResponse>.Success(new CancelVideoCaptureResponse()));
 
+        Mock<IStopVideoCaptureUseCase> stopVideoCapture = new();
+        stopVideoCapture
+            .Setup(useCase => useCase.ExecuteAsync(It.IsAny<StopVideoCaptureRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UseCaseResponse<StopVideoCaptureResponse>.Success(new StopVideoCaptureResponse()));
+
         Mock<IPrepareVideoCaptureUseCase> prepareVideoCapture = new();
         prepareVideoCapture
             .Setup(useCase => useCase.ExecuteAsync(It.IsAny<PrepareVideoCaptureRequest>(), It.IsAny<CancellationToken>()))
@@ -508,7 +568,7 @@ public sealed class CaptureOverlayViewModelAudioInputTests
             Mock.Of<IGoBackFromCaptureOverlayUseCase>(),
             startVideoCapture.Object,
             cancelVideoCapture.Object,
-            Mock.Of<IStopVideoCaptureUseCase>(),
+            stopVideoCapture.Object,
             toggleDesktopAudio.Object,
             setDesktopAudioVolume.Object,
             Mock.Of<IToggleVideoCapturePauseResumeUseCase>(),
@@ -529,6 +589,7 @@ public sealed class CaptureOverlayViewModelAudioInputTests
             videoCaptureState,
             startVideoCapture,
             cancelVideoCapture,
+            stopVideoCapture,
             toggleDesktopAudio,
             setDesktopAudioVolume,
             selectAudioInputSource,
@@ -562,6 +623,7 @@ public sealed class CaptureOverlayViewModelAudioInputTests
         Mock<IVideoCaptureState> VideoCaptureState,
         Mock<IStartVideoCaptureUseCase> StartVideoCapture,
         Mock<ICancelVideoCaptureUseCase> CancelVideoCapture,
+        Mock<IStopVideoCaptureUseCase> StopVideoCapture,
         Mock<IToggleVideoCaptureDesktopAudioUseCase> ToggleDesktopAudio,
         Mock<ISetVideoCaptureDesktopAudioVolumeUseCase> SetDesktopAudioVolume,
         Mock<ISelectAudioInputSourceUseCase> SelectAudioInputSource,

--- a/tests/CaptureTool.Presentation.Tests/Features/CaptureOverlayWindowGeometryTests.cs
+++ b/tests/CaptureTool.Presentation.Tests/Features/CaptureOverlayWindowGeometryTests.cs
@@ -1,0 +1,280 @@
+using CaptureTool.Presentation.Features.CaptureOverlay;
+using System.Drawing;
+
+namespace CaptureTool.Presentation.Tests.Features;
+
+[TestClass]
+public sealed class CaptureOverlayWindowGeometryTests
+{
+    private const int TopInsetPixels = 14;
+    private const double ShadowPaddingDips = 16d;
+
+    [TestMethod]
+    public void TryCalculate_At100Percent_CentersToolbarAndInflatesShadow()
+    {
+        Rectangle monitorBounds = new(100, 200, 1920, 1080);
+
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            400,
+            60,
+            1d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsTrue(calculated);
+        Assert.AreEqual(new Rectangle(860, 214, 400, 60), layout.ToolbarBounds);
+        Assert.AreEqual(new Rectangle(844, 198, 432, 92), layout.ShadowBounds);
+        Assert.AreEqual(new Point(16, 16), layout.ShadowCasterOffset);
+    }
+
+    [TestMethod]
+    public void TryCalculate_At125Percent_CeilsFractionalContentAndPadding()
+    {
+        Rectangle monitorBounds = new(100, 200, 1501, 900);
+
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            333.2,
+            51.3,
+            1.25d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsTrue(calculated);
+        Assert.AreEqual(new Rectangle(642, 214, 417, 65), layout.ToolbarBounds);
+        Assert.AreEqual(new Rectangle(622, 194, 457, 105), layout.ShadowBounds);
+        Assert.AreEqual(new Point(20, 20), layout.ShadowCasterOffset);
+    }
+
+    [TestMethod]
+    public void TryCalculate_At150Percent_SupportsNegativeMonitorOrigin()
+    {
+        Rectangle monitorBounds = new(-1920, -200, 1920, 1080);
+
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            401.25,
+            59.5,
+            1.5d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsTrue(calculated);
+        Assert.AreEqual(new Rectangle(-1261, -186, 602, 90), layout.ToolbarBounds);
+        Assert.AreEqual(new Rectangle(-1285, -210, 650, 138), layout.ShadowBounds);
+        Assert.AreEqual(new Point(24, 24), layout.ShadowCasterOffset);
+    }
+
+    [TestMethod]
+    public void TryCalculate_At200Percent_ScalesContentAndShadowButNotPhysicalTopInset()
+    {
+        Rectangle monitorBounds = new(1920, 0, 3840, 2160);
+
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            468,
+            76,
+            2d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsTrue(calculated);
+        Assert.AreEqual(new Rectangle(3372, 14, 936, 152), layout.ToolbarBounds);
+        Assert.AreEqual(new Rectangle(3340, -18, 1000, 216), layout.ShadowBounds);
+        Assert.AreEqual(new Point(32, 32), layout.ShadowCasterOffset);
+    }
+
+    [TestMethod]
+    public void TryCalculate_WhenContentWidthChanges_PreservesMonitorCenterAndTopInset()
+    {
+        Rectangle monitorBounds = new(0, 0, 1920, 1080);
+
+        bool initialCalculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            360,
+            60,
+            1.25d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout initialLayout);
+        bool expandedCalculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            416,
+            60,
+            1.25d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout expandedLayout);
+
+        Assert.IsTrue(initialCalculated);
+        Assert.IsTrue(expandedCalculated);
+        Assert.AreEqual(new Rectangle(735, 14, 450, 75), initialLayout.ToolbarBounds);
+        Assert.AreEqual(new Rectangle(700, 14, 520, 75), expandedLayout.ToolbarBounds);
+        Assert.AreEqual(960d, GetHorizontalCenter(initialLayout.ToolbarBounds));
+        Assert.AreEqual(960d, GetHorizontalCenter(expandedLayout.ToolbarBounds));
+        Assert.AreEqual(initialLayout.ToolbarBounds.Top, expandedLayout.ToolbarBounds.Top);
+        Assert.AreEqual(initialLayout.ShadowCasterOffset, expandedLayout.ShadowCasterOffset);
+    }
+
+    [TestMethod]
+    public void TryCalculate_WhenCenterOffsetIsHalfPixel_FloorsToolbarPosition()
+    {
+        Rectangle monitorBounds = new(0, 0, 1920, 1080);
+
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            417,
+            60,
+            1d,
+            TopInsetPixels,
+            ShadowPaddingDips,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsTrue(calculated);
+        Assert.AreEqual(new Rectangle(751, 14, 417, 60), layout.ToolbarBounds);
+        Assert.AreEqual(959.5d, GetHorizontalCenter(layout.ToolbarBounds));
+    }
+
+    [TestMethod]
+    public void TryCalculate_WhenScaledShadowPaddingIsFractional_CeilsPaddingOutward()
+    {
+        Rectangle monitorBounds = new(0, 0, 1920, 1080);
+
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            400,
+            60,
+            1.25d,
+            TopInsetPixels,
+            16.1d,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsTrue(calculated);
+        Assert.AreEqual(new Rectangle(710, 14, 500, 75), layout.ToolbarBounds);
+        Assert.AreEqual(new Rectangle(689, -7, 542, 117), layout.ShadowBounds);
+        Assert.AreEqual(new Point(21, 21), layout.ShadowCasterOffset);
+    }
+
+    [TestMethod]
+    [DataRow(0d, 60d)]
+    [DataRow(-1d, 60d)]
+    [DataRow(double.NaN, 60d)]
+    [DataRow(double.PositiveInfinity, 60d)]
+    [DataRow(400d, 0d)]
+    [DataRow(400d, -1d)]
+    [DataRow(400d, double.NaN)]
+    [DataRow(400d, double.PositiveInfinity)]
+    public void TryCalculate_WithInvalidContentSize_ReturnsFalse(double width, double height)
+    {
+        AssertCalculationRejected(
+            new Rectangle(0, 0, 1920, 1080),
+            width,
+            height,
+            1d,
+            TopInsetPixels,
+            ShadowPaddingDips);
+    }
+
+    [TestMethod]
+    [DataRow(0d)]
+    [DataRow(-1d)]
+    [DataRow(double.NaN)]
+    [DataRow(double.PositiveInfinity)]
+    public void TryCalculate_WithInvalidRasterizationScale_ReturnsFalse(double rasterizationScale)
+    {
+        AssertCalculationRejected(
+            new Rectangle(0, 0, 1920, 1080),
+            400,
+            60,
+            rasterizationScale,
+            TopInsetPixels,
+            ShadowPaddingDips);
+    }
+
+    [TestMethod]
+    [DataRow(0d)]
+    [DataRow(-1d)]
+    [DataRow(double.NaN)]
+    [DataRow(double.PositiveInfinity)]
+    public void TryCalculate_WithInvalidShadowPadding_ReturnsFalse(double shadowPaddingDips)
+    {
+        AssertCalculationRejected(
+            new Rectangle(0, 0, 1920, 1080),
+            400,
+            60,
+            1d,
+            TopInsetPixels,
+            shadowPaddingDips);
+    }
+
+    [TestMethod]
+    [DataRow(0, 1080)]
+    [DataRow(-1, 1080)]
+    [DataRow(1920, 0)]
+    [DataRow(1920, -1)]
+    public void TryCalculate_WithInvalidMonitorSize_ReturnsFalse(int monitorWidth, int monitorHeight)
+    {
+        AssertCalculationRejected(
+            new Rectangle(0, 0, monitorWidth, monitorHeight),
+            400,
+            60,
+            1d,
+            TopInsetPixels,
+            ShadowPaddingDips);
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    public void TryCalculate_WithInvalidTopInset_ReturnsFalse(int topInsetPixels)
+    {
+        AssertCalculationRejected(
+            new Rectangle(0, 0, 1920, 1080),
+            400,
+            60,
+            1d,
+            topInsetPixels,
+            ShadowPaddingDips);
+    }
+
+    [TestMethod]
+    public void TryCalculate_WhenScaledDimensionsOverflow_ReturnsFalse()
+    {
+        AssertCalculationRejected(
+            new Rectangle(0, 0, 1920, 1080),
+            double.MaxValue,
+            60,
+            2d,
+            TopInsetPixels,
+            ShadowPaddingDips);
+    }
+
+    private static void AssertCalculationRejected(
+        Rectangle monitorBounds,
+        double logicalContentWidth,
+        double logicalContentHeight,
+        double rasterizationScale,
+        int topInsetPixels,
+        double shadowPaddingDips)
+    {
+        bool calculated = CaptureOverlayWindowGeometry.TryCalculate(
+            monitorBounds,
+            logicalContentWidth,
+            logicalContentHeight,
+            rasterizationScale,
+            topInsetPixels,
+            shadowPaddingDips,
+            out CaptureOverlayWindowLayout layout);
+
+        Assert.IsFalse(calculated);
+        Assert.AreEqual(default, layout);
+    }
+
+    private static double GetHorizontalCenter(Rectangle bounds)
+        => bounds.Left + (bounds.Width / 2d);
+}

--- a/tests/CaptureTool.UiTests/VideoCaptureStartupUiTests.cs
+++ b/tests/CaptureTool.UiTests/VideoCaptureStartupUiTests.cs
@@ -11,6 +11,15 @@ namespace CaptureTool.UiTests;
 [TestClass]
 public sealed class VideoCaptureStartupUiTests
 {
+    private const int GwlExStyle = -20;
+    private const long ShadowWindowExtendedStyles =
+        0x00000008L | // WS_EX_TOPMOST
+        0x00000020L | // WS_EX_TRANSPARENT
+        0x00000080L | // WS_EX_TOOLWINDOW
+        0x00080000L | // WS_EX_LAYERED
+        0x08000000L;  // WS_EX_NOACTIVATE
+    private const uint WdaExcludeFromCapture = 0x00000011;
+
     private static readonly TimeSpan AppLaunchTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan InteractionTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan RecordingStartTimeout = TimeSpan.FromSeconds(20);
@@ -72,6 +81,50 @@ public sealed class VideoCaptureStartupUiTests
                 automation,
                 "StartVideoCaptureButton",
                 InteractionTimeout);
+            AutomationElement captureToolbar = startRecordingButton.Parent ??
+                throw new InvalidOperationException("The recording button should have a toolbar parent.");
+            AutomationElement closeOverlayButton = WaitForElement(
+                app,
+                automation,
+                "CaptureOverlay_CloseButton",
+                InteractionTimeout);
+
+            Assert.IsTrue(
+                captureToolbar.BoundingRectangle.Contains(startRecordingButton.BoundingRectangle),
+                "The start button should fit inside the capture toolbar window.");
+            Assert.IsTrue(
+                captureToolbar.BoundingRectangle.Contains(closeOverlayButton.BoundingRectangle),
+                "The rightmost toolbar button should not overflow the capture toolbar window.");
+
+            nint shadowWindow = FindWindow("CaptureOverlayWindowShadow", null);
+            Assert.AreNotEqual(nint.Zero, shadowWindow, "The toolbar shadow window should exist.");
+            Assert.IsTrue(IsWindowVisible(shadowWindow), "The toolbar shadow window should be visible.");
+
+            nint toolbarWindow = FindWindow("CaptureOverlayWindow", null);
+            Assert.AreNotEqual(nint.Zero, toolbarWindow, "The capture toolbar window should exist.");
+            Assert.IsTrue(
+                GetWindowRect(toolbarWindow, out NativeRect toolbarBounds),
+                "The capture toolbar bounds should be available.");
+            Assert.IsTrue(
+                GetWindowRect(shadowWindow, out NativeRect shadowBounds),
+                "The toolbar shadow bounds should be available.");
+            Assert.IsTrue(
+                shadowBounds.Left < toolbarBounds.Left &&
+                shadowBounds.Top < toolbarBounds.Top &&
+                shadowBounds.Right > toolbarBounds.Right &&
+                shadowBounds.Bottom > toolbarBounds.Bottom,
+                "The shadow window should provide visible padding around every toolbar edge.");
+
+            long shadowExtendedStyles = GetWindowLongPtr(shadowWindow, GwlExStyle);
+            Assert.AreEqual(
+                ShadowWindowExtendedStyles,
+                shadowExtendedStyles & ShadowWindowExtendedStyles,
+                "The shadow window should be layered, click-through, topmost, tool-only, and non-activating.");
+            Assert.IsTrue(
+                GetWindowDisplayAffinity(shadowWindow, out uint shadowDisplayAffinity) &&
+                shadowDisplayAffinity == WdaExcludeFromCapture,
+                "The toolbar shadow should be excluded from screen capture.");
+
             startRecordingButton.Click();
 
             AutomationElement stopRecordingButton = WaitForRecordingState(
@@ -112,6 +165,33 @@ public sealed class VideoCaptureStartupUiTests
             Environment.GetEnvironmentVariable("CAPTURETOOL_RUN_UI_TESTS"),
             "1",
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern nint FindWindow(string? className, string? windowName);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static extern nint GetWindowLongPtr(nint windowHandle, int index);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowVisible(nint windowHandle);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(nint windowHandle, out NativeRect rectangle);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowDisplayAffinity(nint windowHandle, out uint affinity);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
     }
 
     private static LaunchedCaptureToolApp LaunchApp(


### PR DESCRIPTION
## Summary

- add correctly sized toolbar shadows, including a dedicated click-through companion shadow window for the capture overlay
- keep capture toolbar window geometry synchronized with the XAML content and preserve rounded corners without overflow
- disable system text scaling for the spacing-sensitive capture and selection toolbars
- keep the recording toolbar layout stable while stop/navigation tears down the overlay
- marshal clipboard and share storage items through an ABI-compatible `IStorageItem[]`
- add geometry, view-model, UI, and WinRT marshalling regression coverage

## Why

The toolbar windows previously needed oversized interactive bounds to expose their shadows, and the capture toolbar could overflow or visibly resize during recording teardown. The file auto-copy path also passed a generic `List<IStorageItem>` across the WinRT ABI, which could not create the requested `IIterable<IStorageItem>` CCW after a video capture.

This change separates the capture toolbar shadow from its interactive surface, anchors all window sizing to measured XAML geometry, prevents teardown-only state changes from repainting a compact toolbar, and uses a WinRT-supported storage-item collection shape.

## Validation

- `dotnet test tests/CaptureTool.Presentation.Tests/CaptureTool.Presentation.Tests.csproj` — 250 passed
- `dotnet test tests/CaptureTool.Infrastructure.Windows.Tests/CaptureTool.Infrastructure.Windows.Tests.csproj -p:Platform=x64` — 7 passed
- `dotnet build src/CaptureTool.Presentation.Windows.WinUI/CaptureTool.Presentation.Windows.WinUI.csproj -p:Platform=x64` — succeeded with 0 warnings and 0 errors
